### PR TITLE
Groovy code for Ixalan cards (2)

### DIFF
--- a/release/Magarena/scripts/Aetherworks_Marvel.groovy
+++ b/release/Magarena/scripts/Aetherworks_Marvel.groovy
@@ -1,12 +1,14 @@
 def action = {
     final MagicGame game, final MagicEvent event ->
+    final MagicCardList topCards = new MagicCardList(event.getRefCardList());
     event.processChosenCards(game, {
         game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
-        final MagicCardList copyTopCards = new MagicCardList(event.getRefCardList());
-        copyTopCards.removeCard(it);
-        copyTopCards.shuffle();
-        copyTopCards.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
+        topCards.removeCard(it);
     });
+    topCards.shuffle();
+    topCards.each {
+        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary))
+    }
 }
 
 [
@@ -23,18 +25,25 @@ def action = {
         }
         @Override
         public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {
-            final MagicPlayer player = source.getController();
-            final MagicCardList topCards = player.getLibrary().getCardsFromTop(6);
             return new MagicEvent(
                 source,
-                player,
+                this,
+                "PN looks at the top six cards of PN's library."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            final MagicPlayer player = event.getPlayer();
+            final MagicCardList topCards = player.getLibrary().getCardsFromTop(6);
+            game.doAction(new LookAction(topCards, player, "top six cards of your library");
+            game.addEvent(new MagicEvent(
+                event.getSource(),
                 new MagicFromCardListChoice(topCards, 1, true),
                 topCards,
                 action,
-                "Look at the top six cards of your library. " +
-                "PN may cast a card\$ from among them without paying its mana cost. " +
+                "PN may cast a card from among them\$ without paying its mana cost. " +
                 "Put the rest on the bottom of PN's library in a random order."
-            );
+            ));
         }
     }
 ]

--- a/release/Magarena/scripts/Aetherworks_Marvel.groovy
+++ b/release/Magarena/scripts/Aetherworks_Marvel.groovy
@@ -35,7 +35,7 @@ def action = {
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPlayer player = event.getPlayer();
             final MagicCardList topCards = player.getLibrary().getCardsFromTop(6);
-            game.doAction(new LookAction(topCards, player, "top six cards of your library");
+            game.doAction(new LookAction(topCards, player, "top six cards of your library"));
             game.addEvent(new MagicEvent(
                 event.getSource(),
                 new MagicFromCardListChoice(topCards, 1, true),

--- a/release/Magarena/scripts/Arguel_s_Blood_Fast.txt
+++ b/release/Magarena/scripts/Arguel_s_Blood_Fast.txt
@@ -9,4 +9,3 @@ ability={1}{B}, Pay 2 life: Draw a card.;\
 transform=Temple of Aclazotz
 timing=enchantment
 oracle={1}{B}, Pay 2 life: Draw a card.\nAt the beginning of your upkeep, if you have 5 or less life, you may transform Arguel's Blood Fast.
-status=needs other half

--- a/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.groovy
+++ b/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.groovy
@@ -1,0 +1,53 @@
+def action = {
+    final MagicGame game, final MagicEvent event ->
+    final MagicCardList topCards = new MagicCardList(event.getRefCardList());
+    event.processChosenCards(game, {
+        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+        topCards.removeCard(it);
+    });
+    topCards.each {
+        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary))
+    }
+}
+
+[
+    new MagicPermanentActivation(
+        new MagicActivationHints(MagicTiming.Flash),
+        "AddToHand"
+    ) {
+        @Override
+        public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
+            return [
+                new MagicPayManaCostEvent(source, "{2}{U}"),
+                new MagicTapEvent(source)
+            ];
+        }
+        @Override
+        public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                source,
+                this,
+                "PN looks at the top four cards of PN's library."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            final MagicPlayer player = event.getPlayer();
+            final MagicCardList topCards = player.getCardsFromTop(4);
+            game.doAction(new LookAction(topCards, player, "top four cards of your library"));
+            game.addEvent(new MagicEvent(
+                event.getSource(),
+                new MagicFromCardListChoice(
+                    topCards.findAll({ !it.hasType(MagicType.Creature) && !it.hasType(MagicType.Land) }),
+                    1,
+                    true
+                ),
+                topCards,
+                action,
+                "PN may reveal a noncreature, nonland card from among them\$ and put it into PN's hand. " +
+                "PN puts the rest on the bottom of PN's library in any order."
+            ));
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.groovy
+++ b/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.groovy
@@ -33,7 +33,7 @@ def action = {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPlayer player = event.getPlayer();
-            final MagicCardList topCards = player.getCardsFromTop(4);
+            final MagicCardList topCards = player.getLibrary().getCardsFromTop(4);
             game.doAction(new LookAction(topCards, player, "top four cards of your library"));
             game.addEvent(new MagicEvent(
                 event.getSource(),

--- a/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.txt
+++ b/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.txt
@@ -3,10 +3,9 @@ image=https://magiccards.info/scans/en/xln/74b.jpg
 value=2.500
 rarity=R
 type=Legendary,Land
-ability={T}: Add {U} to your mana pool.;\
-        {2}{U}, {T}: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in any order.
+ability={T}: Add {U} to your mana pool.
 transform=Search for Azcanta
 hidden
 timing=land
+requires_groovy_code
 oracle={T}: Add {U} to your mana pool.\n{2}{U}, {T}: Look at the top four cards of your library. You may reveal a noncreature, nonland card from among them and put it into your hand. Put the rest on the bottom of your library in any order.
-status=needs groovy

--- a/release/Magarena/scripts/Sanguine_Sacrament.groovy
+++ b/release/Magarena/scripts/Sanguine_Sacrament.groovy
@@ -13,7 +13,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeLifeAction(event.getPlayer(), event.getRefInt()));
-            game.doAction(new ShiftCardAction(event.getCard(), MagicLocationType.Stack, MagicLocationType.BottomOfOwnersLibrary));
+            game.doAction(new ShiftCardAction(event.getCardOnStack().getCard(), MagicLocationType.Stack, MagicLocationType.BottomOfOwnersLibrary));
         }
     }
 ]

--- a/release/Magarena/scripts/Sanguine_Sacrament.groovy
+++ b/release/Magarena/scripts/Sanguine_Sacrament.groovy
@@ -1,0 +1,20 @@
+[
+    new MagicSpellCardEvent() {
+        @Override
+        public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
+            final int amount = 2 * payedCost.getX();
+            return new MagicEvent(
+                cardOnStack,
+                amount,
+                this,
+                "PN gains ${amount} life. Put SN on the bottom of its owner's library."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            game.doAction(new ChangeLifeAction(event.getPlayer(), event.getRefInt()));
+            game.doAction(new ShiftCardAction(event.getCard(), MagicLocationType.Stack, MagicLocationType.BottomOfOwnersLibrary));
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Sanguine_Sacrament.txt
+++ b/release/Magarena/scripts/Sanguine_Sacrament.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=R
 type=Instant
 cost={X}{W}{W}
-effect=You gain twice X life. Put SN on the bottom of its owner's library.
 timing=removal
+requires_groovy_code
 oracle=You gain twice X life. Put Sanguine Sacrament on the bottom of its owner's library.
-status=needs groovy

--- a/release/Magarena/scripts/Search_for_Azcanta.groovy
+++ b/release/Magarena/scripts/Search_for_Azcanta.groovy
@@ -1,0 +1,51 @@
+def putIntoGraveyardAction = {
+    final MagicGame game, final MagicEvent event ->
+    if (event.isYes()) {
+        game.doAction(new ShiftCardAction(event.getRefCard(), MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
+    }
+}
+
+def transformAction = {
+    final MagicGame game, final MagicEvent event ->
+    if (event.isYes()) {
+        game.doAction(new TransformAction(event.getPermanent()));
+    }
+}
+
+[
+    new AtUpkeepTrigger() {
+        @Override
+        public boolean accept(final MagicPermanent permanent, final MagicPlayer upkeepPlayer) {
+            return permanent.isController(upkeepPlayer);
+        }
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer upkeepPlayer) {
+            return new MagicEvent(
+                permanent,
+                this,
+                "PN looks at the top card of PN's library."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            final MagicPlayer player = event.getPlayer();
+            final MagicCard topCard = player.getLibrary().getCardAtTop();
+            game.doAction(new LookAction(topCard, player, "top card of your library"));
+            game.addEvent(new MagicEvent(
+                event.getSource(),
+                new MagicMayChoice("Put the card into your graveyard?"),
+                putIntoGraveyardAction,
+                "PN may\$ put it into PN's graveyard."
+            ));
+            if (player.getGraveyard().size() >= 7) {
+                game.addEvent(new MagicEvent(
+                    event.getSource(),
+                    new MagicMayChoice("Transfrom ${event.getPermanent()}"),
+                    transformAction,
+                    "PN may\$ transform SN."
+                ));
+            }
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Search_for_Azcanta.txt
+++ b/release/Magarena/scripts/Search_for_Azcanta.txt
@@ -4,8 +4,7 @@ value=2.500
 rarity=R
 type=Legendary,Enchantment
 cost={1}{U}
-ability=At the beginning of your upkeep, look at the top card of your library. You may put it into your graveyard. Then if you have seven or more cards in your graveyard, you may transform SN.
 transform=Azcanta, the Sunken Ruin
 timing=enchantment
+requires_groovy_code
 oracle=At the beginning of your upkeep, look at the top card of your library. You may put it into your graveyard. Then if you have seven or more cards in your graveyard, you may transform Search for Azcanta.
-status=needs groovy

--- a/release/Magarena/scripts/Settle_the_Wreckage.groovy
+++ b/release/Magarena/scripts/Settle_the_Wreckage.groovy
@@ -1,0 +1,38 @@
+[
+    new MagicSpellCardEvent() {
+        @Override
+        public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                cardOnStack,
+                NEG_TARGET_PLAYER,
+                this,
+                "Exile all attacking creatures target player\$ controls."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            event.processTargetPlayer(game, {
+                final MagicPlayer player ->
+                int amount = 0;
+                player.getPermanents().each {
+                    if (it.hasType(MagicType.Creature) && it.hasState(MagicPermanentState.Attacking)) {
+                        game.addEvent(new MagicExileEvent(it));
+                        amount++;
+                    }
+                }
+                game.addEvent(new MagicSearchOntoBattlefieldEvent(
+                    event.getSource(),
+                    player,
+                    new MagicFromCardFilterChoice(
+                        BASIC_LAND_CARD_FROM_LIBRARY,
+                        amount,
+                        true,
+                        "basic land cards from your library"
+                    ),
+                    MagicPlayMod.TAPPED
+                ));
+            });
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Settle_the_Wreckage.txt
+++ b/release/Magarena/scripts/Settle_the_Wreckage.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=R
 type=Instant
 cost={2}{W}{W}
-effect=Exile all attacking creatures target player controls. That player may search his or her library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle his or her library.
 timing=removal
+requires_groovy_code
 oracle=Exile all attacking creatures target player controls. That player may search his or her library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle his or her library.
-status=needs groovy

--- a/release/Magarena/scripts/Siren_Stormtamer.groovy
+++ b/release/Magarena/scripts/Siren_Stormtamer.groovy
@@ -1,3 +1,12 @@
+def SPELL_OR_ABILITY_THAT_TARGETS_YOU_OR_A_CREATURE_YOU_CONTROL = new MagicStackFilterImpl() {
+    @Override
+    public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+        final MagicTarget target = item.getTarget();
+        return player.getId() == target.getId() ||
+            (target.hasType(MagicType.Creature) && player.isFriend(target));
+    }
+}
+
 [
     new MagicPermanentActivation(
         new MagicActivationHints(MagicTiming.Counter),
@@ -16,12 +25,7 @@
             return new MagicEvent(
                 source,
                 new MagicTargetChoice(
-                    new MagicStackFilterImpl() {
-                        @Override
-                        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-                            return player.isFriend(item.getTarget());
-                        }
-                    },
+                    SPELL_OR_ABILITY_THAT_TARGETS_YOU_OR_A_CREATURE_YOU_CONTROL,
                     "target spell or ability that targets you or a creature you control"
                 ),
                 this,

--- a/release/Magarena/scripts/Siren_Stormtamer.groovy
+++ b/release/Magarena/scripts/Siren_Stormtamer.groovy
@@ -1,0 +1,41 @@
+[
+    new MagicPermanentActivation(
+        new MagicActivationHints(MagicTiming.Counter),
+        "Counter"
+    ) {
+        @Override
+        public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
+            return [
+                new MagicPayManaCostEvent(source, "{U}"),
+                new MagicSacrificeEvent(source)
+            ];
+        }
+
+        @Override
+        public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                source,
+                new MagicTargetChoice(
+                    new MagicStackFilterImpl() {
+                        @Override
+                        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+                            return player.isFriend(item.getTarget());
+                        }
+                    },
+                    "target spell or ability that targets you or a creature you control"
+                ),
+                this,
+                "Counter target spell or ability that targets PN or a creature PN controls\$."
+            );
+        }
+
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            event.processTargetItemOnStack(game, {
+                game.doAction(new CounterItemOnStackAction(it));
+            });
+        }
+    }
+]
+
+

--- a/release/Magarena/scripts/Siren_Stormtamer.txt
+++ b/release/Magarena/scripts/Siren_Stormtamer.txt
@@ -6,8 +6,7 @@ type=Creature
 subtype=Siren,Pirate,Wizard
 cost={U}
 pt=1/1
-ability=Flying;\
-        {U}, Sacrifice SN: Counter target spell or ability that targets you or a creature you control.
+ability=Flying
 timing=main
+requires_groovy_code
 oracle=Flying\n{U}, Sacrifice Siren Stormtamer: Counter target spell or ability that targets you or a creature you control.
-status=needs groovy

--- a/release/Magarena/scripts/Siren_s_Ruse.groovy
+++ b/release/Magarena/scripts/Siren_s_Ruse.groovy
@@ -1,0 +1,25 @@
+[
+    new MagicSpellCardEvent() {
+        @Override
+        public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                cardOnStack,
+                TARGET_CREATURE_YOU_CONTROL,
+                this,
+                "Exile target creature PN controls\$, then return that card to the battlefield under its owner's control. " +
+                "If a Pirate was exiled this way, PN draws a card."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            event.processTargetPermanent(game, {
+                game.doAction(new RemoveFromPlayAction(it, MagicLocationType.Exile));
+                game.doAction(new PlayCardAction(it.getCard(), it.getOwner()));
+                if (it.hasSubType(MagicSubType.Pirate)) {
+                    game.doAction(new DrawAction(event.getPlayer()));
+                }
+            });
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Siren_s_Ruse.txt
+++ b/release/Magarena/scripts/Siren_s_Ruse.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=C
 type=Instant
 cost={1}{U}
-effect=Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card.
 timing=removal
+requires_groovy_code
 oracle=Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card.
-status=needs groovy

--- a/release/Magarena/scripts/Spell_Swindle.groovy
+++ b/release/Magarena/scripts/Spell_Swindle.groovy
@@ -1,0 +1,29 @@
+[
+    new MagicSpellCardEvent() {
+        @Override
+        public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                cardOnStack,
+                NEG_TARGET_SPELL,
+                this,
+                "Counter target spell\$. " +
+                "Create X colorless Treasure artifact tokens, where X is that spell's converted mana cost. " +
+                "They have \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\""
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            event.processTargetItemOnStack(game, {
+                game.doAction(new CounterItemOnStackAction(it));
+                it.getConvertedCost().times {
+                    game.doAction(new PlayTokenAction(
+                        event.getPlayer(),
+                        CardDefinitions.getToken("colorless Treasure artifact token")
+                    ));
+                }
+            });
+        }
+    }
+]
+
+

--- a/release/Magarena/scripts/Spell_Swindle.txt
+++ b/release/Magarena/scripts/Spell_Swindle.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=R
 type=Instant
 cost={3}{U}{U}
-effect=Counter target spell. Create X colorless Treasure artifact tokens, where X is that spell's converted mana cost. They have "{T}, Sacrifice this artifact: Add one mana of any color to your mana pool."
 timing=counter
+requires_groovy_code
 oracle=Counter target spell. Create X colorless Treasure artifact tokens, where X is that spell's converted mana cost. They have "{T}, Sacrifice this artifact: Add one mana of any color to your mana pool."
-status=needs groovy

--- a/release/Magarena/scripts/Sun_Blessed_Mount.groovy
+++ b/release/Magarena/scripts/Sun_Blessed_Mount.groovy
@@ -1,0 +1,39 @@
+[
+    new EntersBattlefieldTrigger() {
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                permanent,
+                new MagicMayChoice("Search your library and/or graveyard?"),
+                this,
+                "PN may\$ search PN's library and/or graveyard for a card named Huatli, Dinosaur Knight, reveal it, then put it into PN's hand. " +
+                "If PN searched PN's library this way, shuffle it."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            if (event.isYes()) {
+                game.addEvent(new MagicSearchToLocationEvent(
+                    event,
+                    new MagicFromCardFilterChoice(
+                        new MagicCardFilterImpl() {
+                            @Override
+                            public boolean accept(final MagicSource source,final MagicPlayer player,final MagicCard target) {
+                                return target.getName().equalsIgnoreCase("Huatli, Dinosaur Knight");
+                            }
+                            @Override
+                            public boolean acceptType(final MagicTargetType targetType) {
+                                return targetType == MagicTargetType.Library || targetType == MagicTargetType.Graveyard;
+                            }
+                        },
+                        1,
+                        false,
+                        "a card named Huatli, Dinosaur Knight from your library and/or graveyard"
+                    ),
+                    MagicLocationType.OwnersHand
+                ));
+            }
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Sun_Blessed_Mount.txt
+++ b/release/Magarena/scripts/Sun_Blessed_Mount.txt
@@ -6,7 +6,6 @@ type=Creature
 subtype=Dinosaur
 cost={3}{R}{W}
 pt=4/4
-ability=When SN enters the battlefield, you may search your library and/or graveyard for a card named Huatli, Dinosaur Knight, reveal it, then put it into your hand. If you searched your library this way, shuffle it.
 timing=main
+requires_groovy_code
 oracle=When Sun-Blessed Mount enters the battlefield, you may search your library and/or graveyard for a card named Huatli, Dinosaur Knight, reveal it, then put it into your hand. If you searched your library this way, shuffle it.
-status=needs groovy

--- a/release/Magarena/scripts/Sunbird_s_Invocation.groovy
+++ b/release/Magarena/scripts/Sunbird_s_Invocation.groovy
@@ -1,0 +1,43 @@
+def action = {
+    final MagicGame game, final MagicEvent event ->
+    event.processChosenCards(game, {
+        game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
+        final MagicCardList topCards = new MagicCardList(event.getRefCardList());
+        topCards.removeCard(it);
+        topCards.shuffle();
+        topCards.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
+    });
+}
+
+[
+    new OtherSpellIsCastTrigger() {
+        @Override
+        public boolean accept(final MagicPermanent permanent, final MagicCardOnStack spell) {
+            return permanent.isFriend(spell);
+        }
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicCardOnStack spell) {
+            final int cmc = spell.getConvertedCost();
+            return new MagicEvent(
+                permanent,
+                cmc,
+                this,
+                "PN reveals the top ${cmc} cards of PN's library."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            final int cmc = event.getRefInt();
+            final MagicCardList revealedCards = player.getLibrary().getCardsFromTop(cmc);
+            game.addEvent(new MagicEvent(
+                source,
+                new MagicMayChoice(new MagicFromCardListChoice(revealedCards, 1, false)),
+                revealedCards,
+                action,
+                "PN may\$ cast a card revealed this way with converted mana cost ${cmc} or less\$ without paying its mana cost. " +
+                "Put the rest on the bottom of PN's library in a random order."
+            ));
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Sunbird_s_Invocation.groovy
+++ b/release/Magarena/scripts/Sunbird_s_Invocation.groovy
@@ -22,7 +22,7 @@ def action = {
                 permanent,
                 cmc,
                 this,
-                "PN reveals the top ${cmc} cards of PN's library."
+                "PN reveals the top RN cards of PN's library."
             );
         }
         @Override

--- a/release/Magarena/scripts/Sunbird_s_Invocation.groovy
+++ b/release/Magarena/scripts/Sunbird_s_Invocation.groovy
@@ -1,12 +1,14 @@
 def action = {
     final MagicGame game, final MagicEvent event ->
+    final MagicCardList topCards = new MagicCardList(event.getRefCardList());
     event.processChosenCards(game, {
         game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
-        final MagicCardList topCards = new MagicCardList(event.getRefCardList());
         topCards.removeCard(it);
-        topCards.shuffle();
-        topCards.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
     });
+    topCards.shuffle();
+    topCards.each {
+        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary))
+    }
 }
 
 [
@@ -31,10 +33,14 @@ def action = {
             final MagicCardList revealedCards = event.getPlayer().getLibrary().getCardsFromTop(cmc);
             game.addEvent(new MagicEvent(
                 event.getSource(),
-                new MagicMayChoice(new MagicFromCardListChoice(revealedCards, 1, false)),
+                new MagicFromCardListChoice(
+                    revealedCards.findAll({ it.getConvertedCost() <= cmc }),
+                    1,
+                    true
+                ),
                 revealedCards,
                 action,
-                "PN may\$ cast a card revealed this way with converted mana cost ${cmc} or less\$ without paying its mana cost. " +
+                "PN may cast a card revealed this way with converted mana cost ${cmc} or less\$ without paying its mana cost. " +
                 "Put the rest on the bottom of PN's library in a random order."
             ));
         }

--- a/release/Magarena/scripts/Sunbird_s_Invocation.groovy
+++ b/release/Magarena/scripts/Sunbird_s_Invocation.groovy
@@ -28,9 +28,9 @@ def action = {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final int cmc = event.getRefInt();
-            final MagicCardList revealedCards = player.getLibrary().getCardsFromTop(cmc);
+            final MagicCardList revealedCards = event.getPlayer().getLibrary().getCardsFromTop(cmc);
             game.addEvent(new MagicEvent(
-                source,
+                event.getSource(),
                 new MagicMayChoice(new MagicFromCardListChoice(revealedCards, 1, false)),
                 revealedCards,
                 action,

--- a/release/Magarena/scripts/Sunbird_s_Invocation.txt
+++ b/release/Magarena/scripts/Sunbird_s_Invocation.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=R
 type=Enchantment
 cost={5}{R}
-ability=Whenever you cast a spell from your hand, reveal the top X cards of your library, where X is that spell's converted mana cost. You may cast a card revealed this way with converted mana cost X or less without paying its mana cost. Put the rest on the bottom of your library in a random order.
 timing=enchantment
+requires_groovy_code
 oracle=Whenever you cast a spell from your hand, reveal the top X cards of your library, where X is that spell's converted mana cost. You may cast a card revealed this way with converted mana cost X or less without paying its mana cost. Put the rest on the bottom of your library in a random order.
-status=needs groovy

--- a/release/Magarena/scripts/Sword_Point_Diplomacy.groovy
+++ b/release/Magarena/scripts/Sword_Point_Diplomacy.groovy
@@ -1,0 +1,38 @@
+def action = {
+    final MagicGame game, final MagicPlayer player ->
+    if (event.isYes()) {
+        game.addEvent(new MagicPayLifeEvent(event.getSource(), event.getPlayer(), 3));
+        game.doAction(new ShiftCardAction(event.getRefCard(), MagicLocationType.OwnersLibrary, MagicLocationType.Exile));
+    } else {
+        game.doAction(new ShiftCardAction(event.getRefCard(), MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+    }
+}
+
+[
+    new MagicSpellCardEvent() {
+        @Override
+        public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                cardOnStack,
+                this,
+                "Reveal the top three cards of PN's library."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            final MagicCardList revealedCards = event.getPlayer().getLibrary().getCardsFromTop(3);
+            game.doAction(new RevealAction(revealedCards));
+            revealedCards.each {
+                game.addEvent(new MagicEvent(
+                    event.getSource(),
+                    event.getPlayer().getOpponent(),
+                    new MagicMayChoice("Pay 3 life?"),
+                    it,
+                    action,
+                    "Put RN into ${event.getPlayer()}'s hand unless PN pays 3 life\$."
+                ));
+            }
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Sword_Point_Diplomacy.groovy
+++ b/release/Magarena/scripts/Sword_Point_Diplomacy.groovy
@@ -1,5 +1,5 @@
 def action = {
-    final MagicGame game, final MagicPlayer player ->
+    final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
         game.addEvent(new MagicPayLifeEvent(event.getSource(), event.getPlayer(), 3));
         game.doAction(new ShiftCardAction(event.getRefCard(), MagicLocationType.OwnersLibrary, MagicLocationType.Exile));

--- a/release/Magarena/scripts/Sword_Point_Diplomacy.txt
+++ b/release/Magarena/scripts/Sword_Point_Diplomacy.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=R
 type=Sorcery
 cost={2}{B}
-effect=Reveal the top three cards of your library. For each of those cards, put that card into your hand unless any opponent pays 3 life. Then exile the rest.
 timing=main
+requires_groovy_code
 oracle=Reveal the top three cards of your library. For each of those cards, put that card into your hand unless any opponent pays 3 life. Then exile the rest.
-status=needs groovy

--- a/release/Magarena/scripts/Temple_of_Aclazotz.groovy
+++ b/release/Magarena/scripts/Temple_of_Aclazotz.groovy
@@ -1,6 +1,9 @@
 [
     new MagicPermanentActivation(
-        new MagicActivationHints(MagicTiming.Removal)
+        new MagicActivationHints(
+            MagicTiming.Removal,
+            "Sacrifice"
+        )
     ) {
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {

--- a/release/Magarena/scripts/Temple_of_Aclazotz.groovy
+++ b/release/Magarena/scripts/Temple_of_Aclazotz.groovy
@@ -15,18 +15,17 @@
 
         @Override
         public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {
-            final int amount = ((MagicPermanent)payedCost.getTarget()).getToughness();
             return new MagicEvent(
                 source,
-                amount,
+                payedCost.getTarget(),
                 this,
-                "PN gains ${amount} life."
+                "PN gains life equal to RN's toughness."
             );
         }
 
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeLifeAction(event.getPlayer(), event.getRefInt()));
+            game.doAction(new ChangeLifeAction(event.getPlayer(), event.getRefPermanent().getToughness()));
         }
     }
 ]

--- a/release/Magarena/scripts/Temple_of_Aclazotz.groovy
+++ b/release/Magarena/scripts/Temple_of_Aclazotz.groovy
@@ -1,9 +1,7 @@
 [
     new MagicPermanentActivation(
-        new MagicActivationHints(
-            MagicTiming.Removal,
-            "Sacrifice"
-        )
+        new MagicActivationHints(MagicTiming.Removal),
+        "Sacrifice"
     ) {
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {

--- a/release/Magarena/scripts/Temple_of_Aclazotz.groovy
+++ b/release/Magarena/scripts/Temple_of_Aclazotz.groovy
@@ -1,0 +1,32 @@
+[
+    new MagicPermanentActivation(
+        new MagicActivationHints(MagicTiming.Removal)
+    ) {
+        @Override
+        public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
+            return [
+                new MagicSacrificePermanentEvent(
+                    source,
+                    SACRIFICE_CREATURE
+                )
+            ];
+        }
+
+        @Override
+        public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {
+            final int amount = ((MagicPermanent)payedCost.getTarget()).getToughness();
+            return new MagicEvent(
+                source,
+                amount,
+                this,
+                "PN gains ${amount} life."
+            );
+        }
+
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            game.doAction(new ChangeLifeAction(event.getPlayer(), event.getRefInt()));
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Temple_of_Aclazotz.txt
+++ b/release/Magarena/scripts/Temple_of_Aclazotz.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=R
 type=Legendary,Land
 ability={T}: Add {B} to your mana pool.
-        {T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.
 transform=Arguel's Blood Fast
 hidden
 timing=land

--- a/release/Magarena/scripts/Temple_of_Aclazotz.txt
+++ b/release/Magarena/scripts/Temple_of_Aclazotz.txt
@@ -3,10 +3,10 @@ image=https://magiccards.info/scans/en/xln/90b.jpg
 value=2.500
 rarity=R
 type=Legendary,Land
-ability={T}: Add {B} to your mana pool.;\
+ability={T}: Add {B} to your mana pool.
         {T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.
 transform=Arguel's Blood Fast
 hidden
 timing=land
+requires_groovy_code
 oracle={T}: Add {B} to your mana pool.\n{T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.
-status=needs groovy

--- a/release/Magarena/scripts/Tishana__Voice_of_Thunder.txt
+++ b/release/Magarena/scripts/Tishana__Voice_of_Thunder.txt
@@ -7,8 +7,7 @@ subtype=Merfolk,Shaman
 cost={5}{G}{U}
 pt=*/*
 ability=SN's power and toughness are each equal to the number of cards in your hand.;\
-        You have no maximum hand size.;\
-        When Tishana enters the battlefield, draw a card for each creature you control.
+        When SN enters the battlefield, draw a card for each creature you control.
 timing=main
+requires_groovy_code=Spellbook
 oracle=Tishana, Voice of Thunder's power and toughness are each equal to the number of cards in your hand.\nYou have no maximum hand size.\nWhen Tishana enters the battlefield, draw a card for each creature you control.
-status=needs groovy

--- a/release/Magarena/scripts/Treasure_Cove.txt
+++ b/release/Magarena/scripts/Treasure_Cove.txt
@@ -9,4 +9,3 @@ transform=Treasure Map
 hidden
 timing=land
 oracle={T}: Add {C} to your mana pool.\n{T}, Sacrifice a Treasure: Draw a card.
-status=needs other half

--- a/release/Magarena/scripts/Treasure_Map.groovy
+++ b/release/Magarena/scripts/Treasure_Map.groovy
@@ -1,9 +1,7 @@
 [
     new MagicPermanentActivation(
-        new MagicActivationHints(
-            MagicTiming.Removal,
-            "Transform"
-        )
+        new MagicActivationHints(MagicTiming.Removal),
+        "Transform"
     ) {
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {

--- a/release/Magarena/scripts/Treasure_Map.groovy
+++ b/release/Magarena/scripts/Treasure_Map.groovy
@@ -1,0 +1,43 @@
+[
+    new MagicPermanentActivation(
+        new MagicActivationHints(MagicTiming.Removal)
+    ) {
+        @Override
+        public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
+            return [
+                new MagicPayManaCostEvent("{1}"),
+                new MagicTapEvent(source)
+            ];
+        }
+
+        @Override
+        public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                source,
+                this,
+                "PN scry 1. Put a landmark counter on SN. " +
+                "Then if there are three or more landmark counters on SN, remove those counters, transfrom SN, " +
+                "and create three colorless Treasure artifact tokens with \"{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.\""
+            );
+        }
+
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            final MagicPermanent source = event.getPermanent();
+            game.addEvent(new MagicScryEvent(event));
+            game.doAction(new ChangeCountersAction(source, MagicCounterType.Landmark, 1));
+            final int amount = source.getCounters(MagicCounterType.Landmark);
+            if (amount >= 3) {
+                game.doAction(new ChangeCountersAction(source, MagicCounterType.Landmark, -amount));
+                game.doAction(new TransformAction(source));
+                3.times {
+                    game.doAction(new PlayTokenAction(
+                        event.getPlayer(),
+                        CardDefinitions.getToken("colorless Treasure artifact token")
+                    ));
+                }
+            }
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Treasure_Map.groovy
+++ b/release/Magarena/scripts/Treasure_Map.groovy
@@ -1,6 +1,9 @@
 [
     new MagicPermanentActivation(
-        new MagicActivationHints(MagicTiming.Removal)
+        new MagicActivationHints(
+            MagicTiming.Removal,
+            "Transform"
+        )
     ) {
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {

--- a/release/Magarena/scripts/Treasure_Map.groovy
+++ b/release/Magarena/scripts/Treasure_Map.groovy
@@ -6,7 +6,7 @@
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
             return [
-                new MagicPayManaCostEvent("{1}"),
+                new MagicPayManaCostEvent(source, "{1}"),
                 new MagicTapEvent(source)
             ];
         }

--- a/release/Magarena/scripts/Treasure_Map.txt
+++ b/release/Magarena/scripts/Treasure_Map.txt
@@ -4,8 +4,7 @@ value=2.500
 rarity=R
 type=Artifact
 cost={2}
-ability={1}, {T}: Scry 1. Put a landmark counter on SN. Then if there are three or more landmark counters on it, remove those counters, transform SN, and create three colorless Treasure artifact tokens with "{T}, Sacrifice this artifact: Add one mana of any color to your mana pool."
 transform=Treasure Cove
 timing=artifact
+requires_groovy_code
 oracle={1}, {T}: Scry 1. Put a landmark counter on Treasure Map. Then if there are three or more landmark counters on it, remove those counters, transform Treasure Map, and create three colorless Treasure artifact tokens with "{T}, Sacrifice this artifact: Add one mana of any color to your mana pool."
-status=needs groovy

--- a/release/Magarena/scripts/Vampire_s_Zeal.groovy
+++ b/release/Magarena/scripts/Vampire_s_Zeal.groovy
@@ -1,0 +1,24 @@
+[
+    new MagicSpellCardEvent() {
+        @Override
+        public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
+            return new MagicEvent(
+                cardOnStack,
+                POS_TARGET_CREATURE,
+                MagicPumpTargetPicker.create(),
+                this,
+                "Target creature\$ gets +2/+2 until end of turn. If it's a Vampire, it gains first strike until end of turn."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            event.processTargetPermanent(game, {
+                game.doAction(new ChangeTurnPTAction(it,2,2));
+                if (it.hasSubType(MagicSubType.Vampire)) {
+                    game.doAction(new GainAbilityAction(it, MagicAbility.FirstStrike));
+                }
+            });
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Vampire_s_Zeal.txt
+++ b/release/Magarena/scripts/Vampire_s_Zeal.txt
@@ -4,7 +4,6 @@ value=2.500
 rarity=C
 type=Instant
 cost={W}
-effect=Target creature gets +2/+2 until end of turn. If it's a Vampire, it gains first strike until end of turn.
-timing=removal
+timing=pump
+requires_groovy_code
 oracle=Target creature gets +2/+2 until end of turn. If it's a Vampire, it gains first strike until end of turn.
-status=needs groovy

--- a/release/Magarena/scripts/Verdant_Sun_s_Avatar.groovy
+++ b/release/Magarena/scripts/Verdant_Sun_s_Avatar.groovy
@@ -1,0 +1,22 @@
+[
+    new OtherEntersBattlefieldTrigger() {
+        @Override
+        public boolean accept(final MagicPermanent permanent, final MagicPermanent played) {
+            return permanent.isController(played.getController());
+        }
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPermanent played) {
+            return new MagicEvent(
+                permanent,
+                played,
+                this,
+                "PN gains life equal to RN's toughness."
+            );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            game.doAction(new ChangeLifeAction(event.getPlayer(), event.getRefPermanent().getToughness()));
+        }
+    }
+]
+

--- a/release/Magarena/scripts/Verdant_Sun_s_Avatar.txt
+++ b/release/Magarena/scripts/Verdant_Sun_s_Avatar.txt
@@ -6,7 +6,6 @@ type=Creature
 subtype=Dinosaur,Avatar
 cost={5}{G}{G}
 pt=5/5
-ability=Whenever SN or another creature enters the battlefield under your control, you gain life equal to that creature's toughness.
 timing=main
+requires_groovy_code
 oracle=Whenever Verdant Sun's Avatar or another creature enters the battlefield under your control, you gain life equal to that creature's toughness.
-status=needs groovy

--- a/src/magic/model/MagicCounterType.java
+++ b/src/magic/model/MagicCounterType.java
@@ -76,6 +76,7 @@ public enum MagicCounterType implements MagicCopyable {
     Isolation("isolation","{iso}",1),
     Javelin("javelin","{jav}",1),
     Ki("ki","{ki}",1),
+    Landmark("landmark","{landmark}",0),
     Level("level","{lvl}",0),
     Lore("lore","{lre}",1),
     Loyalty("loyalty","{lyl}",1),

--- a/src/magic/model/MagicCounterType.java
+++ b/src/magic/model/MagicCounterType.java
@@ -76,7 +76,7 @@ public enum MagicCounterType implements MagicCopyable {
     Isolation("isolation","{iso}",1),
     Javelin("javelin","{jav}",1),
     Ki("ki","{ki}",1),
-    Landmark("landmark","{landmark}",0),
+    Landmark("landmark","{landmark}",1),
     Level("level","{lvl}",0),
     Lore("lore","{lre}",1),
     Loyalty("loyalty","{lyl}",1),


### PR DESCRIPTION
Added cards:
- Arguel's Blood Fast (needs other half) // Temple of Aclazotz (needs groovy)
- Sanguine Sacrament (closes #1454)
- Search for Azcanta (needs groovy) // Azcanta, the Sunken Ruin (needs groovy)
- Settle the Wreckage
- Siren Stormtamer
- Siren's Ruse
- Spell Swindle
- Sun-Blessed Mount
- Sunbird's Invocation
- Sword-Point Diplomacy
- Tishana, Voice of Thunder
- Treasure Map (needs groovy) // Treasure Cove (needs other half) (also added MagicCounterType.Landmark)
- Vampire's Zeal (closes #1459)
- Verdant Sun's Avatar

I also fixed a bug in a card I added earlier: Aetherworks Marvel. In the old version the cards won't be put on the bottom of library if no cards are chosen.