### PR TITLE
Fix abilities that reveal cards from top of library until certain condition

### DIFF
--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -6,23 +6,29 @@
                 source,
                 this,
                 "PN reveals cards from the top of PN's library until PN reveals a creature card. " +
-                "Put that card into PN's hand and the rest on the bottom of PN's library in a random order."
+                "PN puts that card into PN's hand and the rest on the bottom of PN's library in a random order."
             );
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Creature) };
-            final MagicCardList nonTarget = new MagicCardList(library.takeWhile({ !predicate(it) }));
-            if (library.any(predicate)) {
-                final MagicCard target = library.find(predicate);
-                game.doAction(new RevealAction(nonTarget.plus(target)));
-                game.doAction(new ShiftCardAction(target, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
-            } else {
-                game.doAction(new RevealAction(nonTarget));
+            final MagicCardList revealed = new MagicCardList();
+            MagicCard target = MagicCard.NONE;
+            while (target == MagicCard.NONE && library.size() > 0) {
+                final MagicCard topCard = library.getCardAtTop();
+                game.doAction(new RevealAction(topCard));
+                if (predicate(topCard)) {
+                    target = topCard;
+                    game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                } else {
+                    revealed.add(topCard);
+                    game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));
+                }
             }
-            nonTarget.shuffle();
-            nonTarget.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
+
+            revealed.shuffle();
+            revealed.each({ game.doAction(new MoveCardAction(it, MagicLocationType.BottomOfOwnersLibrary)) });
         }
     }
     ,

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -14,13 +14,12 @@
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Creature) };
             final MagicCardList revealed = new MagicCardList();
-            MagicCard target = MagicCard.NONE;
-            while (target == MagicCard.NONE && library.size() > 0) {
+            while (library.size() > 0) {
                 final MagicCard topCard = library.getCardAtTop();
                 game.doAction(new RevealAction(topCard));
                 if (predicate(topCard)) {
-                    target = topCard;
                     game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                    break;
                 } else {
                     revealed.add(topCard);
                     game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -28,7 +28,7 @@
             }
 
             revealed.shuffle();
-            revealed.each({ game.doAction(new MoveCardAction(it, MagicLocationType.BottomOfOwnersLibrary)) });
+            revealed.each({ game.doAction(new MoveCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
         }
     }
     ,

--- a/release/Magarena/scripts/Madcap_Experiment.groovy
+++ b/release/Magarena/scripts/Madcap_Experiment.groovy
@@ -18,13 +18,13 @@
             final MagicCardList revealed = new MagicCardList();
             MagicCard target = MagicCard.NONE;
             int amount = 0;
-            while (target == MagicCard.NONE && library.size() > 0) {
+            while (library.size() > 0) {
                 final MagicCard topCard = library.getCardAtTop();
                 game.doAction(new RevealAction(topCard));
                 amount++;
                 if (predicate(topCard)) {
-                    target = topCard;
                     game.doAction(new ReturnCardAction(MagicLocationType.OwnersLibrary, topCard, player));
+                    break;
                 } else {
                     revealed.add(topCard);
                     game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));

--- a/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
+++ b/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
@@ -14,13 +14,12 @@
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Artifact) };
             final MagicCardList revealed = new MagicCardList();
-            MagicCard target = MagicCard.NONE;
-            while (target == MagicCard.NONE && library.size() > 0) {
+            while (library.size() > 0) {
                 final MagicCard topCard = library.getCardAtTop();
                 game.doAction(new RevealAction(topCard));
                 if (predicate(topCard)) {
-                    target = topCard;
                     game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                    break;
                 } else {
                     revealed.add(topCard);
                     game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));

--- a/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
+++ b/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
@@ -28,7 +28,7 @@
             }
 
             revealed.shuffle();
-            revealed.each({ game.doAction(new MoveCardAction(it, MagicLocationType.BottomOfOwnersLibrary)) });
+            revealed.each({ game.doAction(new MoveCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
         }
     }
 ]

--- a/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
+++ b/release/Magarena/scripts/Tezzeret__Master_of_Metal.groovy
@@ -6,23 +6,29 @@
                 source,
                 this,
                 "PN reveals cards from the top of PN's library until PN reveals an artifact card. " +
-                "Put that card into PN's hand and the rest on the bottom of PN's library in a random order."
+                "PN puts that card into PN's hand and the rest on the bottom of PN's library in a random order."
             );
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCardList library = event.getPlayer().getLibrary();
             def predicate = { final MagicCard card -> card.hasType(MagicType.Artifact) };
-            final MagicCardList nonTarget = new MagicCardList(library.takeWhile({ !predicate(it) }));
-            if (library.any(predicate)) {
-                final MagicCard target = library.find(predicate);
-                game.doAction(new RevealAction(nonTarget.plus(target)));
-                game.doAction(new ShiftCardAction(target, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
-            } else {
-                game.doAction(new RevealAction(nonTarget));
+            final MagicCardList revealed = new MagicCardList();
+            MagicCard target = MagicCard.NONE;
+            while (target == MagicCard.NONE && library.size() > 0) {
+                final MagicCard topCard = library.getCardAtTop();
+                game.doAction(new RevealAction(topCard));
+                if (predicate(topCard)) {
+                    target = topCard;
+                    game.doAction(new ShiftCardAction(topCard, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
+                } else {
+                    revealed.add(topCard);
+                    game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));
+                }
             }
-            nonTarget.shuffle();
-            nonTarget.each({ game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary)) });
+
+            revealed.shuffle();
+            revealed.each({ game.doAction(new MoveCardAction(it, MagicLocationType.BottomOfOwnersLibrary)) });
         }
     }
 ]

--- a/release/Magarena/scripts/Treasure_Keeper.groovy
+++ b/release/Magarena/scripts/Treasure_Keeper.groovy
@@ -1,7 +1,7 @@
 def restoreCardAction = {
     final MagicGame game, final MagicEvent event ->
     final MagicCardList revealed = event.getRefCardList();
-    cards.shuffle();
+    revealed.shuffle();
     revealed.each {
         game.doAction(new MoveCardAction(
             it,

--- a/release/Magarena/scripts/Treasure_Keeper.groovy
+++ b/release/Magarena/scripts/Treasure_Keeper.groovy
@@ -1,19 +1,37 @@
+def restoreCardAction = {
+    final MagicGame game, final MagicEvent event ->
+    final MagicCardList revealed = event.getRefCardList();
+    cards.shuffle();
+    revealed.each {
+        game.doAction(new MoveCardAction(
+            it,
+            MagicLocationType.OwnersLibrary,
+            MagicLocationType.BottomOfOwnersLibrary
+        ));
+    }
+}
+
 def castAction = {
     final MagicGame game, final MagicEvent event ->
     final MagicCardList revealed = new MagicCardList(event.getRefCardList());
     if (event.isYes()) {
-        final MagicCard toCast = revealed.last();
-        revealed.remove(toCast);
+        final MagicCard card = revealed.removeCardAtTop();
         game.doAction(CastCardAction.WithoutManaCost(
             event.getPlayer(),
-            toCast,
+            card,
             MagicLocationType.OwnersLibrary,
             MagicLocationType.Graveyard
         ));
+    } else {
+        game.doAction(new RemoveCardAction(topCard));
     }
-    revealed.each {
-        game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary))
-    }
+    game.addEvent(new MagicEvent(
+        event.getSource(),
+        event.getPlayer(),
+        revealed,
+        restoreCardAction,
+        "PN puts all revealed cards not cast this way on the bottom of PN's library in a random order."
+    ));
 }
 
 [
@@ -31,23 +49,35 @@ def castAction = {
             final MagicPlayer player = event.getPlayer();
             final MagicCardList library = player.getLibrary();
             def predicate = { final MagicCard card -> !card.hasType(MagicType.Land) && card.getConvertedCost() <= 3 }
-            final MagicCardList nonTarget = new MagicCardList(library.takeWhile({ !predicate(it) }));
-            if (library.any(predicate)) {
-                final MagicCard target = library.find(predicate);
-                game.doAction(new RevealAction(nonTarget.plus(target)));
+            final MagicCardList revealed = new MagicCardList();
+            MagicCard target = MagicCard.NONE;
+            while (target == MagicCard.NONE && library.size() > 0) {
+                final MagicCard topCard = library.getCardAtTop()
+                game.doAction(new RevealAction(topCard));
+                revealed.add(topCard);
+                if (predicate(topCard)) {
+                    target = topCard;
+                } else {
+                    game.doAction(new RemoveCardAction(topCard));
+                }
+            }
+
+            if (target != MagicCard.NONE) {
                 game.addEvent(new MagicEvent(
                     event.getSource(),
                     new MagicMayChoice("Cast the card?"),
-                    new MagicCardList(nonTarget.plus(target)),
+                    revealed,
                     castAction,
-                    "PN may\$ cast that card without paying its mana cost. " +
-                    "Put all revealed cards not cast this way on the bottom of PN's library in any order."
+                    "PN may\$ cast that card without paying its mana cost."
                 ));
-            } else {
-                game.doAction(new RevealAction(nonTarget));
-                nonTarget.each {
-                    game.doAction(new ShiftCardAction(it, MagicLocationType.OwnersLibrary, MagicLocationType.BottomOfOwnersLibrary))
-                }
+            }
+            else {
+                game.addEvent(new MagicEvent(
+                    event.getSource(),
+                    revealed,
+                    restoreCardAction,
+                    "PN puts all revealed cards not cast this way on the bottom of PN's library in a random order."
+                ));
             }
         }
     }

--- a/release/Magarena/scripts/Treasure_Keeper.groovy
+++ b/release/Magarena/scripts/Treasure_Keeper.groovy
@@ -23,7 +23,7 @@ def castAction = {
             MagicLocationType.Graveyard
         ));
     } else {
-        game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));
+        game.doAction(new RemoveCardAction(revealed.getCardAtTop(), MagicLocationType.OwnersLibrary));
     }
     game.addEvent(new MagicEvent(
         event.getSource(),

--- a/release/Magarena/scripts/Treasure_Keeper.groovy
+++ b/release/Magarena/scripts/Treasure_Keeper.groovy
@@ -23,7 +23,7 @@ def castAction = {
             MagicLocationType.Graveyard
         ));
     } else {
-        game.doAction(new RemoveCardAction(topCard));
+        game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));
     }
     game.addEvent(new MagicEvent(
         event.getSource(),
@@ -58,7 +58,7 @@ def castAction = {
                 if (predicate(topCard)) {
                     target = topCard;
                 } else {
-                    game.doAction(new RemoveCardAction(topCard));
+                    game.doAction(new RemoveCardAction(topCard, MagicLocationType.OwnersLibrary));
                 }
             }
 


### PR DESCRIPTION
- Tezzeret, Master of Metal
- Ajani, Valiant Protector
- Madcap Experiment
- Treasure Keeper

I had some problem with "cards not cast this way" in Treasure Keeper, since it included the CMC 3 or less nonland card that isn't cast because the player chose not to cast it. Then I remembered Cascade exists.

Fixes #1527 