### PR TITLE
Add RevealAction to Dubious Challenge

### DIFF
--- a/release/Magarena/scripts/Dubious_Challenge.groovy
+++ b/release/Magarena/scripts/Dubious_Challenge.groovy
@@ -17,6 +17,7 @@ def exileAction = {
     final MagicPlayer controller = event.getPlayer();
     final MagicCardList exiled = new MagicCardList();
     event.processChosenCards(game, {
+        game.doAction(new RevealAction(it));
         game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.Exile));
         if (it.isInExile()) {
             exiled.add(it);


### PR DESCRIPTION
The effect of Dubious Challenge happens across two events, so it needs a `RevealAction` on exiled cards.