### PR TITLE
Fix bugs

### DIFF
--- a/release/Magarena/scripts/Aetherworks_Marvel.groovy
+++ b/release/Magarena/scripts/Aetherworks_Marvel.groovy
@@ -2,8 +2,8 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     final MagicCardList topCards = new MagicCardList(event.getRefCardList());
     event.processChosenCards(game, {
-        game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
         topCards.removeCard(it);
+        game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
     });
     topCards.shuffle();
     topCards.each {

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -12,15 +12,16 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
-            def nonTarget = library.takeWhile({ !it.hasType(MagicType.Creature) });
-            if (library.any({ it.hasType(MagicType.Creature) })) {
-                final MagicCard target = library.find({ it.hasType(MagicType.Creature) });
+            def predicate = { final MagicCard card -> card.hasType(MagicType.creature) };
+            final MagicCardList nonTarget = library.takeWhile({ !predicate(it) });
+            if (library.any(predicate)) {
+                final MagicCard target = library.find(predicate);
                 game.doAction(new RevealAction(nonTarget.plus(target)));
                 game.doAction(new ShiftCardAction(target, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
             } else {
                 game.doAction(new RevealAction(nonTarget));
             }
-            Collections.shuffle(nonTarget);
+            nonTarget.shuffle();
             nonTarget.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
         }
     }

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -13,7 +13,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Creature) };
-            final MagicCardList nonTarget = library.takeWhile({ !predicate(it) });
+            final MagicCardList nonTarget = (MagicCardList)library.takeWhile({ !predicate(it) });
             if (library.any(predicate)) {
                 final MagicCard target = library.find(predicate);
                 game.doAction(new RevealAction(nonTarget.plus(target)));

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -13,7 +13,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Creature) };
-            final MagicCardList nonTarget = (MagicCardList)library.takeWhile({ !predicate(it) });
+            final MagicCardList nonTarget = new MagicCardList(library.takeWhile({ !predicate(it) }));
             if (library.any(predicate)) {
                 final MagicCard target = library.find(predicate);
                 game.doAction(new RevealAction(nonTarget.plus(target)));

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -12,7 +12,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
-            def predicate = { final MagicCard card -> card.hasType(MagicType.creature) };
+            def predicate = { final MagicCard card -> card.hasType(MagicType.Creature) };
             final MagicCardList nonTarget = library.takeWhile({ !predicate(it) });
             if (library.any(predicate)) {
                 final MagicCard target = library.find(predicate);

--- a/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.groovy
+++ b/release/Magarena/scripts/Azcanta__the_Sunken_Ruin.groovy
@@ -2,8 +2,8 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     final MagicCardList topCards = new MagicCardList(event.getRefCardList());
     event.processChosenCards(game, {
-        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
         topCards.removeCard(it);
+        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
     });
     topCards.each {
         game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary))

--- a/release/Magarena/scripts/Combustible_Gearhulk.groovy
+++ b/release/Magarena/scripts/Combustible_Gearhulk.groovy
@@ -7,7 +7,7 @@ def choiceAction = {
     } else {
         final MagicAction millAction = new MillLibraryAction(player, 3);
         game.doAction(millAction);
-        final int amount = (int)millAction.getMilledCards()*.getConvertedCost().sum();
+        final int amount = (int)millAction.getMilledCards()*.getConvertedCost().sum(0);
         game.doAction(new DealDamageAction(
             event.getSource(),
             opponent,

--- a/release/Magarena/scripts/Rashmi__Eternities_Crafter.groovy
+++ b/release/Magarena/scripts/Rashmi__Eternities_Crafter.groovy
@@ -24,17 +24,19 @@ def action = {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCard topCard = event.getPlayer().getLibrary().getCardAtTop();
-            game.doAction(new RevealAction(topCard));
-            if (!topCard.hasType(MagicType.Land) && topCard.getConvertedCost() < event.getRefCardOnStack().getConvertedCost()) {
-                game.addEvent(new MagicEvent(
+            if (topCard != MagicCard.NONE) {
+                game.doAction(new RevealAction(topCard));
+                if (!topCard.hasType(MagicType.Land) && topCard.getConvertedCost() < event.getRefCardOnStack().getConvertedCost()) {
+                    game.addEvent(new MagicEvent(
                     event.getSource(),
                     new MagicMayChoice("Cast the card without paying its mana cost?"),
                     topCard,
                     action,
                     "If it's a nonland card with converted mana cost less than that spell's, PN may\$ cast it without paying its mana cost. If PN doesn't cast the revealed card, put it into PN's hand."
-                ));
-            } else {
-                game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                    ));
+                } else {
+                    game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                }
             }
         }
     }

--- a/release/Magarena/scripts/Rashmi__Eternities_Crafter.groovy
+++ b/release/Magarena/scripts/Rashmi__Eternities_Crafter.groovy
@@ -23,19 +23,18 @@ def action = {
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            final MagicCard topCard = event.getPlayer().getLibrary().getCardAtTop();
-            if (topCard != MagicCard.NONE) {
-                game.doAction(new RevealAction(topCard));
-                if (!topCard.hasType(MagicType.Land) && topCard.getConvertedCost() < event.getRefCardOnStack().getConvertedCost()) {
+            event.getPlayer().getLibrary().getCardsFromTop(1).each {
+                game.doAction(new RevealAction(it));
+                if (!it.hasType(MagicType.Land) && it.getConvertedCost() < event.getRefCardOnStack().getConvertedCost()) {
                     game.addEvent(new MagicEvent(
-                    event.getSource(),
-                    new MagicMayChoice("Cast the card without paying its mana cost?"),
-                    topCard,
-                    action,
-                    "If it's a nonland card with converted mana cost less than that spell's, PN may\$ cast it without paying its mana cost. If PN doesn't cast the revealed card, put it into PN's hand."
+                        event.getSource(),
+                        new MagicMayChoice("Cast the card without paying its mana cost?"),
+                        it,
+                        action,
+                        "If it's a nonland card with converted mana cost less than that spell's, PN may\$ cast it without paying its mana cost. If PN doesn't cast the revealed card, put it into PN's hand."
                     ));
                 } else {
-                    game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                    game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
                 }
             }
         }

--- a/release/Magarena/scripts/Ruin_Raider.groovy
+++ b/release/Magarena/scripts/Ruin_Raider.groovy
@@ -15,10 +15,11 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            final MagicCard topCard = event.getPlayer().getLibrary().getCardAtTop();
-            game.doAction(new RevealAction(topCard));
-            game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
-            game.doAction(new ChangeLifeAction(event.getPlayer(), -topCard.getConvertedCost()));
+            event.getPlayer().getLibrary().getCardsFromTop(1).each {
+                game.doAction(new RevealAction(topCard));
+                game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                game.doAction(new ChangeLifeAction(event.getPlayer(), -topCard.getConvertedCost()));
+            }
         }
     }
 ]

--- a/release/Magarena/scripts/Ruin_Raider.groovy
+++ b/release/Magarena/scripts/Ruin_Raider.groovy
@@ -16,9 +16,9 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.getPlayer().getLibrary().getCardsFromTop(1).each {
-                game.doAction(new RevealAction(topCard));
-                game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
-                game.doAction(new ChangeLifeAction(event.getPlayer(), -topCard.getConvertedCost()));
+                game.doAction(new RevealAction(it));
+                game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                game.doAction(new ChangeLifeAction(event.getPlayer(), -it.getConvertedCost()));
             }
         }
     }

--- a/release/Magarena/scripts/Search_for_Azcanta.groovy
+++ b/release/Magarena/scripts/Search_for_Azcanta.groovy
@@ -37,11 +37,11 @@ def putIntoGraveyardAction = {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.getPlayer().getLibrary().getCardsFromTop(1).each {
-                game.doAction(new LookAction(topCard, event.getPlayer(), "top card of your library"));
+                game.doAction(new LookAction(it, event.getPlayer(), "top card of your library"));
                 game.addEvent(new MagicEvent(
                     event.getSource(),
                     new MagicMayChoice("Put the card into your graveyard?"),
-                    topCard,
+                    it,
                     putIntoGraveyardAction,
                     "PN may\$ put it into PN's graveyard."
                 ));

--- a/release/Magarena/scripts/Search_for_Azcanta.groovy
+++ b/release/Magarena/scripts/Search_for_Azcanta.groovy
@@ -36,16 +36,16 @@ def putIntoGraveyardAction = {
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            final MagicCard topCard = event.getPlayer().getLibrary().getCardAtTop();
-            game.doAction(new LookAction(topCard, event.getPlayer(), "top card of your library"));
-            game.addEvent(new MagicEvent(
-                event.getSource(),
-                new MagicMayChoice("Put the card into your graveyard?"),
-                topCard,
-                putIntoGraveyardAction,
-                "PN may\$ put it into PN's graveyard."
-            ));
-
+            event.getPlayer().getLibrary().getCardsFromTop(1).each {
+                game.doAction(new LookAction(topCard, event.getPlayer(), "top card of your library"));
+                game.addEvent(new MagicEvent(
+                    event.getSource(),
+                    new MagicMayChoice("Put the card into your graveyard?"),
+                    topCard,
+                    putIntoGraveyardAction,
+                    "PN may\$ put it into PN's graveyard."
+                ));
+            }
         }
     }
 ]

--- a/release/Magarena/scripts/Sunbird_s_Invocation.groovy
+++ b/release/Magarena/scripts/Sunbird_s_Invocation.groovy
@@ -2,8 +2,8 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     final MagicCardList topCards = new MagicCardList(event.getRefCardList());
     event.processChosenCards(game, {
-        game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
         topCards.removeCard(it);
+        game.doAction(CastCardAction.WithoutManaCost(event.getPlayer(), it, MagicLocationType.OwnersLibrary, MagicLocationType.Graveyard));
     });
     topCards.shuffle();
     topCards.each {

--- a/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
+++ b/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
@@ -13,7 +13,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Artifact) };
-            final MagicCardList nonTarget = (MagicCardList)library.takeWhile({ !predicate(it) });
+            final MagicCardList nonTarget = new MagicCardList(library.takeWhile({ !predicate(it) }));
             if (library.any(predicate)) {
                 final MagicCard target = library.find(predicate);
                 game.doAction(new RevealAction(nonTarget.plus(target)));

--- a/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
+++ b/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
@@ -12,7 +12,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
-            def predicate = { it.hasType(MagicType.Artifact) };
+            def predicate = { final MagicCard card -> card.hasType(MagicType.Artifact) };
             final MagicCardList nonTarget = (MagicCardList)library.takeWhile({ !predicate(it) });
             if (library.any(predicate)) {
                 final MagicCard target = library.find(predicate);

--- a/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
+++ b/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
@@ -12,15 +12,16 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
-            def nonTarget = library.takeWhile({ !it.hasType(MagicType.Artifact) });
-            if (library.any({ it.hasType(MagicType.Artifact) })) {
-                final MagicCard target = library.find({ it.hasType(MagicType.Artifact) });
+            def predicate = { it.hasType(MagicType.Artifact) };
+            final MagicCardList nonTarget = (MagicCardList)library.takeWhile({ !predicate(it) });
+            if (library.any(predicate)) {
+                final MagicCard target = library.find(predicate);
                 game.doAction(new RevealAction(nonTarget.plus(target)));
                 game.doAction(new ShiftCardAction(target, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
             } else {
                 game.doAction(new RevealAction(nonTarget));
             }
-            Collections.shuffle(nonTarget);
+            nonTarget.shuffle();
             nonTarget.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
         }
     }


### PR DESCRIPTION
- Fix crash Combustible Gearhulk's ability is used on empty library
  - Combustible Gearhulk (empty lists sum to null by default in Groovy) [CI build](https://circleci.com/gh/Fulmene/magarena/251)
- Change `library.getCardAtTop()` to `library.getCardsFromTop(1)`
  - Rashmi, Eternities Crafter (getGame called for MagicPlayer.NONE) [CI build](https://circleci.com/gh/Fulmene/magarena/250)
  - Ruin Raider
  - Search for Azcanta
- Fix crash when use Sunbird's Invocation and similar cards (the cast card wasn't properly removed from return list due to it changed location before the removal, so it doesn't `equals` the same card anymore) [CI build](https://circleci.com/gh/Fulmene/magarena/329)
  - Aetherworks Marvel
  - Azcanta, the Sunken Ruin
  - Sunbird's Invocation
- Fix Collections.shuffle usage (#1502)
  - Tezzeret, Master of Metal
  - Ajani, Valiant Protector