### PR TITLE
fix Phyrexian Metamorph

### DIFF
--- a/release/Magarena/scripts/Phyrexian_Metamorph.groovy
+++ b/release/Magarena/scripts/Phyrexian_Metamorph.groovy
@@ -11,7 +11,7 @@ def type = new MagicStatic(MagicLayer.Type) {
         public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
             return new MagicEvent(
                 cardOnStack,
-                new MagicMayChoice(MagicTargetChoice.ARTIFACT_OR_CREATURE),
+                new MagicMayChoice(MagicTargetChoice.TARGET_ARTIFACT_OR_CREATURE),
                 MagicCopyPermanentPicker.create(),
                 this,
                 "You may\$ have SN enter the battlefield as a copy of any artifact or creature\$ on the battlefield, except it's an artifact in addition to its other types."


### PR DESCRIPTION
firemind game logs showed that this card crashes in duels.

It seems the MagicTargetChoice.ARTIFACT_OR_CREATURE got renamed so I fixed that.

Quick grep over Magarena/scripts showed that no other scripts still use MagicTargetChoice.ARTIFACT_OR_CREATURE