### PR TITLE
Fix incorrect argument usage in Crown of Doom

### DIFF
--- a/release/Magarena/scripts/Crown_of_Doom.groovy
+++ b/release/Magarena/scripts/Crown_of_Doom.groovy
@@ -1,7 +1,7 @@
 def filter = new MagicPlayerFilterImpl() {
     @Override
     public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPlayer target) {
-        return player != ((MagicPermanent)source).getOwner();
+        return target != ((MagicPermanent)source).getOwner();
     }
 };
 


### PR DESCRIPTION
Crown of Doom used `player` rather than `target` for its filtering, which is why it doesn't find any player to target.

Closes #1465