### PR TITLE
improve mulligan choice for AI

### DIFF
--- a/src/magic/model/choice/MagicMulliganChoice.java
+++ b/src/magic/model/choice/MagicMulliganChoice.java
@@ -1,16 +1,29 @@
 package magic.model.choice;
 
+
+import magic.data.DuelConfig;
+import magic.data.GeneralConfig;
 import magic.model.MagicCard;
 import magic.model.MagicCardDefinition;
+import magic.model.MagicCostManaType;
 import magic.model.MagicGame;
+import magic.model.MagicManaCost;
 import magic.model.MagicPlayer;
 import magic.model.MagicSource;
+import magic.model.action.MagicPlayCardAction;
 import magic.model.event.MagicEvent;
-import magic.exception.UndoClickedException;
+import magic.model.phase.MagicMainPhase;
+import magic.ui.GameController;
+import magic.exceptions.UndoClickedException;
+import magic.ui.duel.choice.MayChoicePanel;
+import magic.ui.duel.choice.MulliganChoicePanel;
+import magic.ui.screen.MulliganScreen;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import magic.model.IUIGameController;
+import java.util.concurrent.Callable;
 
 public class MagicMulliganChoice extends MagicChoice {
 
@@ -18,7 +31,9 @@ public class MagicMulliganChoice extends MagicChoice {
             Collections.singletonList(new Object[]{YES_CHOICE});
     private static final List<Object[]> NO_CHOICE_LIST =
             Collections.singletonList(new Object[]{NO_CHOICE});
-
+    private static final List<Object[]> ACTUAL_CHOICE_LIST =
+            Collections.singletonList(new Object[]{NO_CHOICE,YES_CHOICE});
+    
     public MagicMulliganChoice() {
         super("");
     }
@@ -38,43 +53,83 @@ public class MagicMulliganChoice extends MagicChoice {
             final MagicEvent event,
             final MagicPlayer player,
             final MagicSource source) {
-        int minLands = (game.getTurnPlayer() == player) ? 3 : 2;
-        final int maxLands = 4;
-        int lands = 0;
-        int high = 0;
-        int nonLandManaSources = 0;
 
-        if (player.getHandSize() <= 5) {
+    	int costSum = 0;
+    	List<MagicCard> deck = new ArrayList<>();
+    	deck.addAll(player.getLibrary());
+    	deck.addAll(player.getHand());
+    	for(MagicCard card: deck){
+    		costSum += card.getConvertedCost();
+    	}
+    	
+    	// There is more fine tuning to be done here
+		int minLands = 2;
+		int maxLands = 3;
+    	if(costSum > 90){
+    		minLands = 3;
+    		maxLands = 4;
+    	}else if(costSum > 70){
+    		minLands = 2;
+    		maxLands = 4;
+    	}
+    	
+        if (player.getHandSize() <= 4) {
             return NO_CHOICE_LIST;
         }
 
-        for (final MagicCard card : player.getHand()) {
+		final MagicGame assumedGame = new MagicGame(game, player);
+		MagicPlayer assumedPlayer = assumedGame.getPlayer(player.getIndex());
+		assumedGame.setPhase(MagicMainPhase.getFirstInstance());
+		List<MagicCard> lands = new ArrayList<>();
+        for (final MagicCard card : assumedPlayer.getHand()) {
             final MagicCardDefinition cardDefinition = card.getCardDefinition();
             if (cardDefinition.isLand()) {
-                lands++;
-            } else {
-                if (!cardDefinition.getManaActivations().isEmpty()) {
-                    nonLandManaSources++;
-                }
-                if (cardDefinition.getConvertedCost()>4) {
-                    high++;
-                }
+            	assumedGame.doAction(new MagicPlayCardAction(card));
+                lands.add(card);
             }
         }
 
-        if (nonLandManaSources >= 1) {
-            minLands--;
-        }
-        if (lands >= minLands && lands <= maxLands && high <= 2) {
-            return NO_CHOICE_LIST;
+        int playableCards = 0;
+        for (final MagicCard card : assumedPlayer.getHand()) {
+            final MagicCardDefinition cardDefinition = card.getCardDefinition();
+            if (!cardDefinition.isLand() ) {
+            	if(playableWith(card, assumedGame, assumedPlayer)){
+            		playableCards++;
+            	}
+            }
         }
 
-        return YES_CHOICE_LIST;
+        if(player.getHandSize() > 6){
+	        if(playableCards > 1){
+	            return NO_CHOICE_LIST;
+	        }
+        }else{
+	        if(playableCards > 0){
+	            return NO_CHOICE_LIST;
+	        }
+        }
+
+        if(lands.size() < minLands || lands.size() > maxLands){
+            return YES_CHOICE_LIST;
+        }else{
+	        return ACTUAL_CHOICE_LIST;
+        }
     }
+    
+    private boolean playableWith(MagicCard toPlay, MagicGame game, MagicPlayer player){
+    	MagicManaCost mmc = toPlay.getCardDefinition().getCost();
+    	List<MagicCostManaType> mcmts =  mmc.getCostManaTypes(0);
+
+        final MagicBuilderManaCost builderCost=new MagicBuilderManaCost();
+        builderCost.addTypes(mcmts);
+        final MagicPayManaCostResultBuilder builder=new MagicPayManaCostResultBuilder(game,player,builderCost);
+        return builder.hasResults();
+    }
+    
 
     @Override
     public Object[] getPlayerChoiceResults(
-            final IUIGameController controller,
+            final GameController controller,
             final MagicGame game,
             final MagicPlayer player,
             final MagicSource source) throws UndoClickedException {
@@ -83,10 +138,21 @@ public class MagicMulliganChoice extends MagicChoice {
             return new Object[]{NO_CHOICE};
         }
         controller.disableActionButton(false);
-        if (controller.getTakeMulliganChoice(source, player)) {
+        final MayChoicePanel choicePanel = controller.waitForInput(new Callable<MayChoicePanel>() {
+            public MayChoicePanel call() {
+                final boolean showMulliganScreen =
+                        MulliganScreen.isActive() ||
+                        (player.getHandSize() == DuelConfig.getInstance().getHandSize() && GeneralConfig.getInstance().showMulliganScreen());
+                if (showMulliganScreen) {
+                    return new MulliganChoicePanel(controller, source, "You may take a mulligan.", player.getPrivateHand());
+                } else {
+                    return new MayChoicePanel(controller,source,"You may take a mulligan.");
+                }
+            }
+        });
+        if (choicePanel.isYesClicked()) {
             return new Object[]{YES_CHOICE};
         }
         return new Object[]{NO_CHOICE};
     }
-
 }

--- a/src/magic/model/choice/MagicMulliganChoice.java
+++ b/src/magic/model/choice/MagicMulliganChoice.java
@@ -1,8 +1,5 @@
 package magic.model.choice;
 
-
-import magic.data.DuelConfig;
-import magic.data.GeneralConfig;
 import magic.model.MagicCard;
 import magic.model.MagicCardDefinition;
 import magic.model.MagicCostManaType;
@@ -13,17 +10,14 @@ import magic.model.MagicSource;
 import magic.model.action.MagicPlayCardAction;
 import magic.model.event.MagicEvent;
 import magic.model.phase.MagicMainPhase;
-import magic.ui.GameController;
-import magic.exceptions.UndoClickedException;
-import magic.ui.duel.choice.MayChoicePanel;
-import magic.ui.duel.choice.MulliganChoicePanel;
-import magic.ui.screen.MulliganScreen;
+import magic.exception.UndoClickedException;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
+
+import magic.model.IUIGameController;
 
 public class MagicMulliganChoice extends MagicChoice {
 
@@ -33,7 +27,7 @@ public class MagicMulliganChoice extends MagicChoice {
             Collections.singletonList(new Object[]{NO_CHOICE});
     private static final List<Object[]> ACTUAL_CHOICE_LIST =
             Collections.singletonList(new Object[]{NO_CHOICE,YES_CHOICE});
-    
+
     public MagicMulliganChoice() {
         super("");
     }
@@ -125,11 +119,10 @@ public class MagicMulliganChoice extends MagicChoice {
         final MagicPayManaCostResultBuilder builder=new MagicPayManaCostResultBuilder(game,player,builderCost);
         return builder.hasResults();
     }
-    
 
     @Override
     public Object[] getPlayerChoiceResults(
-            final GameController controller,
+            final IUIGameController controller,
             final MagicGame game,
             final MagicPlayer player,
             final MagicSource source) throws UndoClickedException {
@@ -138,21 +131,10 @@ public class MagicMulliganChoice extends MagicChoice {
             return new Object[]{NO_CHOICE};
         }
         controller.disableActionButton(false);
-        final MayChoicePanel choicePanel = controller.waitForInput(new Callable<MayChoicePanel>() {
-            public MayChoicePanel call() {
-                final boolean showMulliganScreen =
-                        MulliganScreen.isActive() ||
-                        (player.getHandSize() == DuelConfig.getInstance().getHandSize() && GeneralConfig.getInstance().showMulliganScreen());
-                if (showMulliganScreen) {
-                    return new MulliganChoicePanel(controller, source, "You may take a mulligan.", player.getPrivateHand());
-                } else {
-                    return new MayChoicePanel(controller,source,"You may take a mulligan.");
-                }
-            }
-        });
-        if (choicePanel.isYesClicked()) {
+        if (controller.getTakeMulliganChoice(source, player)) {
             return new Object[]{YES_CHOICE};
         }
         return new Object[]{NO_CHOICE};
     }
+
 }


### PR DESCRIPTION
This improves the AI's mulligan decisions in 3 major ways:

1. It bases max. and min. lands on the sum of all mana costs for each deck. This is to ensure that a modern burn deck is completely fine with 2 lands whereas a deck with a mana curve heavier on three- and four-drops might want at least 3. Certainly needs some fine-tuning but at least it now handles average modern decks better that have a lower mana curve than what is assumed for the randomly-generated decks.
2. It checks how many spells in hand can actually be cast with the lands in hand. This ensures that a deck full of 1 drops is completely fine with just one land as long as that land enables it to cast it's 1 drops. For now this is only a positive check, if it doesn't match it falls back on just counting the lands. I'd like to also add a negative clause (like: always mulligan a hand with 3 islands and 4 green spells since you can't cast anything), but the problem is that it doesn't handle fetch lands and the like too well since I haven't figured out a clean way to consider all to combinations of duel lands it could fetch. But this is what part three is for:
3. Now if the land count clause matches but the "can I cast anything" clause does not it will return an actual choice which will cause the AI to evaluate both paths (taking a mulligan or keeping).