### PR TITLE
Make targeting spells and abilities "countered" if the target becomes illegal

### DIFF
--- a/release/Magarena/scripts/Chandra_s_Defeat.groovy
+++ b/release/Magarena/scripts/Chandra_s_Defeat.groovy
@@ -13,7 +13,7 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
         game.addEvent(new MagicDiscardChosenEvent(event.getSource(), A_CARD_FROM_HAND));
-        game.doAction(new DrawAction(event.getPlayer()));
+        game.addEvent(new MagicDrawEvent(event.getSource(), event.getPlayer(), 1));
     }
 }
 
@@ -35,9 +35,9 @@ def action = {
                 if (it.hasType(MagicType.Planeswalker) && it.hasSubType(MagicSubType.Chandra)) {
                     game.addEvent(new MagicEvent(
                         event.getSource(),
-                        new MagicMayChoice(),
+                        new MagicMayChoice("Discard a card?"),
                         action,
-                        "PN may\$ discard a card. If PN does, draw a card."
+                        "PN may\$ discard a card\$."
                     ));
                 }
             });

--- a/release/Magarena/scripts/Chandra_s_Defeat.groovy
+++ b/release/Magarena/scripts/Chandra_s_Defeat.groovy
@@ -37,7 +37,7 @@ def action = {
                         event.getSource(),
                         new MagicMayChoice("Discard a card?"),
                         action,
-                        "PN may\$ discard a card\$."
+                        "PN may\$ discard a card."
                     ));
                 }
             });

--- a/release/Magarena/scripts/Confiscation_Coup.groovy
+++ b/release/Magarena/scripts/Confiscation_Coup.groovy
@@ -2,7 +2,7 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
         final MagicPermanent target = event.getRefPermanent();
-        game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCountersType.Energy, -target.getConvertedCost()));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, -target.getConvertedCost()));
         game.doAction(new GainControlAction(event.getPlayer(), target));
     }
 }

--- a/release/Magarena/scripts/Confiscation_Coup.groovy
+++ b/release/Magarena/scripts/Confiscation_Coup.groovy
@@ -2,7 +2,7 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
         final MagicPermanent target = event.getRefPermanent();
-        game.addEvent(new MagicPayEnergyEvent(event.getSource(), target.getConvertedCost()));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCountersType.Energy, -target.getConvertedCost()));
         game.doAction(new GainControlAction(event.getPlayer(), target));
     }
 }
@@ -21,9 +21,8 @@ def action = {
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, 4));
-
             event.processTargetPermanent(game, {
+                game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, 4));
                 if (event.getPlayer().getEnergy() >= it.getConvertedCost()) {
                     game.addEvent(new MagicEvent(
                         event.getSource(),

--- a/release/Magarena/scripts/Expel_from_Orazca.groovy
+++ b/release/Magarena/scripts/Expel_from_Orazca.groovy
@@ -19,8 +19,8 @@ def action = {
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.addEvent(MagicRuleEventAction.create("ascend").getEvent(event));
             event.processTargetPermanent(game, {
+                game.addEvent(MagicRuleEventAction.create("ascend").getEvent(event));
                 if (event.getPlayer().hasState(MagicPlayerState.CitysBlessing)) {
                     game.addEvent(new MagicEvent(
                         event.getSource(),

--- a/release/Magarena/scripts/Field_of_Ruin.groovy
+++ b/release/Magarena/scripts/Field_of_Ruin.groovy
@@ -17,7 +17,7 @@
                 source,
                 new MagicTargetChoice("target nonbasic land an opponent controls"),
                 this,
-                "Destroy target nonbasic land an opponent controls\$. " +
+                "Destroy target nonbasic land PN's opponent controls\$. " +
                 "Each player searches his or her library for a basic land card, puts it onto the battle field, then shuffles his or her library."
             );
         }
@@ -25,19 +25,19 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 game.doAction(new DestroyAction(it));
-            });
-            game.getAPNAP().each({
-                final MagicPlayer player ->
-                game.addEvent(new MagicSearchOntoBattlefieldEvent(
-                    event.getSource(),
-                    player,
-                    new MagicFromCardFilterChoice(
-                        BASIC_LAND_CARD_FROM_LIBRARY,
-                        1,
-                        false,
-                        "a basic land card from library"
-                    )
-                ));
+                game.getAPNAP().each({
+                    final MagicPlayer player ->
+                    game.addEvent(new MagicSearchOntoBattlefieldEvent(
+                        event.getSource(),
+                        player,
+                        new MagicFromCardFilterChoice(
+                            BASIC_LAND_CARD_FROM_LIBRARY,
+                            1,
+                            false,
+                            "a basic land card from library"
+                        )
+                    ));
+                });
             });
         }
     }

--- a/release/Magarena/scripts/Imminent_Doom.groovy
+++ b/release/Magarena/scripts/Imminent_Doom.groovy
@@ -6,7 +6,7 @@
                 new MagicEvent(
                     permanent,
                     NEG_TARGET_CREATURE_OR_PLAYER,
-                    spell.getConvertedCost(),
+                    permanent.getCounters(MagicCounterType.Doom),
                     this,
                     "SN deals RN damage to target creature or player\$. " +
                     "Then put a doom counter on SN."
@@ -18,8 +18,8 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTarget(game, {
                 game.doAction(new DealDamageAction(event.getSource(), it, event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getSource(), MagicCounterType.Doom, 1));
             });
-            game.doAction(new ChangeCountersAction(event.getSource(), MagicCounterType.Doom, 1));
         }
     }
 ]

--- a/release/Magarena/scripts/Kari_Zev_s_Expertise.groovy
+++ b/release/Magarena/scripts/Kari_Zev_s_Expertise.groovy
@@ -26,17 +26,18 @@ def action = {
                 game.doAction(new GainControlAction(event.getPlayer(), it, MagicStatic.UntilEOT));
                 game.doAction(new UntapAction(it));
                 game.doAction(new GainAbilityAction(it, MagicAbility.Haste, MagicStatic.UntilEOT));
+
+                game.addEvent(new MagicEvent(
+                    event.getSource(),
+                    new MagicMayChoice(new MagicTargetChoice(
+                        card().cmcLEQ(2).from(MagicTargetType.Hand),
+                        "a card with converted mana cost 2 or less from your hand"
+                    )),
+                    action,
+                    "PN may\$ cast a card with converted mana cost 2 or less from PN's hand\$ without paying its mana cost."
+                ));
             });
 
-            game.addEvent(new MagicEvent(
-                event.getSource(),
-                new MagicMayChoice(new MagicTargetChoice(
-                    card().cmcLEQ(2).from(MagicTargetType.Hand),
-                    "a card with converted mana cost 2 or less from your hand"
-                )),
-                action,
-                "PN may\$ cast a card with converted mana cost 2 or less from PN's hand\$ without paying its mana cost."
-            ));
         }
     }
 ]

--- a/release/Magarena/scripts/Liberating_Combustion.groovy
+++ b/release/Magarena/scripts/Liberating_Combustion.groovy
@@ -39,13 +39,13 @@ def searchAction = {
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTarget(game, {
                 game.doAction(new DealDamageAction(event.getSource(), it, 6));
+                game.addEvent(new MagicEvent(
+                    event.getSource(),
+                    new MagicMayChoice("Search your library?"),
+                    searchAction,
+                    "PN may\$ search PN's library and/or graveyard for a card named Chandra, Pyrogenius, reveal it, and put it into PN's hand. If PN search his or her library this way, shuffle it."
+                ));
             });
-            game.addEvent(new MagicEvent(
-                event.getSource(),
-                new MagicMayChoice("Search your library?"),
-                searchAction,
-                "PN may\$ search PN's library and/or graveyard for a card named Chandra, Pyrogenius, reveal it, and put it into PN's hand. If PN search his or her library this way, shuffle it."
-            ));
         }
     }
 ]

--- a/release/Magarena/scripts/Wasp_of_the_Bitter_End.groovy
+++ b/release/Magarena/scripts/Wasp_of_the_Bitter_End.groovy
@@ -1,8 +1,7 @@
 def action = {
     final MagicGame game, final MagicEvent event ->
-    event.processTargetPermanent(game, {
-        game.doAction(new DestroyAction(it));
-    });
+    game.doAction(new SacrificeAction(event.getPermanent()));
+    game.doAction(new DestroyAction(event.getRefPermanent()));
 }
 
 [
@@ -15,21 +14,22 @@ def action = {
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicCardOnStack spell) {
             return new MagicEvent(
                 permanent,
-                new MagicMayChoice(),
+                NEG_TARGET_CREATURE,
                 this,
-                "PN may\$ sacrifice SN."
+                "PN chooses a target creature\$."
             );
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            if (event.isYes()) {
-                game.doAction(new EnqueueTriggerAction(new MagicEvent(
+            event.processTargetPermanent(game, {
+                game.addEvent(new MagicEvent(
                     event.getSource(),
-                    NEG_TARGET_CREATURE,
+                    new MagicMayChoice("Sacrifice ${event.getSource()}?"),
+                    it,
                     action,
-                    "Destroy target creature\$."
-                )));
-            }
+                    "PN may\$ sacrifice SN. If PN does, destroy RN."
+                ));
+            });
         }
     }
 ]


### PR DESCRIPTION
Targeting spells and abilities won't resolve if the target becomes illegal. Affected cards are cards that put effects that don't have anything to do with the target outside of `event.processTarget` so it would still apply if the target became illegal.