### PR TITLE
Fix bugs

### DIFF
--- a/release/Magarena/scripts/Deathgorge_Scavenger.groovy
+++ b/release/Magarena/scripts/Deathgorge_Scavenger.groovy
@@ -5,7 +5,7 @@ def action = {
             if (it.hasType(MagicType.Creature)) {
                 game.doAction(new ChangeLifeAction(event.getPlayer(), 2));
             } else {
-                game.doAction(new ChangeTurnPTAction(event.getRefPermanent(), 1, 1));
+                game.doAction(new ChangeTurnPTAction(event.getPermanent(), 1, 1));
             }
         });
     }

--- a/release/Magarena/scripts/Entrancing_Melody.groovy
+++ b/release/Magarena/scripts/Entrancing_Melody.groovy
@@ -17,7 +17,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(event.getPlayer(), it);
+                game.doAction(new GainControlAction(event.getPlayer(), it));
             });
         }
     }

--- a/release/Magarena/scripts/Entrancing_Melody.groovy
+++ b/release/Magarena/scripts/Entrancing_Melody.groovy
@@ -1,5 +1,6 @@
 [
     new MagicSpellCardEvent() {
+        @Override
         public MagicEvent getEvent(final MagicCardOnStack cardOnStack,final MagicPayedCost payedCost) {
             final int x = payedCost.getX();
             return new MagicEvent(
@@ -12,6 +13,12 @@
                 this,
                 "PN gains control of target creature with converted mana cost ${x}\$."
             );
+        }
+        @Override
+        public void executeEvent(final MagicGame game, final MagicEvent event) {
+            event.processTargetPermanent(game, {
+                game.doAction(event.getPlayer(), it);
+            });
         }
     }
 ]

--- a/release/Magarena/scripts/Heart_Piercer_Manticore.groovy
+++ b/release/Magarena/scripts/Heart_Piercer_Manticore.groovy
@@ -11,7 +11,7 @@ def damageAction = {
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPayedCost payedCost) {
             return new MagicEvent(
                 permanent,
-                new MagicMayChoice(ANOTHER_CREATURE_YOU_CONTROL),
+                new MagicMayChoice(new MagicTargetChoice("another creature to sacrifice")),
                 this,
                 "PN may\$ sacrifice another creature PN controls\$."
             );

--- a/release/Magarena/scripts/Search_for_Azcanta.groovy
+++ b/release/Magarena/scripts/Search_for_Azcanta.groovy
@@ -10,7 +10,7 @@ def putIntoGraveyardAction = {
     if (event.isYes()) {
         game.doAction(new ShiftCardAction(event.getRefCard(), MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
     }
-    if (player.getGraveyard().size() >= 7) {
+    if (event.getPlayer().getGraveyard().size() >= 7) {
         game.addEvent(new MagicEvent(
             event.getSource(),
             new MagicMayChoice("Transfrom ${event.getPermanent()}"),
@@ -36,9 +36,8 @@ def putIntoGraveyardAction = {
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            final MagicPlayer player = event.getPlayer();
-            final MagicCard topCard = player.getLibrary().getCardAtTop();
-            game.doAction(new LookAction(topCard, player, "top card of your library"));
+            final MagicCard topCard = event.getPlayer().getLibrary().getCardAtTop();
+            game.doAction(new LookAction(topCard, event.getPlayer(), "top card of your library"));
             game.addEvent(new MagicEvent(
                 event.getSource(),
                 new MagicMayChoice("Put the card into your graveyard?"),

--- a/release/Magarena/scripts/Search_for_Azcanta.groovy
+++ b/release/Magarena/scripts/Search_for_Azcanta.groovy
@@ -1,14 +1,22 @@
+def transformAction = {
+    final MagicGame game, final MagicEvent event ->
+    if (event.isYes()) {
+        game.doAction(new TransformAction(event.getPermanent()));
+    }
+}
+
 def putIntoGraveyardAction = {
     final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
         game.doAction(new ShiftCardAction(event.getRefCard(), MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
     }
-}
-
-def transformAction = {
-    final MagicGame game, final MagicEvent event ->
-    if (event.isYes()) {
-        game.doAction(new TransformAction(event.getPermanent()));
+    if (player.getGraveyard().size() >= 7) {
+        game.addEvent(new MagicEvent(
+            event.getSource(),
+            new MagicMayChoice("Transfrom ${event.getPermanent()}"),
+            transformAction,
+            "PN may\$ transform SN."
+        ));
     }
 }
 
@@ -34,17 +42,11 @@ def transformAction = {
             game.addEvent(new MagicEvent(
                 event.getSource(),
                 new MagicMayChoice("Put the card into your graveyard?"),
+                topCard,
                 putIntoGraveyardAction,
                 "PN may\$ put it into PN's graveyard."
             ));
-            if (player.getGraveyard().size() >= 7) {
-                game.addEvent(new MagicEvent(
-                    event.getSource(),
-                    new MagicMayChoice("Transfrom ${event.getPermanent()}"),
-                    transformAction,
-                    "PN may\$ transform SN."
-                ));
-            }
+
         }
     }
 ]

--- a/src/magic/model/MagicAbility.java
+++ b/src/magic/model/MagicAbility.java
@@ -1731,8 +1731,8 @@ public enum MagicAbility {
         protected void addAbilityImpl(final MagicAbilityStore card, final Matcher arg) {
             final String[] ptStr = ARG.ptStr(arg);
             final MagicPowerToughness pt = new MagicPowerToughness(
-                MagicAmountParser.getX(ptStr[0], 1),
-                MagicAmountParser.getX(ptStr[1], 1)
+                MagicAmountParser.getXSign(ptStr[0], 1),
+                MagicAmountParser.getXSign(ptStr[1], 1)
             );
             final MagicTargetFilter<MagicPermanent> affected = MagicTargetFilterFactory.Permanent(ARG.wordrun(arg));
             final MagicAmount count = MagicAmountParser.build(ARG.wordrun2(arg));

--- a/src/magic/model/MagicAmount.java
+++ b/src/magic/model/MagicAmount.java
@@ -11,21 +11,11 @@ public abstract class MagicAmount {
     }
 
     public int getPositiveAmount(final MagicSource source, final MagicPlayer player) {
-        if (this == MagicAmountFactory.NegXCost) {
-            // Return a negative number for NegXCost
-            return Math.min(getAmount(source, player), 0);
-        } else {
-            return Math.max(getAmount(source, player), 0);
-        }
+        return Math.max(getAmount(source, player), 0);
     }
 
     public int getPositiveAmount(final MagicEvent event) {
-        if (this == MagicAmountFactory.NegXCost) {
-            // Return a negative number for NegXCost
-            return Math.min(getAmount(event), 0);
-        } else {
-            return Math.max(getAmount(event), 0);
-        }
+        return Math.max(getAmount(event), 0);
     }
 
     public boolean isConstant() {

--- a/src/magic/model/MagicAmount.java
+++ b/src/magic/model/MagicAmount.java
@@ -24,11 +24,11 @@ public abstract class MagicAmount {
 
     public static int countEachProduct(final MagicAmount amount, final MagicAmount eachCount, final MagicEvent event) {
         if (eachCount != MagicAmountFactory.One && amount == MagicAmountFactory.XCost) {
-            return eachCount.getPositiveAmount(event);
+            return eachCount.getAmount(event);
         } else if (eachCount != MagicAmountFactory.One && amount == MagicAmountFactory.NegXCost) {
-            return -eachCount.getPositiveAmount(event);
+            return -eachCount.getAmount(event);
         } else {
-            return amount.getPositiveAmount(event) * eachCount.getPositiveAmount(event);
+            return amount.getAmount(event) * eachCount.getAmount(event);
         }
     }
 }

--- a/src/magic/model/MagicAmount.java
+++ b/src/magic/model/MagicAmount.java
@@ -10,17 +10,35 @@ public abstract class MagicAmount {
         return getAmount(event.getSource(), event.getPlayer());
     }
 
+    public int getPositiveAmount(final MagicSource source, final MagicPlayer player) {
+        if (this == MagicAmountFactory.NegXCost) {
+            // Return a negative number for NegXCost
+            return Math.min(getAmount(source, player), 0);
+        } else {
+            return Math.max(getAmount(source, player), 0);
+        }
+    }
+
+    public int getPositiveAmount(final MagicEvent event) {
+        if (this == MagicAmountFactory.NegXCost) {
+            // Return a negative number for NegXCost
+            return Math.min(getAmount(event), 0);
+        } else {
+            return Math.max(getAmount(event), 0);
+        }
+    }
+
     public boolean isConstant() {
         return false;
     }
 
     public static int countEachProduct(final MagicAmount amount, final MagicAmount eachCount, final MagicEvent event) {
         if (eachCount != MagicAmountFactory.One && amount == MagicAmountFactory.XCost) {
-            return eachCount.getAmount(event);
+            return eachCount.getPositiveAmount(event);
         } else if (eachCount != MagicAmountFactory.One && amount == MagicAmountFactory.NegXCost) {
-            return -eachCount.getAmount(event);
+            return -eachCount.getPositiveAmount(event);
         } else {
-            return amount.getAmount(event) * eachCount.getAmount(event);
+            return amount.getPositiveAmount(event) * eachCount.getPositiveAmount(event);
         }
     }
 }

--- a/src/magic/model/MagicAmountParser.java
+++ b/src/magic/model/MagicAmountParser.java
@@ -140,7 +140,7 @@ public enum MagicAmountParser {
 
     public abstract MagicAmount toAmount(final Matcher arg);
 
-    public static final int getX(final String text, final int X) {
+    public static final int getXSign(final String text, final int X) {
         if (text.equalsIgnoreCase("x")) {
             return X;
         } else if (text.equalsIgnoreCase("-x")) {

--- a/src/magic/model/event/MagicHandCastActivation.java
+++ b/src/magic/model/event/MagicHandCastActivation.java
@@ -141,7 +141,7 @@ public class MagicHandCastActivation extends MagicActivation<MagicCard> implemen
                     new MagicPayManaCostEvent(
                         source,
                         source.getGameCost().reduce(
-                            amount.getAmount(source, source.getController())
+                            amount.getPositiveAmount(source, source.getController())
                         )
                     )
                 );

--- a/src/magic/model/event/MagicRuleEventAction.java
+++ b/src/magic/model/event/MagicRuleEventAction.java
@@ -570,7 +570,7 @@ public enum MagicRuleEventAction {
             final MagicAmount count = MagicAmountParser.build(ARG.wordrun(matcher));
             final MagicTargetFilter<MagicTarget> filter = ARG.targetsParse(matcher);
             return (game, event) -> {
-                final int amount = count.getAmount(event);
+                final int amount = count.getPositiveAmount(event);
                 game.logAppendValue(event.getPlayer(), amount);
                 for (final MagicTarget target : ARG.targets(event, matcher, filter)) {
                     game.doAction(new DealDamageAction(
@@ -1111,7 +1111,7 @@ public enum MagicRuleEventAction {
             final MagicAmount count = ARG.each(matcher);
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
-                final int multiplier = count.getAmount(event);
+                final int multiplier = count.getPositiveAmount(event);
                 final int total = amount.getAmount(event) * multiplier;
                 if (count != MagicAmountFactory.One) {
                     game.logAppendValue(event.getPlayer(), total);
@@ -1140,7 +1140,7 @@ public enum MagicRuleEventAction {
             final MagicAmount eachCount = ARG.each(matcher);
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
-                final int multiplier = eachCount.getAmount(event);
+                final int multiplier = eachCount.getPositiveAmount(event);
                 final int total = lifeCount.getAmount(event) * multiplier;
                 if (eachCount != MagicAmountFactory.One) {
                     game.logAppendValue(event.getPlayer(), total);
@@ -3178,7 +3178,7 @@ public enum MagicRuleEventAction {
             final MagicAmount eachCount = ARG.each(matcher);
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
-                final int multiplier = eachCount.getAmount(event);
+                final int multiplier = eachCount.getPositiveAmount(event);
                 final int total = amount * multiplier;
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
                     game.doAction(new ChangeCountersAction(it, MagicCounterType.Energy, total));

--- a/src/magic/model/event/MagicSearchToLocationEvent.java
+++ b/src/magic/model/event/MagicSearchToLocationEvent.java
@@ -50,7 +50,9 @@ public class MagicSearchToLocationEvent extends MagicEvent {
             if (event.isNo()) {
                 // do nothing
             } else if (event.getChosen()[0] instanceof MagicCardChoiceResult) {
-                game.doAction(new ShuffleLibraryAction(event.getPlayer()));
+                if (event.getCardChoice().stream().anyMatch(MagicCard::isInLibrary)) {
+                    game.doAction(new ShuffleLibraryAction(event.getPlayer()));
+                }
                 event.processChosenCards(game, (final MagicCard card) -> {
                     if (revealed) {
                         game.logAppendMessage(
@@ -59,11 +61,13 @@ public class MagicSearchToLocationEvent extends MagicEvent {
                         );
                         game.doAction(new AIRevealAction(card));
                     }
-                    game.doAction(new ShiftCardAction(card,MagicLocationType.OwnersLibrary, toLocation));
+                    game.doAction(new ShiftCardAction(card, card.getLocation(), toLocation));
                 });
             } else {
-                game.doAction(new ShuffleLibraryAction(event.getPlayer()));
                 event.processTargetCard(game, (final MagicCard card) -> {
+                    if (card.isInLibrary()) {
+                        game.doAction(new ShuffleLibraryAction(event.getPlayer()));
+                    }
                     if (revealed) {
                         game.logAppendMessage(
                             event.getPlayer(),
@@ -71,7 +75,7 @@ public class MagicSearchToLocationEvent extends MagicEvent {
                         );
                         game.doAction(new AIRevealAction(card));
                     }
-                    game.doAction(new ShiftCardAction(card, MagicLocationType.OwnersLibrary, toLocation));
+                    game.doAction(new ShiftCardAction(card, card.getLocation(), toLocation));
                 });
             }
         };

--- a/src/magic/model/mstatic/MagicStatic.java
+++ b/src/magic/model/mstatic/MagicStatic.java
@@ -102,7 +102,7 @@ public abstract class MagicStatic extends MagicDummyModifier implements MagicCha
         return new MagicStatic(MagicLayer.ModPT, affected) {
             @Override
             public void modPowerToughness(final MagicPermanent source, final MagicPermanent permanent, final MagicPowerToughness pt) {
-                final int amt = count.getAmount(source, source.getController());
+                final int amt = count.getPositiveAmount(source, source.getController());
                 pt.add(given.power() * amt, given.toughness() * amt);
             }
         };

--- a/src/magic/model/trigger/EntersWithCounterTrigger.java
+++ b/src/magic/model/trigger/EntersWithCounterTrigger.java
@@ -43,7 +43,7 @@ public class EntersWithCounterTrigger extends EntersBattlefieldTrigger {
 
     @Override
     public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicPayedCost payedCost) {
-        final int total = amount * count.getAmount(permanent, permanent.getController());
+        final int total = amount * count.getPositiveAmount(permanent, permanent.getController());
         if (cond.accept(permanent)) {
             game.doAction(ChangeCountersAction.Enters(
                 permanent,


### PR DESCRIPTION
- Change behaviour of `MagicSearchToLocationEvent` (#1466)
  - The searched cards can be from anywhere, as opposed to just library.
  - Shuffle the library only if any of the searched cards are from the library.
- Add method `MagicAmount.getPositiveAmount` (#1462)
- Some minor fixes for bugs I stumbled upon
  - Heart-Piercer Manticore now uses sacrifice target choice
  - Implement `executeEvent` in Entrancing Melody
  - Fix wrong method call in Deathgorge Scavenger