### PR TITLE
Configurable time limits for running AI game.

### DIFF
--- a/src/magic/DeckStrCal.java
+++ b/src/magic/DeckStrCal.java
@@ -4,6 +4,8 @@ import java.io.File;
 import magic.ai.MagicAIImpl;
 import magic.data.DeckGenerators;
 import magic.data.DuelConfig;
+import magic.data.GeneralConfig;
+import magic.data.settings.IntegerSetting;
 import magic.exception.handler.ConsoleExceptionHandler;
 import magic.headless.HeadlessGameController;
 import magic.model.DuelPlayerConfig;
@@ -192,8 +194,7 @@ public class DeckStrCal {
             final MagicGame game=testDuel.nextGame();
             game.setArtificial(true);
 
-            //maximum duration of a game is 60 minutes
-            final HeadlessGameController controller = new HeadlessGameController(game, 3600000);
+            final HeadlessGameController controller = new HeadlessGameController(game, GeneralConfig.get(IntegerSetting.AI_DUEL_MATCH_LIMIT) * 1000);
 
             controller.runGame();
             if (testDuel.getGamesPlayed() > played) {

--- a/src/magic/HeadlessAIGame.java
+++ b/src/magic/HeadlessAIGame.java
@@ -3,6 +3,8 @@ package magic;
 import java.util.Collections;
 import magic.ai.MagicAI;
 import magic.data.DuelConfig;
+import magic.data.GeneralConfig;
+import magic.data.settings.IntegerSetting;
 import magic.exception.handler.ConsoleExceptionHandler;
 import magic.headless.HeadlessGameController;
 import magic.model.MagicDeck;
@@ -114,7 +116,7 @@ public class HeadlessAIGame {
 
             //maximum duration of a game is 10 minutes
             final HeadlessGameController controller = new HeadlessGameController(
-                game, 600000
+                game, GeneralConfig.get(IntegerSetting.AI_DUEL_MATCH_LIMIT) * 1000
             );
 
             final long start_time = System.currentTimeMillis();

--- a/src/magic/data/settings/IntegerSetting.java
+++ b/src/magic/data/settings/IntegerSetting.java
@@ -4,15 +4,22 @@ import java.awt.Color;
 import magic.ui.MagicStickyFrame;
 
 public enum IntegerSetting {
-
+    /** Maximum duration of AI duel in seconds. */
+    AI_DUEL_MATCH_LIMIT("aiDuelMatchLimitSeconds",600),
     CARD_OVERLAY_MIN_HEIGHT("overlayPermanentMinHeight", 30),
     DECK_MAX_LINES("deckFileMaxLines", 500),
+    /** Maximum duration of AI game in deck strength calculator in seconds. */
+    DECK_STR_MATCH_LIMIT("deckStrengthMatchLimitSeconds", 3600),
+    /** Maximum duration of Firemind game in seconds. */
+    FIREMIND_MATCH_LIMIT("firemindMatchLimitSeconds", 3600),
     FRAME_HEIGHT("height", MagicStickyFrame.DEFAULT_HEIGHT),
     FRAME_LEFT("left", -1),
     FRAME_TOP("top", -1),
     FRAME_WIDTH("width", MagicStickyFrame.DEFAULT_WIDTH),
     GAME_VOLUME("gameVolume", 80),
     ROLLOVER_RGB("rolloverColor", Color.YELLOW.getRGB()),
+    /** Maximum duration of test match in seconds. */
+    TEST_MATCH_LIMIT("testMatchLimitSeconds", 60),
     UI_VOLUME("uiSoundVolume", 80),
     ;
 

--- a/src/magic/firemind/FiremindDuelRunner.java
+++ b/src/magic/firemind/FiremindDuelRunner.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 import magic.ai.MagicAIImpl;
 import magic.data.CardDefinitions;
 import magic.data.DuelConfig;
+import magic.data.GeneralConfig;
+import magic.data.settings.IntegerSetting;
 import magic.headless.HeadlessGameController;
 import magic.model.DuelPlayerConfig;
 import magic.model.MagicDeckProfile;
@@ -169,7 +171,7 @@ public class FiremindDuelRunner {
 
             // maximum duration of a game is 60 minutes
             final HeadlessGameController controller = new HeadlessGameController(
-                    game, 3600000);
+                    game, GeneralConfig.get(IntegerSetting.FIREMIND_MATCH_LIMIT) * 1000);
 
             controller.runGame();
             if (testDuel.getGamesPlayed() > played) {

--- a/src/magic/ui/screen/stats/TestGameRunner.java
+++ b/src/magic/ui/screen/stats/TestGameRunner.java
@@ -8,6 +8,8 @@ import javax.swing.SwingWorker;
 import magic.ai.MagicAIImpl;
 import magic.data.DeckGenerators;
 import magic.data.DuelConfig;
+import magic.data.GeneralConfig;
+import magic.data.settings.IntegerSetting;
 import magic.data.stats.MagicStats;
 import magic.exception.InvalidDeckException;
 import magic.headless.HeadlessGameController;
@@ -40,7 +42,7 @@ class TestGameRunner extends SwingWorker<Void, Integer> {
         final MagicGame game = duel.nextGame();
         game.setArtificial(true);
         //maximum duration of a game is 1 minute
-        final HeadlessGameController controller = new HeadlessGameController(game, 60000);
+        final HeadlessGameController controller = new HeadlessGameController(game, GeneralConfig.get(IntegerSetting.TEST_MATCH_LIMIT) * 1000);
         controller.runGame();
         MagicStats.saveGameData(game);
     }


### PR DESCRIPTION
While default limits for headless AI vs AI game are usually OK, sometimes (when testing aggro deck, or some control deck, or when running on a stronger/weaker CPU) you may wish for smaller or larger limits.

This merge request makes the values configurable in the settings (general.cfg) instead of being hardcoded in the source code.