### PR TITLE
Fixes the mac launcher version check

### DIFF
--- a/Magarena.app/Contents/MacOS/MagarenaLauncher.sh
+++ b/Magarena.app/Contents/MacOS/MagarenaLauncher.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
 # based on http://mjhutchinson.com/journal/2010/01/24/creating_mac_app_bundle_for_gtk_app
- 
+
 # change these values to match your app
 APPNAME="Magarena"
- 
+
 # java version check
-REQUIRED_VERSION=1.[7-9]
+REQUIRED_VERSION=[7-9].[0-9]
  
 VERSION_TITLE="Cannot launch $APPNAME"
 VERSION_MSG="$APPNAME requires the Java SE 7 JDK or later."
 DOWNLOAD_URL="http://www.oracle.com/technetwork/java/javase/downloads/index.html"
- 
+
 JAVA_VERSION="$(java -version 2>&1 | grep $REQUIRED_VERSION)"
-if [ -z "$JAVA_VERSION" ] 
+if [ -z "$JAVA_VERSION" ]
 then
     osascript \
     -e "set question to display dialog \"$VERSION_MSG\" with title \"$VERSION_TITLE\" buttons {\"Cancel\", \"Download...\"} default button 2" \


### PR DESCRIPTION
Java versions starting with 9.0.0 return a version string
that omits the `1` before the major version, like below:

```
$ java -version
java version "9.0.1"
Java(TM) SE Runtime Environment (build 9.0.1+11)
Java HotSpot(TM) 64-Bit Server VM (build 9.0.1+11, mixed mode)
```

This new check should correctly match version strings in both
formats for java 7, 8, and 9 (`1.7.x`, `1.8.x`, `9.x.y`)