### PR TITLE
Improve and generalize script parsing

### DIFF
--- a/release/Magarena/scripts/Doorkeeper.groovy
+++ b/release/Magarena/scripts/Doorkeeper.groovy
@@ -1,8 +1,4 @@
-def CREATURE_WITH_DEFENDER_YOU_CONTROL = new MagicPermanentFilterImpl() {
-    public boolean accept(final MagicSource source,final MagicPlayer player,final MagicPermanent target) {
-        return target.isCreature() && target.hasAbility(MagicAbility.Defender) == true
-    }
-};
+def CREATURE_WITH_DEFENDER_YOU_CONTROL = creature(MagicAbility.Defender, Control.You);
 
 [
     new MagicPermanentActivation(

--- a/release/Magarena/scripts/Goblin_Snowman.groovy
+++ b/release/Magarena/scripts/Goblin_Snowman.groovy
@@ -1,9 +1,3 @@
-def CREATURE_BLOCKED_BY_SN = new MagicPermanentFilterImpl() {
-    public boolean accept(final MagicSource source,final MagicPlayer player,final MagicPermanent target) {
-        return target.isCreature() && target.getBlockingCreatures().contains(source);
-    }
-}
-
 def TARGET_CREATURE_BLOCKED_BY_SOURCE = {
     final MagicSource source ->
     return new MagicTargetChoice(

--- a/release/Magarena/scripts/Horribly_Awry.txt
+++ b/release/Magarena/scripts/Horribly_Awry.txt
@@ -9,4 +9,3 @@ ability=Devoid
 effect=Counter target creature spell with converted mana cost 4 or less. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.
 timing=counter
 oracle=Devoid\nCounter target creature spell with converted mana cost 4 or less. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.
-status=needs groovy

--- a/release/Magarena/scripts/Radiant_Kavu.txt
+++ b/release/Magarena/scripts/Radiant_Kavu.txt
@@ -9,4 +9,3 @@ pt=3/3
 ability={R}{G}{W}: Prevent all combat damage blue creatures and black creatures would deal this turn.
 timing=main
 oracle={R}{G}{W}: Prevent all combat damage blue creatures and black creatures would deal this turn.
-status=needs groovy

--- a/release/Magarena/scripts/Sequestered_Stash.groovy
+++ b/release/Magarena/scripts/Sequestered_Stash.groovy
@@ -15,7 +15,7 @@ def action = {
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
             return [
-                new MagicPayManaCostEvent(source, "4"),
+                new MagicPayManaCostEvent(source, "{4}"),
                 new MagicTapEvent(source),
                 new MagicSacrificeEvent(source)
             ];

--- a/release/Magarena/scripts/Thoughtbind.txt
+++ b/release/Magarena/scripts/Thoughtbind.txt
@@ -7,4 +7,3 @@ cost={2}{U}
 effect=Counter target spell with converted mana cost 4 or less.
 timing=counter
 oracle=Counter target spell with converted mana cost 4 or less.
-status=needs groovy

--- a/src/magic/model/target/DetectedPrefixes.java
+++ b/src/magic/model/target/DetectedPrefixes.java
@@ -1,0 +1,93 @@
+package magic.model.target;
+
+import magic.model.MagicColor;
+import magic.model.MagicSubType;
+import magic.model.MagicType;
+
+import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parsed restriction on color, type and subtype.
+ */
+public class DetectedPrefixes {
+    /**
+     * Type of detected prefix. If not None, then one of the other fields will be set.
+     */
+    public PrefixType prefixType;
+    public MagicColor color;
+    public MagicType type;
+    public MagicSubType subType;
+
+    private DetectedPrefixes(PrefixType prefixType, MagicColor color, MagicType type, MagicSubType subType) {
+        this.prefixType = prefixType;
+        this.color = color;
+        this.type = type;
+        this.subType = subType;
+    }
+
+    private static final Pattern COLOR_REGEX = makeGroupRegex(MagicColor.values());
+    private static final Pattern TYPE_REGEX = makeGroupRegex(MagicType.values());
+    private static final Pattern SUBTYPE_REGEX = makeGroupRegex(MagicSubType.values());
+
+    /**
+     * Make a regex that matches if text matches one of enum's values, optionally prefixed with "non" or "non-"
+     */
+    private static Pattern makeGroupRegex(Enum[] values) {
+        StringJoiner joiner = new StringJoiner("|");
+        for (Enum i : values) {
+            joiner.add(i.toString());
+        }
+        String re = "(non-?)?(" + joiner.toString() + ")";
+        return Pattern.compile(re, Pattern.CASE_INSENSITIVE);
+    }
+
+    /**
+     * Parse prefix alone, returning recognized restriction, if any.
+     */
+    public static DetectedPrefixes parseFrom(String prefix) {
+        // Example: black / nonblack
+        Matcher m1 = COLOR_REGEX.matcher(prefix);
+        if (m1.matches()) {
+            boolean isNegative = m1.group(1) != null;
+            String base = m1.group(2);
+            for (final MagicColor c : MagicColor.values()) {
+                if (base.equalsIgnoreCase(c.getName())) {
+                    return new DetectedPrefixes(isNegative ? PrefixType.NonColor : PrefixType.Color,
+                            c, null, null);
+                }
+            }
+        }
+        // Example: land / nonland
+        Matcher m2 = TYPE_REGEX.matcher(prefix);
+        if (m2.matches()) {
+            boolean isNegative = m2.group(1) != null;
+            String base = m2.group(2);
+            for (final MagicType t : MagicType.values()) {
+                if (base.equalsIgnoreCase(t.toString())) {
+                    return new DetectedPrefixes(isNegative ? PrefixType.NonType : PrefixType.Type,
+                            null, t, null);
+                }
+            }
+        }
+        // Example: Vampire / non-Vampire
+        Matcher m3 = SUBTYPE_REGEX.matcher(prefix);
+        if (m3.matches()) {
+            boolean isNegative = m3.group(1) != null;
+            String base = m3.group(2);
+            for (final MagicSubType st : MagicSubType.values()) {
+                if (base.equalsIgnoreCase(st.toString())) {
+                    return new DetectedPrefixes(isNegative ? PrefixType.NonSubType : PrefixType.SubType,
+                            null, null, st);
+                }
+            }
+        }
+        // Nothing detected
+        return new DetectedPrefixes(PrefixType.None, null, null, null);
+    }
+
+    enum PrefixType {
+        None, Color, NonColor, Type, NonType, SubType, NonSubType
+    }
+}

--- a/src/magic/model/target/MagicCardFilterImpl.java
+++ b/src/magic/model/target/MagicCardFilterImpl.java
@@ -138,6 +138,11 @@ public abstract class MagicCardFilterImpl implements MagicTargetFilter<MagicCard
             }
         };
     }
+
+    /**
+     * @param color required color
+     * @return return filter with additional condition for target having given color
+     */
     public MagicCardFilterImpl and(final MagicColor color) {
         final MagicCardFilterImpl curr = this;
         return new MagicCardFilterImpl() {
@@ -147,6 +152,11 @@ public abstract class MagicCardFilterImpl implements MagicTargetFilter<MagicCard
             }
         };
     }
+
+    /**
+     * @param ability required ability
+     * @return return filter with additional condition for target having given ability
+     */
     public MagicCardFilterImpl and(final MagicAbility ability) {
         final MagicCardFilterImpl curr = this;
         return new MagicCardFilterImpl() {
@@ -156,6 +166,10 @@ public abstract class MagicCardFilterImpl implements MagicTargetFilter<MagicCard
             }
         };
     }
+
+    /**
+     * @return return filter with additional condition for target being a card that defines a permanent
+     */
     public MagicCardFilterImpl permanent() {
         final MagicCardFilterImpl curr = this;
         return new MagicCardFilterImpl() {
@@ -165,6 +179,11 @@ public abstract class MagicCardFilterImpl implements MagicTargetFilter<MagicCard
             }
         };
     }
+
+    /**
+     * @param n CMC limit
+     * @return return filter with additional condition for target's converted mana cost being less or equal to given limit
+     */
     public MagicCardFilterImpl cmcLEQ(final int n) {
         final MagicCardFilterImpl curr = this;
         return new MagicCardFilterImpl() {
@@ -174,6 +193,11 @@ public abstract class MagicCardFilterImpl implements MagicTargetFilter<MagicCard
             }
         };
     }
+
+    /**
+     * @param n power limit
+     * @return return filter with additional condition for target's power being less or equal to given limit
+     */
     public MagicCardFilterImpl powerLEQ(final int n) {
         final MagicCardFilterImpl curr = this;
         return new MagicCardFilterImpl() {

--- a/src/magic/model/target/MagicPermanentFilterImpl.java
+++ b/src/magic/model/target/MagicPermanentFilterImpl.java
@@ -91,4 +91,57 @@ public abstract class MagicPermanentFilterImpl implements MagicTargetFilter<Magi
         };
     }
 
+
+    /**
+     * @return filter with added condition matching permanent with specified exact converted mana cost
+     */
+    public MagicPermanentFilterImpl cmcEQ(int cmc) {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && target.getConvertedCost() == cmc;
+            }
+        };
+    }
+
+    /**
+     * @return filter with added condition matching permanent with specified minimal converted mana cost
+     */
+    public MagicPermanentFilterImpl cmcGEQ(int cmc) {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && target.getConvertedCost() >= cmc;
+            }
+        };
+    }
+
+    /**
+     * @return filter with added condition matching permanent with specified maximal converted mana cost
+     */
+    public MagicPermanentFilterImpl cmcLEQ(int cmc) {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && target.getConvertedCost() <= cmc;
+            }
+        };
+    }
+
+    /**
+     * @return filter with added condition for a non-token permanent
+     */
+    public MagicPermanentFilterImpl nonToken() {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && !target.isToken();
+            }
+        };
+    }
+
 }

--- a/src/magic/model/target/MagicPermanentFilterImpl.java
+++ b/src/magic/model/target/MagicPermanentFilterImpl.java
@@ -4,6 +4,7 @@ import magic.model.MagicGame;
 import magic.model.MagicPermanent;
 import magic.model.MagicPlayer;
 import magic.model.MagicSource;
+import magic.model.MagicType;
 import magic.model.event.MagicEvent;
 
 import java.util.ArrayList;
@@ -50,4 +51,44 @@ public abstract class MagicPermanentFilterImpl implements MagicTargetFilter<Magi
     public MagicPermanentFilterImpl except(final MagicPermanent invalid) {
         return new MagicOtherPermanentTargetFilter(this, invalid);
     }
+
+    /**
+     * @return filter that adds "is attacking" condition
+     */
+    public MagicPermanentFilterImpl andAttacking() {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && target.isAttacking();
+            }
+        };
+    }
+
+    /**
+     * @return filter that adds condition for type of permanent
+     */
+    public MagicPermanentFilterImpl andType(final MagicType type) {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && target.hasType(type);
+            }
+        };
+    }
+
+    /**
+     * @return filter that adds "nonartifact" / "is not artifact" condition
+     */
+    public MagicPermanentFilterImpl andNotArtifact() {
+        final MagicPermanentFilterImpl curr = this;
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(MagicSource source, MagicPlayer player, MagicPermanent target) {
+                return curr.accept(source, player, target) && !target.isArtifact();
+            }
+        };
+    }
+
 }

--- a/src/magic/model/target/MagicStackFilterImpl.java
+++ b/src/magic/model/target/MagicStackFilterImpl.java
@@ -46,4 +46,69 @@ public abstract class MagicStackFilterImpl implements MagicTargetFilter<MagicIte
     public boolean acceptType(final MagicTargetType targetType) {
         return targetType==MagicTargetType.Stack;
     }
+
+    /**
+     * @return filter with added condition matching spell with specified exact converted mana cost
+     */
+    public MagicStackFilterImpl withCmcEq(int cmc) {
+        final MagicStackFilterImpl curr = this;
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+                return curr.accept(source, player, item) && item.getConvertedCost() == cmc;
+            }
+        };
+    }
+
+    /**
+     * @return filter with added condition matching spell with specified minimal converted mana cost
+     */
+    public MagicStackFilterImpl withCmcMin(int cmc) {
+        final MagicStackFilterImpl curr = this;
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+                return curr.accept(source, player, item) && item.getConvertedCost() >= cmc;
+            }
+        };
+    }
+
+    /**
+     * @return filter with added condition matching spell with specified maximal converted mana cost
+     */
+    public MagicStackFilterImpl withCmcMax(int cmc) {
+        final MagicStackFilterImpl curr = this;
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+                return curr.accept(source, player, item) && item.getConvertedCost() <= cmc;
+            }
+        };
+    }
+
+    /**
+     * @return with added condition filter matching spell controlled by you
+     */
+    public MagicStackFilterImpl youControl() {
+        final MagicStackFilterImpl curr = this;
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+                return curr.accept(source, player, item) && item.isFriend(player);
+            }
+        };
+    }
+
+    /**
+     * @return with added condition filter matching spell not controlled by you
+     */
+    public MagicStackFilterImpl youNotControl() {
+        final MagicStackFilterImpl curr = this;
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
+                return curr.accept(source, player, item) && item.isEnemy(player);
+            }
+        };
+    }
 }

--- a/src/magic/model/target/MagicStackFilterImpl.java
+++ b/src/magic/model/target/MagicStackFilterImpl.java
@@ -50,7 +50,7 @@ public abstract class MagicStackFilterImpl implements MagicTargetFilter<MagicIte
     /**
      * @return filter with added condition matching spell with specified exact converted mana cost
      */
-    public MagicStackFilterImpl withCmcEq(int cmc) {
+    public MagicStackFilterImpl cmcEQ(int cmc) {
         final MagicStackFilterImpl curr = this;
         return new MagicStackFilterImpl() {
             @Override
@@ -63,7 +63,7 @@ public abstract class MagicStackFilterImpl implements MagicTargetFilter<MagicIte
     /**
      * @return filter with added condition matching spell with specified minimal converted mana cost
      */
-    public MagicStackFilterImpl withCmcMin(int cmc) {
+    public MagicStackFilterImpl cmcGEQ(int cmc) {
         final MagicStackFilterImpl curr = this;
         return new MagicStackFilterImpl() {
             @Override
@@ -76,7 +76,7 @@ public abstract class MagicStackFilterImpl implements MagicTargetFilter<MagicIte
     /**
      * @return filter with added condition matching spell with specified maximal converted mana cost
      */
-    public MagicStackFilterImpl withCmcMax(int cmc) {
+    public MagicStackFilterImpl cmcLEQ(int cmc) {
         final MagicStackFilterImpl curr = this;
         return new MagicStackFilterImpl() {
             @Override

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -18,7 +18,6 @@ import magic.model.MagicPlayer;
 import magic.model.MagicSource;
 import magic.model.MagicSubType;
 import magic.model.MagicType;
-import magic.model.choice.MagicTargetChoice;
 import magic.model.stack.MagicAbilityOnStack;
 import magic.model.stack.MagicItemOnStack;
 
@@ -1334,13 +1333,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONWHITE_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.White);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONWHITE_CREATURE = creatureNon(MagicColor.White, Control.Any);
 
     public static final MagicPermanentFilterImpl NONWHITE_NONBLACK_CREATURE = new MagicPermanentFilterImpl() {
         @Override
@@ -1357,29 +1350,11 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONBLACK_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.Black);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONBLACK_CREATURE = creatureNon(MagicColor.Black, Control.Any);
 
-    public static final MagicPermanentFilterImpl NONBLUE_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.Blue);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONBLUE_CREATURE = creatureNon(MagicColor.Blue, Control.Any);
 
-    public static final MagicPermanentFilterImpl NONGREEN_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.Green);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONGREEN_CREATURE = creatureNon(MagicColor.Green, Control.Any);
 
     public static final MagicPermanentFilterImpl NONBLACK_ATTACKING_CREATURE = new MagicPermanentFilterImpl() {
         @Override
@@ -1390,13 +1365,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONRED_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.Red);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONRED_CREATURE = creatureNon(MagicColor.Red, Control.Any);
 
     public static final MagicPermanentFilterImpl NONARTIFACT_CREATURE = new MagicPermanentFilterImpl() {
         @Override
@@ -1415,14 +1384,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONARTIFACT_NONBLACK_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.isArtifact() &&
-                !target.hasColor(MagicColor.Black);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONARTIFACT_NONBLACK_CREATURE = creatureNon(MagicColor.Black, Control.Any).andNotArtifact();
 
     public static final MagicPermanentFilterImpl NONSNOW_CREATURE = new MagicPermanentFilterImpl() {
         @Override
@@ -1592,7 +1554,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl CREATURE_MINSUONE_COUNTER = creature(MagicCounterType.MinusOne, Control.Any);
+    public static final MagicPermanentFilterImpl CREATURE_MINUSONE_COUNTER = creature(MagicCounterType.MinusOne, Control.Any);
 
     public static final MagicPermanentFilterImpl CREATURE_WITH_COUNTER = new MagicPermanentFilterImpl() {
         @Override
@@ -1949,12 +1911,7 @@ public class MagicTargetFilterFactory {
     public static final MagicCardFilterImpl CREATURE_CARD_FROM_OPPONENTS_GRAVEYARD =
         card(MagicType.Creature).from(MagicTargetType.OpponentsGraveyard);
 
-    public static final MagicCardFilterImpl ARTIFACT_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.hasType(MagicType.Artifact);
-        }
-    };
+    public static final MagicCardFilterImpl ARTIFACT_CARD = card(MagicType.Artifact);
 
     public static final MagicCardFilterImpl NONCREATURE_ARTIFACT_CARD_WITH_CMC_LEQ_1_FROM_GRAVEYARD = new MagicCardFilterImpl() {
         @Override
@@ -1985,12 +1942,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicCardFilterImpl CREATURE_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.hasType(MagicType.Creature);
-        }
-    };
+    public static final MagicCardFilterImpl CREATURE_CARD = card(MagicType.Creature);
 
     public static final MagicCardFilterImpl ENCHANTMENT_CARD_FROM_GRAVEYARD = new MagicCardFilterImpl() {
         @Override
@@ -2004,26 +1956,11 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicCardFilterImpl ENCHANTMENT_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.hasType(MagicType.Enchantment);
-        }
-    };
+    public static final MagicCardFilterImpl ENCHANTMENT_CARD = card(MagicType.Enchantment);
 
-    public static final MagicCardFilterImpl INSTANT_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.hasType(MagicType.Instant);
-        }
-    };
+    public static final MagicCardFilterImpl INSTANT_CARD = card(MagicType.Instant);
 
-    public static final MagicCardFilterImpl SORCERY_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.hasType(MagicType.Sorcery);
-        }
-    };
+    public static final MagicCardFilterImpl SORCERY_CARD = card(MagicType.Sorcery);
 
     public static final MagicCardFilterImpl INSTANT_OR_SORCERY_CARD_FROM_ALL_GRAVEYARDS = new MagicCardFilterImpl() {
         @Override
@@ -2040,12 +1977,7 @@ public class MagicTargetFilterFactory {
 
     public static final MagicCardFilterImpl LAND_CARD_FROM_YOUR_GRAVEYARD = card(MagicType.Land).from(MagicTargetType.Graveyard);
 
-    public static final MagicCardFilterImpl LAND_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.hasType(MagicType.Land);
-        }
-    };
+    public static final MagicCardFilterImpl LAND_CARD = card(MagicType.Land);
 
     public static final MagicCardFilterImpl ARTIFACT_OR_CREATURE_CARD = new MagicCardFilterImpl() {
         @Override
@@ -2189,19 +2121,9 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicCardFilterImpl NONCREATURE_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return !target.hasType(MagicType.Creature);
-        }
-    };
+    public static final MagicCardFilterImpl NONCREATURE_CARD = cardNot(MagicType.Creature);
 
-    public static final MagicCardFilterImpl NONARTIFACT_CARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return !target.hasType(MagicType.Artifact);
-        }
-    };
+    public static final MagicCardFilterImpl NONARTIFACT_CARD = cardNot(MagicType.Artifact);
 
     public static final MagicCardFilterImpl NONARTIFACT_NONLAND_CARD = new MagicCardFilterImpl() {
         @Override
@@ -2240,13 +2162,7 @@ public class MagicTargetFilterFactory {
 
     public static final MagicPermanentFilterImpl KNIGHT_OR_SOLDIER = permanentOr(MagicSubType.Knight, MagicSubType.Soldier, Control.Any);
 
-    public static final MagicPermanentFilterImpl ELF_OR_SOLDIER_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                (target.hasSubType(MagicSubType.Elf) || target.hasSubType(MagicSubType.Soldier));
-        }
-    };
+    public static final MagicPermanentFilterImpl ELF_OR_SOLDIER_CREATURE = creatureOr(MagicSubType.Elf, MagicSubType.Soldier, Control.Any);
 
     public static final MagicPermanentFilterImpl ELDRAZI_SPAWN_CREATURE = new MagicPermanentFilterImpl() {
         @Override
@@ -2681,8 +2597,17 @@ public class MagicTargetFilterFactory {
 
         // ... card
         addp("instant or sorcery card", INSTANT_OR_SORCERY_CARD);
-        addp("red sorcery card", RED_SORCERY_CARD);
-        addp("blue instant card", BLUE_INSTANT_CARD);
+        for (MagicColor c: MagicColor.values()) {
+            // Single colored specific cards, i.e. "blue instant card"
+            addp(c.name() + " sorcery card", card(c).and(MagicType.Sorcery));
+            addp(c.name() + " instant card", card(c).and(MagicType.Instant));
+            for (MagicColor c2 : MagicColor.values()) {
+                // Cards of one of two colors, i.e. "red or green card"
+                if (c!=c2) {
+                    addp(c.name() + " or " + c2.name() + " card", card(c).or(c2));
+                }
+            }
+        }
         addp("basic land card", BASIC_LAND_CARD);
         addp("snow land card", SNOW_LAND_CARD);
         addp("artifact or enchantment card", card(MagicType.Artifact).or(MagicType.Enchantment));
@@ -2695,7 +2620,6 @@ public class MagicTargetFilterFactory {
         addp("nonartifact card", NONARTIFACT_CARD);
         addp("noncreature, nonland card", NONCREATURE_NONLAND_CARD);
         addp("nonartifact, nonland card", NONARTIFACT_NONLAND_CARD);
-        addp("red or green card", RED_OR_GREEN_CARD);
         addp("artifact, creature, or land card", ARTIFACT_OR_CREATURE_OR_LAND_CARD);
         addp("basic land card or a Desert card", BASIC_LAND_CARD_OR_DESERT_CARD);
         addp("basic land card or a Gate card", BASIC_LAND_CARD_OR_GATE_CARD);
@@ -2760,18 +2684,15 @@ public class MagicTargetFilterFactory {
         add("artifact card with converted mana cost 3 from your library", permanentCardEqualCMC(MagicType.Artifact, MagicTargetType.Library, 3));
 
         // <color|type|subtype> permanent card from your library
-        add("Rebel permanent card with converted mana cost 1 or less from your library", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Library, 1));
-        add("Rebel permanent card with converted mana cost 2 or less from your library", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Library, 2));
-        add("Rebel permanent card with converted mana cost 3 or less from your library", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Library, 3));
-        add("Rebel permanent card with converted mana cost 4 or less from your library", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Library, 4));
-        add("Rebel permanent card with converted mana cost 5 or less from your library", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Library, 5));
-        add("Rebel permanent card with converted mana cost 6 or less from your library", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Library, 6));
-        add("Mercenary permanent card with converted mana cost 1 or less from your library", permanentCardMaxCMC(MagicSubType.Mercenary, MagicTargetType.Library, 1));
-        add("Mercenary permanent card with converted mana cost 2 or less from your library", permanentCardMaxCMC(MagicSubType.Mercenary, MagicTargetType.Library, 2));
-        add("Mercenary permanent card with converted mana cost 3 or less from your library", permanentCardMaxCMC(MagicSubType.Mercenary, MagicTargetType.Library, 3));
-        add("Mercenary permanent card with converted mana cost 4 or less from your library", permanentCardMaxCMC(MagicSubType.Mercenary, MagicTargetType.Library, 4));
-        add("Mercenary permanent card with converted mana cost 5 or less from your library", permanentCardMaxCMC(MagicSubType.Mercenary, MagicTargetType.Library, 5));
-        add("Mercenary permanent card with converted mana cost 6 or less from your library", permanentCardMaxCMC(MagicSubType.Mercenary, MagicTargetType.Library, 6));
+        MagicSubType[] someSubtypes = new MagicSubType[]{MagicSubType.Rebel, MagicSubType.Mercenary};
+        for (MagicSubType subType: someSubtypes) {
+            add(subType.name() + " permanent card with converted mana cost 1 or less from your library", permanentCardMaxCMC(subType, MagicTargetType.Library, 1));
+            add(subType.name() + " permanent card with converted mana cost 2 or less from your library", permanentCardMaxCMC(subType, MagicTargetType.Library, 2));
+            add(subType.name() + " permanent card with converted mana cost 3 or less from your library", permanentCardMaxCMC(subType, MagicTargetType.Library, 3));
+            add(subType.name() + " permanent card with converted mana cost 4 or less from your library", permanentCardMaxCMC(subType, MagicTargetType.Library, 4));
+            add(subType.name() + " permanent card with converted mana cost 5 or less from your library", permanentCardMaxCMC(subType, MagicTargetType.Library, 5));
+            add(subType.name() + " permanent card with converted mana cost 6 or less from your library", permanentCardMaxCMC(subType, MagicTargetType.Library, 6));
+        }
         add("legendary Spirit permanent card from your library", LEGENDARY_SPIRIT_PERMANENT_CARD_FROM_LIBRARY);
         add("permanent card from your library", PERMANENT_CARD_FROM_LIBRARY);
 
@@ -2786,38 +2707,46 @@ public class MagicTargetFilterFactory {
         add("creature you control that's a wolf or a werewolf", WEREWOLF_OR_WOLF_CREATURE_YOU_CONTROL);
 
         // <color|type|subtype> creature
+        for (MagicColor c1 : MagicColor.values()) {
+            // Single colored, i.e. "nonblue creature"
+            add("non" + c1.name() + " creature", creatureNon(c1, Control.Any));
+            // Single colored, i.e. "nonblue attacking creature"
+            add("non" + c1.name() + " attacking creature", creatureNon(c1, Control.Any).andAttacking());
+
+            for (MagicColor c2 : MagicColor.values()) {
+                // Creature having one of two colors, i.e. "blue or black creature"
+                if (c1 != c2) {
+                    add(c1.name() + " or " + c2.name() + " creature", creatureOr(c1, c2, Control.Any));
+                    add(c1.name() + " creature or " + c2.name() + " creature", creatureOr(c1, c2, Control.Any));
+                }
+                // Creature not having any of two colors, i.e. "nonwhite, nonblack creature"
+                add("non" + c1.name() + ", non" + c2.name() + " creature", creatureNeither(c1, c2, Control.Any));
+            }
+        }
+        add("nonartifact, nonblack creature", NONARTIFACT_NONBLACK_CREATURE);
+        add("nonartifact, nonwhite creature", NONARTIFACT_NONWHITE_CREATURE);
+        add("artifact creature or black creature", ARTIFACT_CREATURE_OR_BLACK_CREATURE);
+        add("land or nonblack creature", LAND_OR_NONBLACK_CREATURE);
+        add("black or red creature that's attacking or blocking", BLACK_OR_RED_CREATURE_ATTACKING_OR_BLOCKING);
+        add("blue or black creature with flying", BLUE_OR_BLACK_CREATURE_WITH_FLYING);
+
         add("1/1 creature", new MagicPTTargetFilter(CREATURE, Operator.EQUAL, 1, Operator.EQUAL, 1));
-        add("blue or black creature", BLUE_OR_BLACK_CREATURE);
         add("creature with modular", MODULAR_CREATURE);
         add("creature with trample", CREATURE_WITH_TRAMPLE);
         add("creature with level up", LEVELUP_CREATURE);
         add("creature with infect", CREATURE_WITH_INFECT);
-        add("red creature or white creature", RED_OR_WHITE_CREATURE);
         add("werewolf or wolf creature", WEREWOLF_OR_WOLF_CREATURE);
         add("Eldrazi Spawn creature", ELDRAZI_SPAWN_CREATURE);
         add("Eldrazi Spawn", ELDRAZI_SPAWN);
         add("face-up nontoken creature", FACEUP_NONTOKEN_CREATURE);
 
-        add("nongreen creature", NONGREEN_CREATURE);
-        add("nonblue creature", NONBLUE_CREATURE);
-        add("nonblack creature", NONBLACK_CREATURE);
-        add("nonblack attacking creature", NONBLACK_ATTACKING_CREATURE);
-        add("nonwhite creature", NONWHITE_CREATURE);
         add("nonwhite creature with power 3 or greater", new MagicPTTargetFilter(NONWHITE_CREATURE, Operator.GREATER_THAN_OR_EQUAL, 3));
-        add("nonwhite, nonblack creature", NONWHITE_NONBLACK_CREATURE);
-        add("nonred creature", NONRED_CREATURE);
         add("nonartifact creature", NONARTIFACT_CREATURE);
         add("nonland creature", NONLAND_CREATURE);
         add("non-Vampire, non-Werewolf, non-Zombie creature", NONVAMPIRE_NONWEREWOLF_NONZOMBIE_CREATURE);
         add("Skeleton, Vampire, or Zombie", SKELETON_VAMPIRE_OR_ZOMBIE);
         add("noncreature", NONCREATURE);
-        add("nonartifact, nonblack creature", NONARTIFACT_NONBLACK_CREATURE);
-        add("nonartifact, nonwhite creature", NONARTIFACT_NONWHITE_CREATURE);
-        add("artifact creature or black creature", ARTIFACT_CREATURE_OR_BLACK_CREATURE);
         add("nonartifact attacking creature", NONARTIFACT_ATTACKING_CREATURE);
-        add("land or nonblack creature", LAND_OR_NONBLACK_CREATURE);
-        add("red or green creature", RED_OR_GREEN_CREATURE);
-        add("red or white creature", RED_OR_WHITE_CREATURE);
         add("face-down creature", FACE_DOWN_CREATURE);
         add("artifact or creature", ARTIFACT_OR_CREATURE);
         add("unpaired Soulbond creature", UNPAIRED_SOULBOND_CREATURE);
@@ -2825,21 +2754,11 @@ public class MagicTargetFilterFactory {
         add("nonattacking creature", NONATTACKING_CREATURE);
         add("blocked creature", BLOCKED_CREATURE);
         add("blocking creature", BLOCKING_CREATURE);
-        add("blue or red creature", BLUE_OR_RED_CREATURE);
-        add("black or green creature", BLACK_OR_GREEN_CREATURE);
-        add("black or red creature", BLACK_OR_RED_CREATURE);
-        add("black or red creature that's attacking or blocking", BLACK_OR_RED_CREATURE_ATTACKING_OR_BLOCKING);
-        add("green or white creature", GREEN_OR_WHITE_CREATURE);
-        add("green or blue creature", GREEN_OR_BLUE_CREATURE);
-        add("green creature or white creature", GREEN_OR_WHITE_CREATURE);
-        add("white or blue creature", WHITE_OR_BLUE_CREATURE);
-        add("white or black creature", WHITE_OR_BLACK_CREATURE);
         add("white creature with power 2 or greater", WHITE_CREATURE_POWER_2_OR_MORE);
         add("creature with converted mana cost 3 or less", CREATURE_CONVERTED_3_OR_LESS);
         add("creature with converted mana cost 2 or less", CREATURE_CONVERTED_2_OR_LESS);
         add("creature with flying", CREATURE_WITH_FLYING);
         add("creature with flying or reach", CREATURE_WITH_FLYING_OR_REACH);
-        add("blue or black creature with flying", BLUE_OR_BLACK_CREATURE_WITH_FLYING);
         add("creature without flying", CREATURE_WITHOUT_FLYING);
         add("creature without defender", CREATURE_WITHOUT_DEFENDER);
         add("creature without shadow", CREATURE_WITHOUT_SHADOW);
@@ -2866,8 +2785,8 @@ public class MagicTargetFilterFactory {
         add("creature with toughness 4 or greater", CREATURE_TOUGHNESS_4_OR_GREATER);
         add("creature with shadow", CREATURE_WITH_SHADOW);
         add("creature with a +1/+1 counter on it", CREATURE_PLUSONE_COUNTER);
-        add("creature with a -1/-1 counter on it", CREATURE_MINSUONE_COUNTER);
-        add("creature that has a -1/-1 counter on it", CREATURE_MINSUONE_COUNTER);
+        add("creature with a -1/-1 counter on it", CREATURE_MINUSONE_COUNTER);
+        add("creature that has a -1/-1 counter on it", CREATURE_MINUSONE_COUNTER);
         add("creature with a level counter on it", CREATURE_LEVEL_COUNTER);
         add("creature that has a fate counter on it", CREATURE_FATE_COUNTER);
         add("creature with a counter on it", CREATURE_WITH_COUNTER);
@@ -2910,7 +2829,6 @@ public class MagicTargetFilterFactory {
         add("land with a trap counter on it", TRAPPED_LAND);
         add("Caribou token", CARIBOU_TOKEN);
         add("permanent with fading", PERMANENT_WITH_FADING);
-        add("green or white permanent", GREEN_OR_WHITE_PERMANENT);
         add("nontoken artifact", NONTOKEN_ARTIFACT);
         add("soldier or warrior", SOLDIER_OR_WARRIOR);
         add("forest or treefolk", FOREST_OR_TREEFOLK);
@@ -2920,7 +2838,6 @@ public class MagicTargetFilterFactory {
         add("snow Plains", SNOW_PLAINS);
         add("snow Forest", SNOW_FOREST);
         add("legendary snake", LEGENDARY_SNAKE);
-        add("red or green enchantment", RED_OR_GREEN_ENCHANTMENT);
 
         // <color|type|subtype> you control
         add("equipped creature you control", EQUIPPED_CREATURE_YOU_CONTROL);
@@ -2930,6 +2847,22 @@ public class MagicTargetFilterFactory {
         add("spell you don't control", SPELL_YOU_DONT_CONTROL);
 
         // <color|type|subtype> permanent
+        for (MagicColor c1 : MagicColor.values()) {
+            // Single colored, i.e. "nonblue permanent"
+            add("non" + c1.name() + " permanent", permanentNot(c1));
+
+            for (MagicColor c2 : MagicColor.values()) {
+                if (c1 != c2) {
+                    // Permanent having one of two colors, i.e. "blue or black permanent"
+                    add(c1.name() + " or " + c2.name() + " permanent", permanentOr(c1, c2, Control.Any));
+                    add(c1.name() + " permanent or " + c2.name() + " permanent", permanentOr(c1, c2, Control.Any));
+                    // Enchantment having one of two colors, i.e. "blue or black enchantment"
+                    add(c1.name() + " or " + c2.name() + " enchantment", permanentOr(c1, c2, Control.Any).andType(MagicType.Enchantment));
+                    add(c1.name() + " enchantment or " + c2.name() + " enchantment", permanentOr(c1, c2, Control.Any).andType(MagicType.Enchantment));
+                }
+            }
+        }
+
         add("permanent", PERMANENT);
         add("untapped permanent", UNTAPPED_PERMANENT);
         add("permanent you own", PERMANENT_YOU_OWN);
@@ -2941,15 +2874,7 @@ public class MagicTargetFilterFactory {
         add("nontoken red permanent", NONTOKEN_RED_PERMANENT);
         add("nontoken white permanent", NONTOKEN_WHITE_PERMANENT);
         add("nonland permanent with converted mana cost 3 or less", NONLAND_PERMANENT_CMC_LEQ_3);
-        add("black or red permanent", BLACK_OR_RED_PERMANENT);
-        add("black or green permanent", BLACK_OR_GREEN_PERMANENT);
-        add("blue or red permanent", BLUE_OR_RED_PERMANENT);
-        add("green or blue permanent", GREEN_OR_BLUE_PERMANENT);
-        add("white or black permanent", WHITE_OR_BLACK_PERMANENT);
-        add("white or blue permanent", WHITE_OR_BLUE_PERMANENT);
-        add("red or white permanent", RED_OR_WHITE_PERMANENT);
         add("multicolored permanent", MULTICOLORED_PERMANENT);
-        add("nonwhite permanent", NONWHITE_PERMANENT);
         add("permanent that is enchanted", PERMANENT_ENCHANTED);
         add("enchantment or enchanted permanent", ENCHANTMENT_OR_ENCHANTED_PERMANENT);
         add("nonartifact permanent", NONARTIFACT_PERMANENT);
@@ -3479,6 +3404,15 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    public static final MagicPermanentFilterImpl permanentNot(final MagicColor color) {
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
+                return !target.hasColor(color);
+            }
+        };
+    }
+
     public static final MagicPermanentFilterImpl permanentAnd(final MagicType type1, final MagicType type2, final Control control) {
         return new MagicPermanentFilterImpl() {
             @Override
@@ -3571,8 +3505,6 @@ public class MagicTargetFilterFactory {
         };
     }
 
-    ;
-
     public static final MagicPermanentFilterImpl creature(final MagicColor color, final Control control) {
         return creatureOr(color, color, control);
     }
@@ -3610,6 +3542,46 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @param color1  Disallowed color
+     * @param control Allowed controller of the creature
+     * @return filter matching creature permanent that is not of specified color
+     */
+    public static final MagicPermanentFilterImpl creatureNon(final MagicColor color1, final Control control) {
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
+                return target.isCreature() &&
+                    (target.hasColor(color1) == false) &&
+                    control.matches(player,target);
+            }
+        };
+    }
+
+    /**
+     * @param color1  First disallowed color
+     * @param color2  Second disallowed color
+     * @param control allowed controller of the creature
+     * @return filter matching creature permanent that is not of either of two specified colors
+     */
+    public static final MagicPermanentFilterImpl creatureNeither(final MagicColor color1, final MagicColor color2, final Control control) {
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
+                return target.isCreature() &&
+                    (!target.hasColor(color1)) &&
+                    (!target.hasColor(color2)) &&
+                    control.matches(player,target);
+            }
+        };
+    }
+
+    /**
+     * @param color1  First allowed color
+     * @param color2  Second allowed color
+     * @param control Allowed controller of the creature
+     * @return filter matching creature permanent that has at least one of two specified colors
+     */
     public static final MagicPermanentFilterImpl creatureOr(final MagicColor color1, final MagicColor color2, final Control control) {
         return new MagicPermanentFilterImpl() {
             @Override
@@ -3720,6 +3692,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting any card
+     */
     public static final MagicCardFilterImpl card() {
         return new MagicCardFilterImpl() {
             @Override
@@ -3729,6 +3704,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting cards of specified type
+     */
     public static final MagicCardFilterImpl card(final MagicType type) {
         return new MagicCardFilterImpl() {
             @Override
@@ -3738,6 +3716,21 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting cards that are not of specified type
+     */
+    public static final MagicCardFilterImpl cardNot(final MagicType type) {
+        return new MagicCardFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
+                return !target.hasType(type);
+            }
+        };
+    }
+
+    /**
+     * @return filter accepting cards of specified subtype
+     */
     public static final MagicCardFilterImpl card(final MagicSubType subType) {
         return new MagicCardFilterImpl() {
             @Override
@@ -3747,6 +3740,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting cards of specified color
+     */
     public static final MagicCardFilterImpl card(final MagicColor color) {
         return new MagicCardFilterImpl() {
             @Override
@@ -3756,6 +3752,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting cards of specified name
+     */
     public static final MagicCardFilterImpl cardName(final String name) {
         return new MagicCardFilterImpl() {
             @Override
@@ -3766,6 +3765,9 @@ public class MagicTargetFilterFactory {
     }
 
 
+    /**
+     * @return filter accepting spells of specified color
+     */
     public static final MagicStackFilterImpl spell(final MagicColor color) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3775,6 +3777,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of specified type
+     */
     public static final MagicStackFilterImpl spell(final MagicType type) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3784,6 +3789,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of specified subtype
+     */
     public static final MagicStackFilterImpl spell(final MagicSubType subType) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3793,6 +3801,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of one of two specified types
+     */
     public static final MagicStackFilterImpl spellOr(final MagicType type1, final MagicType type2) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3802,6 +3813,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of one of two specified types, with condition on spell controller
+     */
     public static final MagicStackFilterImpl spellOr(final MagicType type1, final MagicType type2, final Control control) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3815,6 +3829,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of given type or subtype
+     */
     public static final MagicStackFilterImpl spellOr(final MagicType type, final MagicSubType subType) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3824,6 +3841,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of one of two specified subtypes
+     */
     public static final MagicStackFilterImpl spellOr(final MagicSubType subType1, final MagicSubType subType2) {
         return new MagicStackFilterImpl() {
             @Override
@@ -3833,6 +3853,9 @@ public class MagicTargetFilterFactory {
         };
     }
 
+    /**
+     * @return filter accepting spells of one of two specified colors
+     */
     public static final MagicStackFilterImpl spellOr(final MagicColor color1, final MagicColor color2) {
         return new MagicStackFilterImpl() {
             @Override

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -196,58 +196,19 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicStackFilterImpl SPELL_YOU_DONT_CONTROL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell() && item.isEnemy(player);
-        }
-    };
+    public static final MagicStackFilterImpl SPELL_YOU_DONT_CONTROL = SPELL.youNotControl();
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_1 = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell() && item.getConvertedCost() == 1;
-        }
-    };
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_1 = SPELL.withCmcEq(1);
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_2 = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell() && item.getConvertedCost() == 2;
-        }
-    };
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_2 = SPELL.withCmcEq(2);
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_LEQ_3 = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell() && item.getConvertedCost() <= 3;
-        }
-    };
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_LEQ_3 = SPELL.withCmcMax(3);
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_4_OR_GREATER = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell() && item.getConvertedCost() >= 4;
-        }
-    };
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_4_OR_GREATER = SPELL.withCmcMin(4);
 
-    public static final MagicStackFilterImpl INSTANT_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell(MagicType.Instant) &&
-                item.getConvertedCost() <= 2 &&
-                item.isFriend(player);
-        }
-    };
+    public static final MagicStackFilterImpl INSTANT_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 = spell(MagicType.Instant).youControl().withCmcMax(2);
 
-    public static final MagicStackFilterImpl SORCERY_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
-            return item.isSpell(MagicType.Sorcery) &&
-                item.getConvertedCost() <= 2 &&
-                item.isFriend(player);
-        }
-    };
+    public static final MagicStackFilterImpl SORCERY_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 =spell(MagicType.Sorcery).youControl().withCmcMax(2);
 
     public static final MagicStackFilterImpl SPELL_WITH_X_COST = new MagicStackFilterImpl() {
         @Override
@@ -262,19 +223,9 @@ public class MagicTargetFilterFactory {
 
     public static final MagicStackFilterImpl GREEN_OR_WHITE_SPELL = spellOr(MagicColor.Green, MagicColor.White);
 
-    public static final MagicStackFilterImpl NONBLUE_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell() && !itemOnStack.hasColor(MagicColor.Blue);
-        }
-    };
+    public static final MagicStackFilterImpl NONBLUE_SPELL = spellNon(MagicColor.Blue);
 
-    public static final MagicStackFilterImpl NONBLACK_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell() && !itemOnStack.hasColor(MagicColor.Black);
-        }
-    };
+    public static final MagicStackFilterImpl NONBLACK_SPELL = spellNon(MagicColor.Black);
 
     public static final MagicStackFilterImpl NONFAERIE_SPELL = new MagicStackFilterImpl() {
         @Override
@@ -283,12 +234,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicStackFilterImpl BLUE_INSTANT_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell(MagicType.Instant) && itemOnStack.hasColor(MagicColor.Blue);
-        }
-    };
+    public static final MagicStackFilterImpl BLUE_INSTANT_SPELL = spell(MagicColor.Blue, MagicType.Instant);
 
     public static final MagicStackFilterImpl BLUE_SPELL_YOUR_TURN = new MagicStackFilterImpl() {
         @Override
@@ -308,12 +254,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicStackFilterImpl NONRED_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell() && !itemOnStack.hasColor(MagicColor.Red);
-        }
-    };
+    public static final MagicStackFilterImpl NONRED_SPELL = spellNon(MagicColor.Red);
 
     public static final MagicStackFilterImpl BLUE_OR_BLACK_OR_RED_SPELL = new MagicStackFilterImpl() {
         @Override
@@ -340,35 +281,13 @@ public class MagicTargetFilterFactory {
 
     public static final MagicStackFilterImpl CREATURE_OR_SORCERY_SPELL = spellOr(MagicType.Creature, MagicType.Sorcery);
 
-    public static final MagicStackFilterImpl NONCREATURE_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell() &&
-                !itemOnStack.isSpell(MagicType.Creature);
-        }
-    };
+    public static final MagicStackFilterImpl NONCREATURE_SPELL = spellNon(MagicType.Creature);
 
-    public static final MagicStackFilterImpl NONARTIFACT_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell() &&
-                !itemOnStack.isSpell(MagicType.Artifact);
-        }
-    };
+    public static final MagicStackFilterImpl NONARTIFACT_SPELL = spellNon(MagicType.Artifact);
 
-    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_6_OR_MORE = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell(MagicType.Creature) && itemOnStack.getConvertedCost() >= 6;
-        }
-    };
+    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_6_OR_MORE = spell(MagicType.Creature).withCmcMin(6);
 
-    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_3_OR_LESS = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell(MagicType.Creature) && itemOnStack.getConvertedCost() <= 3;
-        }
-    };
+    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_3_OR_LESS = spell(MagicType.Creature).withCmcMax(3);
 
     public static final MagicStackFilterImpl CREATURE_SPELL_WITH_INFECT = new MagicStackFilterImpl() {
         @Override
@@ -377,19 +296,9 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicStackFilterImpl GREEN_CREATURE_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell(MagicType.Creature) && itemOnStack.hasColor(MagicColor.Green);
-        }
-    };
+    public static final MagicStackFilterImpl GREEN_CREATURE_SPELL = spell(MagicColor.Green, MagicType.Creature);
 
-    public static final MagicStackFilterImpl BLUE_CREATURE_SPELL = new MagicStackFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
-            return itemOnStack.isSpell(MagicType.Creature) && itemOnStack.hasColor(MagicColor.Blue);
-        }
-    };
+    public static final MagicStackFilterImpl BLUE_CREATURE_SPELL = spell(MagicColor.Blue, MagicType.Creature);
 
     public static final MagicStackFilterImpl WHITE_OR_BLUE_INSTANT_OR_SORCERY_SPELL = new MagicStackFilterImpl() {
         @Override
@@ -3778,6 +3687,18 @@ public class MagicTargetFilterFactory {
     }
 
     /**
+     * @return filter accepting spells that are not of specified color
+     */
+    public static final MagicStackFilterImpl spellNon(final MagicColor color) {
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
+                return itemOnStack.isSpell() && !itemOnStack.hasColor(color);
+            }
+        };
+    }
+
+    /**
      * @return filter accepting spells of specified type
      */
     public static final MagicStackFilterImpl spell(final MagicType type) {
@@ -3785,6 +3706,30 @@ public class MagicTargetFilterFactory {
             @Override
             public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
                 return itemOnStack.isSpell(type);
+            }
+        };
+    }
+
+    /**
+     * @return filter accepting spells that are not of specified type
+     */
+    public static final MagicStackFilterImpl spellNon(final MagicType type) {
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
+                return itemOnStack.isSpell() && !itemOnStack.hasType(type);
+            }
+        };
+    }
+
+    /**
+     * @return filter accepting spells of specified color and specified type
+     */
+    public static final MagicStackFilterImpl spell(final MagicColor color, final MagicType type) {
+        return new MagicStackFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack itemOnStack) {
+                return itemOnStack.isSpell(type) && itemOnStack.hasColor(color);
             }
         };
     }

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -298,10 +298,6 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicStackFilterImpl GREEN_CREATURE_SPELL = spell(MagicColor.Green, MagicType.Creature);
-
-    public static final MagicStackFilterImpl BLUE_CREATURE_SPELL = spell(MagicColor.Blue, MagicType.Creature);
-
     public static final MagicStackFilterImpl WHITE_OR_BLUE_INSTANT_OR_SORCERY_SPELL = new MagicStackFilterImpl() {
         @Override
         public boolean accept(final MagicSource source, final MagicPlayer player, final MagicItemOnStack item) {
@@ -587,18 +583,6 @@ public class MagicTargetFilterFactory {
 
     public static final MagicPermanentFilterImpl ARTIFACT_OR_ENCHANTMENT = permanentOr(MagicType.Artifact, MagicType.Enchantment, Control.Any);
 
-    public static final MagicPermanentFilterImpl ARTIFACT_OR_ENCHANTMENT_CMC_3_OR_LESS = new MagicCMCPermanentFilter(
-        ARTIFACT_OR_ENCHANTMENT,
-        Operator.LESS_THAN_OR_EQUAL,
-        3
-    );
-
-    public static final MagicPermanentFilterImpl ARTIFACT_OR_ENCHANTMENT_CMC_4_OR_LESS = new MagicCMCPermanentFilter(
-        ARTIFACT_OR_ENCHANTMENT,
-        Operator.LESS_THAN_OR_EQUAL,
-        4
-    );
-
     public static final MagicPermanentFilterImpl ARTIFACT_OR_LAND = permanentOr(MagicType.Artifact, MagicType.Land, Control.Any);
 
     public static final MagicPermanentFilterImpl ARTIFACT_OR_ENCHANTMENT_OR_LAND = new MagicPermanentFilterImpl() {
@@ -704,13 +688,6 @@ public class MagicTargetFilterFactory {
         @Override
         public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
             return target.isOwner(player) && target.isController(player) && target.hasType(MagicType.Enchantment);
-        }
-    };
-
-    public static final MagicPermanentFilterImpl RED_OR_GREEN_ENCHANTMENT = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isEnchantment() && (target.hasColor(MagicColor.Red) || target.hasColor(MagicColor.Green));
         }
     };
 
@@ -2284,36 +2261,6 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl CREATURE_TOUGHNESS_2_OR_LESS = MagicPTTargetFilter.Toughness(
-        CREATURE,
-        Operator.LESS_THAN_OR_EQUAL,
-        2
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_TOUGHNESS_3_OR_LESS = MagicPTTargetFilter.Toughness(
-        CREATURE,
-        Operator.LESS_THAN_OR_EQUAL,
-        3
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_TOUGHNESS_3_OR_GREATER = MagicPTTargetFilter.Toughness(
-        CREATURE,
-        Operator.GREATER_THAN_OR_EQUAL,
-        3
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_TOUGHNESS_4_OR_GREATER = MagicPTTargetFilter.Toughness(
-        CREATURE,
-        Operator.GREATER_THAN_OR_EQUAL,
-        4
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_POWER_1_OR_LESS = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.LESS_THAN_OR_EQUAL,
-        1
-    );
-
     public static final MagicPermanentFilterImpl CREATURE_POWER_OR_TOUGHNESS_1_OR_LESS = new MagicPermanentFilterImpl() {
         @Override
         public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
@@ -2354,55 +2301,10 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl CREATURE_POWER_2_OR_LESS = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.LESS_THAN_OR_EQUAL,
-        2
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_POWER_3_OR_LESS = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.LESS_THAN_OR_EQUAL,
-        3
-    );
-
     public static final MagicPermanentFilterImpl CREATURE_POWER_4_OR_MORE = new MagicPTTargetFilter(
         CREATURE,
         Operator.GREATER_THAN_OR_EQUAL,
         4
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_POWER_4_OR_LESS = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.LESS_THAN_OR_EQUAL,
-        4
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_POWER_2_OR_MORE = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.GREATER_THAN_OR_EQUAL,
-        2
-    );
-
-    public static final MagicPermanentFilterImpl WHITE_CREATURE_POWER_2_OR_MORE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.hasColor(MagicColor.White) &&
-                target.isCreature() &&
-                target.getPower() >= 2;
-        }
-    };
-
-    public static final MagicPermanentFilterImpl CREATURE_POWER_3_OR_MORE = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.GREATER_THAN_OR_EQUAL,
-        3
-    );
-
-    public static final MagicPermanentFilterImpl CREATURE_POWER_5_OR_MORE = new MagicPTTargetFilter(
-        CREATURE,
-        Operator.GREATER_THAN_OR_EQUAL,
-        5
     );
 
     /**

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -3071,14 +3071,17 @@ public class MagicTargetFilterFactory {
 
         // using source
         add("you", YOU);
-        add("SN", SN);
-        add("it", SN);
         add("this permanent", SN);
         add("this creature", SN);
-        add("creature blocking it", CREATURE_BLOCKING_SN);
-        add("creature blocking SN", CREATURE_BLOCKING_SN);
-        add("creature blocked by SN", CREATURE_BLOCKED_BY_SN);
-        add("creature blocking or blocked by SN", CREATURE_BLOCKING_BLOCKED_BY_SN);
+
+        // "It" and "SN" are synonyms for certain sentences
+        final String itSynonym[] = {"it", "SN"};
+        for (String it : itSynonym) {
+            add(it, SN);
+            add("creature blocking " + it, CREATURE_BLOCKING_SN);
+            add("creature blocked by " + it, CREATURE_BLOCKED_BY_SN);
+            add("creature blocking or blocked by " + it, CREATURE_BLOCKING_BLOCKED_BY_SN);
+        }
     }
 
     private static final String[] ENDING_WITH_S = new String[]{

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -384,15 +384,15 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl BLACK_PERMANENT = permanent(MagicColor.Black, Control.Any);
+    public static final MagicPermanentFilterImpl BLACK_PERMANENT = permanent(MagicColor.Black);
 
-    public static final MagicPermanentFilterImpl WHITE_PERMANENT = permanent(MagicColor.White, Control.Any);
+    public static final MagicPermanentFilterImpl WHITE_PERMANENT = permanent(MagicColor.White);
 
-    public static final MagicPermanentFilterImpl RED_PERMANENT = permanent(MagicColor.Red, Control.Any);
+    public static final MagicPermanentFilterImpl RED_PERMANENT = permanent(MagicColor.Red);
 
-    public static final MagicPermanentFilterImpl GREEN_PERMANENT = permanent(MagicColor.Green, Control.Any);
+    public static final MagicPermanentFilterImpl GREEN_PERMANENT = permanent(MagicColor.Green);
 
-    public static final MagicPermanentFilterImpl BLUE_PERMANENT = permanent(MagicColor.Blue, Control.Any);
+    public static final MagicPermanentFilterImpl BLUE_PERMANENT = permanent(MagicColor.Blue);
 
     public static final MagicPermanentFilterImpl BLUE_PERMANENT_YOU_CONTROL = permanent(MagicColor.Blue, Control.You);
 
@@ -503,12 +503,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONLAND_NONTOKEN_PERMANENT = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return !target.isLand() && !target.isToken();
-        }
-    };
+    public static final MagicPermanentFilterImpl NONLAND_NONTOKEN_PERMANENT = NONLAND_PERMANENT.nonToken();
 
     public static final MagicPermanentFilterImpl NONTOKEN_PERMANENT = new MagicPermanentFilterImpl() {
         @Override
@@ -517,12 +512,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONTOKEN_ARTIFACT = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return !target.isToken() && target.hasType(MagicType.Artifact);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONTOKEN_ARTIFACT = permanent(MagicType.Artifact, Control.Any).nonToken();
 
     public static final MagicPermanentFilterImpl TOKEN_YOU_CONTROL = new MagicPermanentFilterImpl() {
         @Override
@@ -545,19 +535,11 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONTOKEN_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return !target.isToken() && target.isCreature();
-        }
-    };
+    public static final MagicPermanentFilterImpl CREATURE = permanent(MagicType.Creature, Control.Any);
 
-    public static final MagicPermanentFilterImpl NONTOKEN_WHITE_PERMANENT = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return !target.isToken() && target.hasColor(MagicColor.White);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONTOKEN_CREATURE = CREATURE.nonToken();
+
+    public static final MagicPermanentFilterImpl NONTOKEN_WHITE_PERMANENT = permanent(MagicColor.White).nonToken();
 
     public static final MagicPermanentFilterImpl NONTOKEN_ELF = new MagicPermanentFilterImpl() {
         @Override
@@ -566,12 +548,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONTOKEN_RED_PERMANENT = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return !target.isToken() && target.hasColor(MagicColor.Red);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONTOKEN_RED_PERMANENT = permanent(MagicColor.Red).nonToken();
 
     public static final MagicPermanentFilterImpl NONLAND_PERMANENT_YOUR_OPPONENT_CONTROLS = new MagicPermanentFilterImpl() {
         @Override
@@ -1192,8 +1169,6 @@ public class MagicTargetFilterFactory {
 
     public static final MagicPermanentFilterImpl LEVELUP_CREATURE = creature(MagicAbility.LevelUp, Control.Any);
 
-    public static final MagicPermanentFilterImpl CREATURE = permanent(MagicType.Creature, Control.Any);
-
     public static final MagicPermanentFilterImpl WORLD = permanent(MagicType.World, Control.Any);
 
     public static final MagicPermanentFilterImpl CREATURE_YOU_CONTROL = permanent(MagicType.Creature, Control.You);
@@ -1429,13 +1404,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl CREATURE_CONVERTED_3_OR_LESS = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                target.getConvertedCost() <= 3;
-        }
-    };
+    public static final MagicPermanentFilterImpl CREATURE_CONVERTED_3_OR_LESS = permanent(MagicType.Creature, Control.Any).cmcLEQ(3);
 
     public static final MagicCardFilterImpl CREATURE_CARD_CMC_LEQ_3_FROM_GRAVEYARD = card(MagicType.Creature).cmcLEQ(3).from(MagicTargetType.Graveyard);
 
@@ -1727,29 +1696,11 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicCardFilterImpl ARTIFACT_CARD_CMC_LEQ_1_FROM_GRAVEYARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.getConvertedCost() <= 1 && target.hasType(MagicType.Artifact);
-        }
+    public static final MagicCardFilterImpl ARTIFACT_CARD_CMC_LEQ_1_FROM_GRAVEYARD =
+            card(MagicType.Artifact).cmcLEQ(1).from(MagicTargetType.Graveyard);
 
-        @Override
-        public boolean acceptType(final MagicTargetType targetType) {
-            return targetType == MagicTargetType.Graveyard;
-        }
-    };
-
-    public static final MagicCardFilterImpl CREATURE_CARD_CMC_LEQ_2_FROM_GRAVEYARD = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.getConvertedCost() <= 2 && target.hasType(MagicType.Creature);
-        }
-
-        @Override
-        public boolean acceptType(final MagicTargetType targetType) {
-            return targetType == MagicTargetType.Graveyard;
-        }
-    };
+    public static final MagicCardFilterImpl CREATURE_CARD_CMC_LEQ_2_FROM_GRAVEYARD =
+            card(MagicType.Creature).cmcLEQ(2).from(MagicTargetType.Graveyard);
 
     public static final MagicCardFilterImpl CREATURE_CARD_POWER_LEQ_2_FROM_GRAVEYARD = new MagicCardFilterImpl() {
         @Override
@@ -2570,9 +2521,14 @@ public class MagicTargetFilterFactory {
 
         // <color|type|subtype> card from your graveyard
         add("card from your graveyard", CARD_FROM_GRAVEYARD);
-        add("artifact card with converted mana cost 1 or less from your graveyard", ARTIFACT_CARD_CMC_LEQ_1_FROM_GRAVEYARD);
-        add("noncreature artifact card with converted mana cost 1 or less from your graveyard", NONCREATURE_ARTIFACT_CARD_WITH_CMC_LEQ_1_FROM_GRAVEYARD);
-        add("Rebel permanent card with converted mana cost 5 or less from your graveyard", permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Graveyard, 5));
+        add("artifact card with converted mana cost # or less from your graveyard",
+                (MagicTargetFilterGenerator<MagicCard>) params ->
+                        card(MagicType.Artifact).cmcLEQ(params[0]).from(MagicTargetType.Graveyard));
+        add("noncreature artifact card with converted mana cost 1 or less from your graveyard",
+                NONCREATURE_ARTIFACT_CARD_WITH_CMC_LEQ_1_FROM_GRAVEYARD);
+        add("Rebel permanent card with converted mana cost # or less from your graveyard",
+                (MagicTargetFilterGenerator<MagicCard>) params ->
+                        permanentCardMaxCMC(MagicSubType.Rebel, MagicTargetType.Graveyard, params[0]));
 
         // <color|type|subtype> permanent card from your graveyard
         add("permanent card from your graveyard", PERMANENT_CARD_FROM_GRAVEYARD);
@@ -2686,8 +2642,8 @@ public class MagicTargetFilterFactory {
         add("nonattacking creature", NONATTACKING_CREATURE);
         add("blocked creature", BLOCKED_CREATURE);
         add("blocking creature", BLOCKING_CREATURE);
-        add("creature with converted mana cost 3 or less", CREATURE_CONVERTED_3_OR_LESS);
-        add("creature with converted mana cost 2 or less", CREATURE_CONVERTED_2_OR_LESS);
+        add("creature with converted mana cost # or less", (MagicTargetFilterGenerator<MagicPermanent>) params ->
+                permanent(MagicType.Creature, Control.Any).cmcLEQ(params[0]));
         add("creature with flying", CREATURE_WITH_FLYING);
         add("creature with flying or reach", CREATURE_WITH_FLYING_OR_REACH);
         add("creature without flying", CREATURE_WITHOUT_FLYING);
@@ -2823,8 +2779,9 @@ public class MagicTargetFilterFactory {
         add("artifact or land", ARTIFACT_OR_LAND);
         add("artifact land", ARTIFACT_LAND);
         add("artifact or enchantment", ARTIFACT_OR_ENCHANTMENT);
-        add("artifact or enchantment with converted mana cost 3 or less", ARTIFACT_OR_ENCHANTMENT_CMC_3_OR_LESS);
-        add("artifact or enchantment with converted mana cost 4 or less", ARTIFACT_OR_ENCHANTMENT_CMC_4_OR_LESS);
+        add("artifact or enchantment with converted mana cost # or less",
+                (MagicTargetFilterGenerator<MagicPermanent>) params ->
+                        new MagicCMCPermanentFilter(ARTIFACT_OR_ENCHANTMENT, Operator.LESS_THAN_OR_EQUAL, params[0]));
         add("artifact, enchantment, or land", ARTIFACT_OR_ENCHANTMENT_OR_LAND);
         add("artifact, creature, or land", ARTIFACT_OR_CREATURE_OR_LAND);
         add("artifact, creature, or enchantment", ARTIFACT_OR_CREATURE_OR_ENCHANTMENT);
@@ -3438,6 +3395,15 @@ public class MagicTargetFilterFactory {
             public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
                 return (target.hasColor(color1) || target.hasColor(color2)) &&
                     control.matches(player,target);
+            }
+        };
+    }
+
+    public static final MagicPermanentFilterImpl permanent(final MagicColor color) {
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
+                return target.hasColor(color);
             }
         };
     }

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -914,12 +914,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl HUMAN_OR_ANGEL = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.hasSubType(MagicSubType.Human) || target.hasSubType(MagicSubType.Angel);
-        }
-    };
+    public static final MagicPermanentFilterImpl HUMAN_OR_ANGEL = creatureOr(MagicSubType.Human, MagicSubType.Angel, Control.Any);
 
     public static final MagicPermanentFilterImpl SKELETON_VAMPIRE_OR_ZOMBIE = new MagicPermanentFilterImpl() {
         @Override
@@ -939,13 +934,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl VAMPIRE_OR_ZOMBIE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.hasSubType(MagicSubType.Vampire) ||
-                   target.hasSubType(MagicSubType.Zombie);
-        }
-    };
+    public static final MagicPermanentFilterImpl VAMPIRE_OR_ZOMBIE = creatureOr(MagicSubType.Vampire, MagicSubType.Zombie, Control.Any);
 
     public static final MagicPermanentFilterImpl NONVAMPIRE_NONWEREWOLF_NONZOMBIE_CREATURE = new MagicPermanentFilterImpl() {
         @Override
@@ -967,23 +956,11 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONZOMBIE_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasSubType(MagicSubType.Zombie);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONZOMBIE_CREATURE = creatureNon(MagicSubType.Zombie, Control.Any);
 
     public static final MagicPermanentFilterImpl HUMAN = permanent(MagicSubType.Human, Control.Any);
 
-    public static final MagicPermanentFilterImpl NONENCHANTMENT_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasType(MagicType.Enchantment);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONENCHANTMENT_CREATURE = creatureNon(MagicType.Enchantment, Control.Any);
 
     public static final MagicPermanentFilterImpl NONENCHANTMENT_PERMANENT = new MagicPermanentFilterImpl() {
         @Override
@@ -1198,13 +1175,7 @@ public class MagicTargetFilterFactory {
 
     public static final MagicPermanentFilterImpl NONWHITE_CREATURE = creatureNon(MagicColor.White, Control.Any);
 
-    public static final MagicPermanentFilterImpl NONWHITE_NONBLACK_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.White) && !target.hasColor(MagicColor.Black);
-        }
-    };
+    public static final MagicPermanentFilterImpl NONWHITE_NONBLACK_CREATURE = creatureNeither(MagicColor.White, MagicColor.Black, Control.Any);
 
     public static final MagicPermanentFilterImpl NONWHITE_PERMANENT = permanentNot(MagicColor.White, Control.Any);
 
@@ -1214,14 +1185,7 @@ public class MagicTargetFilterFactory {
 
     public static final MagicPermanentFilterImpl NONGREEN_CREATURE = creatureNon(MagicColor.Green, Control.Any);
 
-    public static final MagicPermanentFilterImpl NONBLACK_ATTACKING_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasColor(MagicColor.Black) &&
-                target.isAttacking();
-        }
-    };
+    public static final MagicPermanentFilterImpl NONBLACK_ATTACKING_CREATURE = NONBLACK_CREATURE.andAttacking();
 
     public static final MagicPermanentFilterImpl NONRED_CREATURE = creatureNon(MagicColor.Red, Control.Any);
 
@@ -1233,14 +1197,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl NONARTIFACT_ATTACKING_CREATURE = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.isArtifact() &&
-                target.isAttacking();
-        }
-    };
+    public static final MagicPermanentFilterImpl NONARTIFACT_ATTACKING_CREATURE = NONARTIFACT_CREATURE.andAttacking();
 
     public static final MagicPermanentFilterImpl NONARTIFACT_NONBLACK_CREATURE = creatureNon(MagicColor.Black, Control.Any).andNotArtifact();
 
@@ -1258,30 +1215,11 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_FLYING = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasAbility(MagicAbility.Flying);
-        }
-    };
+    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_FLYING = creatureWithout(MagicAbility.Flying, Control.Any);
 
-    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_DEFENDER = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasAbility(MagicAbility.Defender);
-        }
-    };
+    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_DEFENDER = creatureWithout(MagicAbility.Defender, Control.Any);
 
-    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_FLYING_YOUR_OPPONENT_CONTROLS = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasAbility(MagicAbility.Flying) &&
-                target.isOpponent(player);
-        }
-    };
+    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_FLYING_YOUR_OPPONENT_CONTROLS = creatureWithout(MagicAbility.Flying, Control.Opp);
 
     public static final MagicPermanentFilterImpl CREATURE_WITH_FLYING = creature(MagicAbility.Flying, Control.Any);
 
@@ -1301,13 +1239,7 @@ public class MagicTargetFilterFactory {
 
     public static final MagicPermanentFilterImpl CREATURE_WITH_SHADOW = creature(MagicAbility.Shadow, Control.Any);
 
-    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_SHADOW = new MagicPermanentFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
-            return target.isCreature() &&
-                !target.hasAbility(MagicAbility.Shadow);
-        }
-    };
+    public static final MagicPermanentFilterImpl CREATURE_WITHOUT_SHADOW = creatureWithout(MagicAbility.Shadow, Control.Any);
 
     public static final MagicPermanentFilterImpl CREATURE_WITH_FLYING_OR_REACH = new MagicPermanentFilterImpl() {
         @Override
@@ -3474,6 +3406,17 @@ public class MagicTargetFilterFactory {
             public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
                 return target.isCreature() &&
                     target.hasAbility(ability) &&
+                    control.matches(player, target);
+            }
+        };
+    }
+
+    public static final MagicPermanentFilterImpl creatureWithout(final MagicAbility ability, final Control control) {
+        return new MagicPermanentFilterImpl() {
+            @Override
+            public boolean accept(final MagicSource source, final MagicPlayer player, final MagicPermanent target) {
+                return target.isCreature() &&
+                    !target.hasAbility(ability) &&
                     control.matches(player, target);
             }
         };

--- a/src/magic/model/target/MagicTargetFilterFactory.java
+++ b/src/magic/model/target/MagicTargetFilterFactory.java
@@ -200,17 +200,17 @@ public class MagicTargetFilterFactory {
 
     public static final MagicStackFilterImpl SPELL_YOU_DONT_CONTROL = SPELL.youNotControl();
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_1 = SPELL.withCmcEq(1);
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_1 = SPELL.cmcEQ(1);
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_2 = SPELL.withCmcEq(2);
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_EQ_2 = SPELL.cmcEQ(2);
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_LEQ_3 = SPELL.withCmcMax(3);
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_LEQ_3 = SPELL.cmcLEQ(3);
 
-    public static final MagicStackFilterImpl SPELL_WITH_CMC_4_OR_GREATER = SPELL.withCmcMin(4);
+    public static final MagicStackFilterImpl SPELL_WITH_CMC_4_OR_GREATER = SPELL.cmcGEQ(4);
 
-    public static final MagicStackFilterImpl INSTANT_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 = spell(MagicType.Instant).youControl().withCmcMax(2);
+    public static final MagicStackFilterImpl INSTANT_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 = spell(MagicType.Instant).youControl().cmcLEQ(2);
 
-    public static final MagicStackFilterImpl SORCERY_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 =spell(MagicType.Sorcery).youControl().withCmcMax(2);
+    public static final MagicStackFilterImpl SORCERY_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2 =spell(MagicType.Sorcery).youControl().cmcLEQ(2);
 
     public static final MagicStackFilterImpl SPELL_WITH_X_COST = new MagicStackFilterImpl() {
         @Override
@@ -287,9 +287,9 @@ public class MagicTargetFilterFactory {
 
     public static final MagicStackFilterImpl NONARTIFACT_SPELL = spellNon(MagicType.Artifact);
 
-    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_6_OR_MORE = spell(MagicType.Creature).withCmcMin(6);
+    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_6_OR_MORE = spell(MagicType.Creature).cmcGEQ(6);
 
-    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_3_OR_LESS = spell(MagicType.Creature).withCmcMax(3);
+    public static final MagicStackFilterImpl CREATURE_SPELL_CMC_3_OR_LESS = spell(MagicType.Creature).cmcLEQ(3);
 
     public static final MagicStackFilterImpl CREATURE_SPELL_WITH_INFECT = new MagicStackFilterImpl() {
         @Override
@@ -1925,17 +1925,7 @@ public class MagicTargetFilterFactory {
         }
     };
 
-    public static final MagicCardFilterImpl INSTANT_LEQ_CMC_2_FROM_HAND = new MagicCardFilterImpl() {
-        @Override
-        public boolean accept(final MagicSource source, final MagicPlayer player, final MagicCard target) {
-            return target.getConvertedCost() <= 2 && target.hasType(MagicType.Instant);
-        }
-
-        @Override
-        public boolean acceptType(final MagicTargetType targetType) {
-            return targetType == MagicTargetType.Hand;
-        }
-    };
+    public static final MagicCardFilterImpl INSTANT_LEQ_CMC_2_FROM_HAND = card(MagicType.Instant).from(MagicTargetType.Hand).cmcLEQ(2);
 
     public static final MagicCardFilterImpl CREATURE_CARD_FROM_HAND = card(MagicType.Creature).from(MagicTargetType.Hand);
 
@@ -2586,12 +2576,12 @@ public class MagicTargetFilterFactory {
 
         // <color|type|subtype> permanent card from your graveyard
         add("permanent card from your graveyard", PERMANENT_CARD_FROM_GRAVEYARD);
-        add("permanent card with converted mana cost 3 or less from your graveyard",
+        add("permanent card with converted mana cost # or less from your graveyard",
                 (MagicTargetFilterGenerator<MagicCard>) params -> permanentCardMaxCMC(MagicTargetType.Graveyard, params[0]));
 
         // <color|type|subtype> creature card from your graveyard
-        add("creature card with converted mana cost 3 or less from your graveyard", CREATURE_CARD_CMC_LEQ_3_FROM_GRAVEYARD);
-        add("creature card with converted mana cost 2 or less from your graveyard", CREATURE_CARD_CMC_LEQ_2_FROM_GRAVEYARD);
+        add("creature card with converted mana cost # or less from your graveyard",
+                (MagicTargetFilterGenerator<MagicCard>) params -> card(MagicType.Creature).cmcLEQ(params[0]).from(MagicTargetType.Graveyard));
         add("creature card with power 2 or less from your graveyard", CREATURE_CARD_POWER_LEQ_2_FROM_GRAVEYARD);
         add("creature card with infect from your graveyard", CREATURE_CARD_WITH_INFECT_FROM_GRAVEYARD);
         add("creature card with scavenge from your graveyard", PAYABLE_CREATURE_CARD_FROM_GRAVEYARD);
@@ -2602,7 +2592,8 @@ public class MagicTargetFilterFactory {
 
         // <color|type|subtype> card from your hand
         add("card from your hand", CARD_FROM_HAND);
-        add("instant card with converted mana cost 2 or less from your hand", INSTANT_LEQ_CMC_2_FROM_HAND);
+        add("instant card with converted mana cost # or less from your hand",
+                (MagicTargetFilterGenerator<MagicCard>) params -> card(MagicType.Instant).from(MagicTargetType.Hand).cmcLEQ(params[0]));
 
         // <color|type|subtype> card from your library
         add("card from your library", CARD_FROM_LIBRARY);
@@ -2867,6 +2858,19 @@ public class MagicTargetFilterFactory {
 
         // <color|type> spell
         add("spell", SPELL);
+        for (MagicColor c1 : MagicColor.values()) {
+            // Single colored, i.e. "nonblue spell"
+            add("non" + c1.name() + " spell", spellNon(c1));
+            // Single colored with type, i.e. "blue creature spell"
+            add(c1.name() + " creature spell", spell(c1, MagicType.Creature));
+            add(c1.name() + " instant spell", spell(c1, MagicType.Instant));
+            for (MagicColor c2 : MagicColor.values()) {
+                if (c1 != c2) {
+                    // Spell having one of two colors, i.e. "blue or black spell"
+                    add(c1.name() + " or " + c2.name() + " spell", spellOr(c1, c2));
+                }
+            }
+        }
         add("spell an opponent controls", SPELL_YOU_DONT_CONTROL);
         add("spell or ability", SPELL_OR_ABILITY);
         add("spell or ability you control", SPELL_OR_ABILITY_YOU_CONTROL);
@@ -2888,39 +2892,37 @@ public class MagicTargetFilterFactory {
         add("noncreature spell", NONCREATURE_SPELL);
         add("nonartifact spell", NONARTIFACT_SPELL);
         add("artifact or enchantment spell", ARTIFACT_OR_ENCHANTMENT_SPELL);
-        add("red or green spell", RED_OR_GREEN_SPELL);
-        add("blue or black spell", BLUE_OR_BLACK_SPELL);
-        add("green or white spell", GREEN_OR_WHITE_SPELL);
         add("blue, black, or red spell", BLUE_OR_BLACK_OR_RED_SPELL);
         add("white, blue, black, or red spell", WHITE_OR_BLUE_OR_BLACK_OR_RED_SPELL);
-        add("nonblue spell", NONBLUE_SPELL);
-        add("nonblack spell", NONBLACK_SPELL);
         add("non-Faerie spell", NONFAERIE_SPELL);
         add("blue spell during your turn", BLUE_SPELL_YOUR_TURN);
         add("blue or black spell during your turn", BLUE_OR_BLACK_SPELL_YOUR_TURN);
-        add("blue instant spell", BLUE_INSTANT_SPELL);
-        add("nonred spell", NONRED_SPELL);
         add("instant or sorcery spell", INSTANT_OR_SORCERY_SPELL);
         add("enchantment, instant, or sorcery spell", ENCHANTMENT_OR_INSTANT_OR_SORCERY_SPELL);
         add("white or blue instant or sorcery spell", WHITE_OR_BLUE_INSTANT_OR_SORCERY_SPELL);
         add("instant or sorcery spell you control", INSTANT_OR_SORCERY_SPELL_YOU_CONTROL);
-        add("spell with converted mana cost 1", SPELL_WITH_CMC_EQ_1);
-        add("spell with converted mana cost 2", SPELL_WITH_CMC_EQ_2);
-        add("spell with converted mana cost 3 or less", SPELL_WITH_CMC_LEQ_3);
-        add("spell with converted mana cost 4 or greater", SPELL_WITH_CMC_4_OR_GREATER);
-        add("instant spell you control with converted mana cost 2 or less", INSTANT_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2);
-        add("sorcery spell you control with converted mana cost 2 or less", SORCERY_SPELL_YOU_CONTROL_WITH_CMC_LEQ_2);
-        add("creature spell with converted mana cost 6 or greater", CREATURE_SPELL_CMC_6_OR_MORE);
+        add("spell with converted mana cost #",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> SPELL.cmcEQ(params[0]));
+        add("spell with converted mana cost # or less",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> SPELL.cmcLEQ(params[0]));
+        add("spell with converted mana cost # or greater",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> SPELL.cmcGEQ(params[0]));
+        add("instant spell you control with converted mana cost # or less",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> spell(MagicType.Instant).youControl().cmcLEQ(params[0]));
+        add("sorcery spell you control with converted mana cost # or less",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> spell(MagicType.Sorcery).youControl().cmcLEQ(params[0]));
+        add("creature spell with converted mana cost # or less",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> spell(MagicType.Creature).cmcLEQ(params[0]));
+        add("creature spell with converted mana cost # or greater",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> spell(MagicType.Creature).cmcGEQ(params[0]));
         add("creature spell with infect", CREATURE_SPELL_WITH_INFECT);
-        add("green creature spell", GREEN_CREATURE_SPELL);
-        add("blue creature spell", BLUE_CREATURE_SPELL);
         add("creature or Aura spell", CREATURE_OR_AURA_SPELL);
         add("creature or sorcery spell", CREATURE_OR_SORCERY_SPELL);
         add("Spirit or Arcane spell", SPIRIT_OR_ARCANE_SPELL);
         add("multicolored spell", MULTICOLORED_SPELL);
         add("colorless spell", COLORLESS_SPELL);
-        add("colorless spell with converted mana cost 7 or greater", COLORLESS_SPELL_CMC_7_OR_MORE);
-        add("creature spell with converted mana cost 3 or less", CREATURE_SPELL_CMC_3_OR_LESS);
+        add("colorless spell with converted mana cost # or greater",
+                (MagicTargetFilterGenerator<MagicItemOnStack>) params -> COLORLESS_SPELL.cmcGEQ(params[0]));
         add("aura, equipment, or vehicle spell", AURA_EQUIPMENT_OR_VEHICLE_SPELL);
 
         // player

--- a/src/magic/model/target/MagicTargetFilterGenerator.java
+++ b/src/magic/model/target/MagicTargetFilterGenerator.java
@@ -1,0 +1,10 @@
+package magic.model.target;
+
+/**
+ * Generator for parametric filters with one or more numeric parameters.
+ * Each '#' in the text is matched with one number from input.
+ * Number of parameters will always be equal to the number of '#' characters in the text.
+ */
+public interface MagicTargetFilterGenerator<T extends MagicTarget> {
+    MagicTargetFilter<T> generate(Integer... parameters);
+}


### PR DESCRIPTION
I noticed Thoughtbind (Counter target spell with converted mana cost 4 or less) that is unsupported
is similar to Liquify (Counter target spell with converted mana cost 3 or less ...) which does not even need groovy and is supported.

So I just enabled the card ... and it does not work:
java.lang.RuntimeException: unknown target filter "spell with converted mana cost 4 or less"

I looked then at the system for parsing card rules ... and I decided to generify the system a bit and polish it a little (add Javadoc, add more supported cases, ..) and then create a merge request.

This should help whenever new cards are released, as more of them would be supported just "out of the box".

Some variants are now generated for all spell/permanent/card colors or color combinations in a loop, also there is a template system with numeric parameters (usually there is just one, but you can have any number, for example template for #/# creature has two of them) that generates (on demand) specific filters for all possible numerical values.

No need to have separate rules for stuff like "mana costs 1 and less", "2 and less", "3 and less"... and other countable things. Just one "mana cost # or less" and thats it ... 

Might also help with cards like "Alter Reality" a bit in the future :)

Aside from the code change, this adds support for Thoughtbind ...

Briefly tested (playing vs AI), seems to work fine. I am now running few hundred AI vs AI matches to test that there are no new crashes or other problems.
