### PR TITLE
Add player argument to ChangeCountersAction

### DIFF
--- a/release/Magarena/scripts/Aboroth.groovy
+++ b/release/Magarena/scripts/Aboroth.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1
@@ -19,6 +20,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     event.getPermanent(),
                     MagicCounterType.MinusOne,
                     event.getPermanent().getCounters(MagicCounterType.Age)

--- a/release/Magarena/scripts/Academy_Elite.groovy
+++ b/release/Magarena/scripts/Academy_Elite.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             final int amount = INSTANT_OR_SORCERY_CARD_FROM_ALL_GRAVEYARDS.filter(permanent.getController()).size();
-            game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,amount));
+            game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,amount));
             game.logAppendMessage(permanent.getController(), permanent.getName()+" enters the battlefield with "+amount+" +1/+1 counters on it.");
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Aether_Figment.groovy
+++ b/release/Magarena/scripts/Aether_Figment.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,2));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Aether_Snap.groovy
+++ b/release/Magarena/scripts/Aether_Snap.groovy
@@ -14,7 +14,7 @@
             PERMANENT.filter(event) each {
                 if (it.hasCounters()) {
                     for (MagicCounterType type : MagicCounterType.values()) {
-                        game.doAction(new ChangeCountersAction(it, type, -it.getCounters(type)));
+                        game.doAction(new ChangeCountersAction(event.getPlayer(), it, type, -it.getCounters(type)));
                     }
                 }
                 if (it.isToken()) {

--- a/release/Magarena/scripts/Aetherstorm_Roc.groovy
+++ b/release/Magarena/scripts/Aetherstorm_Roc.groovy
@@ -1,8 +1,8 @@
 def action = {
     final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
-        game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, -2));
-        game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, 1));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Energy, -2));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, 1));
         final MagicPermanent target = event.getRefPermanent();
         if (target.isValid()) {
             game.doAction(new TapAction(target));

--- a/release/Magarena/scripts/Afiya_Grove.groovy
+++ b/release/Magarena/scripts/Afiya_Grove.groovy
@@ -14,8 +14,8 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 if (event.getPermanent().hasCounters(MagicCounterType.PlusOne)) {
-                    game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,-1));
-                    game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,-1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,1));
                 }
             });
         }

--- a/release/Magarena/scripts/Ageless_Entity.groovy
+++ b/release/Magarena/scripts/Ageless_Entity.groovy
@@ -16,7 +16,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
+++ b/release/Magarena/scripts/Ajani__Valiant_Protector.groovy
@@ -46,7 +46,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 final int amount = event.getPlayer().getLife();
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusOne, amount));
                 game.doAction(new GainAbilityAction(it, MagicAbility.Trample, MagicStatic.UntilEOT));
             });
         }

--- a/release/Magarena/scripts/Angelheart_Vial.groovy
+++ b/release/Magarena/scripts/Angelheart_Vial.groovy
@@ -14,6 +14,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.Charge,
                 event.getRefInt()

--- a/release/Magarena/scripts/Apocalypse_Hydra.groovy
+++ b/release/Magarena/scripts/Apocalypse_Hydra.groovy
@@ -5,7 +5,7 @@
             final int count = payedCost.getX() >= 5 ?
                 2 * payedCost.getX() :
                 payedCost.getX();
-            game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,count));
+            game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,count));
             return MagicEvent.NONE;
         }
     }

--- a/release/Magarena/scripts/Arcbound_Fiend.groovy
+++ b/release/Magarena/scripts/Arcbound_Fiend.groovy
@@ -14,8 +14,8 @@
             if (event.isYes()) {
                 event.processTargetPermanent(game, {
                     if (it.hasCounters(MagicCounterType.PlusOne)) {
-                        game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,1));
-                        game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,-1));
+                        game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,1));
+                        game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,-1));
                     }
                 });
             }

--- a/release/Magarena/scripts/Ardent_Soldier.groovy
+++ b/release/Magarena/scripts/Ardent_Soldier.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,1));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Ashnod_s_Transmogrant.groovy
+++ b/release/Magarena/scripts/Ashnod_s_Transmogrant.groovy
@@ -33,7 +33,7 @@ def choice = Positive("target nonartifact creature");
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 game.doAction(new AddStaticAction(it,type));
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,1));
             });
         }
     }

--- a/release/Magarena/scripts/Aven_Mimeomancer.groovy
+++ b/release/Magarena/scripts/Aven_Mimeomancer.groovy
@@ -39,7 +39,7 @@ def AB = new MagicStatic(MagicLayer.Ability) {
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
                 event.processTargetPermanent(game, {
-                    game.doAction(new ChangeCountersAction(it,MagicCounterType.Feather,1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.Feather,1));
                     game.doAction(new AddStaticAction(it, PT));
                     game.doAction(new AddStaticAction(it, AB));
                 });

--- a/release/Magarena/scripts/Bane_of_Progress.groovy
+++ b/release/Magarena/scripts/Bane_of_Progress.groovy
@@ -14,6 +14,7 @@
             final DestroyAction destroy = new DestroyAction(ARTIFACT_OR_ENCHANTMENT.filter(event));
             game.doAction(destroy);
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.PlusOne,
                 destroy.getNumDestroyed()

--- a/release/Magarena/scripts/Benalish_Lancer.groovy
+++ b/release/Magarena/scripts/Benalish_Lancer.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,2));
                 game.doAction(new GainAbilityAction(permanent,MagicAbility.FirstStrike,MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Blade_of_the_Bloodchief.groovy
+++ b/release/Magarena/scripts/Blade_of_the_Bloodchief.groovy
@@ -16,7 +16,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent equippedCreature = event.getPermanent().getEquippedCreature();
             final int amount = equippedCreature.hasSubType(MagicSubType.Vampire) ? 2 : 1;
-            game.doAction(new ChangeCountersAction(equippedCreature,MagicCounterType.PlusOne,amount));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),equippedCreature,MagicCounterType.PlusOne,amount));
         }
     }
 ]

--- a/release/Magarena/scripts/Blood_Hound.groovy
+++ b/release/Magarena/scripts/Blood_Hound.groovy
@@ -17,6 +17,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     event.getPermanent(),
                     MagicCounterType.PlusOne,
                     event.getRefInt()

--- a/release/Magarena/scripts/Blowfly_Infestation.groovy
+++ b/release/Magarena/scripts/Blowfly_Infestation.groovy
@@ -15,7 +15,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.MinusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.MinusOne,1));
             });
         }
     }

--- a/release/Magarena/scripts/Bounty_Hunter.groovy
+++ b/release/Magarena/scripts/Bounty_Hunter.groovy
@@ -34,7 +34,7 @@ def TARGET_CREATURE_WITH_BOUNTY_COUNTER = new MagicTargetChoice(
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                 game.doAction(new ChangeCountersAction(it,MagicCounterType.Tower,1));
+                 game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.Tower,1));
             });
         }
     },

--- a/release/Magarena/scripts/Brace_for_Impact.groovy
+++ b/release/Magarena/scripts/Brace_for_Impact.groovy
@@ -14,6 +14,7 @@ def preventAddPlus = new IfDamageWouldBeDealtTrigger(MagicTrigger.REPLACE_DAMAGE
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         game.doAction(new ChangeCountersAction(
+            event.getPlayer(),
             event.getPermanent(),
             MagicCounterType.PlusOne,
             event.getRefInt()

--- a/release/Magarena/scripts/Bramblewood_Paragon.groovy
+++ b/release/Magarena/scripts/Bramblewood_Paragon.groovy
@@ -6,7 +6,7 @@
                 otherPermanent.isCreature() &&
                 otherPermanent.isFriend(permanent) &&
                 otherPermanent.hasSubType(MagicSubType.Warrior)) {
-                game.doAction(new ChangeCountersAction(otherPermanent,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(permanent.getController(),otherPermanent,MagicCounterType.PlusOne,1));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Caress_of_Phyrexia.groovy
+++ b/release/Magarena/scripts/Caress_of_Phyrexia.groovy
@@ -14,7 +14,7 @@
             event.processTargetPlayer(game, {
                 game.doAction(new DrawAction(it, 3));
                 game.doAction(new ChangeLifeAction(it, -3));
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.Poison, 3));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.Poison, 3));
             });
         }
     }

--- a/release/Magarena/scripts/Cephalid_Vandal.groovy
+++ b/release/Magarena/scripts/Cephalid_Vandal.groovy
@@ -12,6 +12,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.Shred,
                 1

--- a/release/Magarena/scripts/Confiscation_Coup.groovy
+++ b/release/Magarena/scripts/Confiscation_Coup.groovy
@@ -2,7 +2,7 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     if (event.isYes()) {
         final MagicPermanent target = event.getRefPermanent();
-        game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, -target.getConvertedCost()));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Energy, -target.getConvertedCost()));
         game.doAction(new GainControlAction(event.getPlayer(), target));
     }
 }
@@ -22,7 +22,7 @@ def action = {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, 4));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Energy, 4));
                 if (event.getPlayer().getEnergy() >= it.getConvertedCost()) {
                     game.addEvent(new MagicEvent(
                         event.getSource(),

--- a/release/Magarena/scripts/Corrosion.groovy
+++ b/release/Magarena/scripts/Corrosion.groovy
@@ -15,7 +15,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPlayer(game, {
                 ARTIFACT_YOU_CONTROL.filter(it) each {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.Rust, 1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.Rust, 1));
                 }
                 ARTIFACT_YOU_CONTROL.filter(it) each {
                     if (it.getConvertedCost() <= it.getCounters(MagicCounterType.Rust)) {

--- a/release/Magarena/scripts/Cradle_of_Vitality.groovy
+++ b/release/Magarena/scripts/Cradle_of_Vitality.groovy
@@ -21,7 +21,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
                 event.processTargetPermanent(game, {
-                    game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,event.getRefInt()));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,event.getRefInt()));
                 });
             }
         }

--- a/release/Magarena/scripts/Crovax_the_Cursed.groovy
+++ b/release/Magarena/scripts/Crovax_the_Cursed.groovy
@@ -15,9 +15,9 @@
             final MagicEvent sacrifice = new MagicSacrificePermanentEvent(event.getSource(), SACRIFICE_CREATURE);
             if (event.isYes() && sacrifice.isSatisfied()) {
                 game.addEvent(sacrifice);
-                game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, 1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, 1));
             } else {
-                game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, -1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, -1));
             }
         }
     }

--- a/release/Magarena/scripts/Cytoplast_Root_Kin.groovy
+++ b/release/Magarena/scripts/Cytoplast_Root_Kin.groovy
@@ -25,8 +25,8 @@ def choice = MagicTargetChoice.Positive("another target creature you control wit
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 if (it.hasCounters(MagicCounterType.PlusOne)) {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, -1));
-                    game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, 1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusOne, -1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, 1));
                 }
             });
         }

--- a/release/Magarena/scripts/Death_s_Presence.groovy
+++ b/release/Magarena/scripts/Death_s_Presence.groovy
@@ -17,7 +17,7 @@ def choice = Positive("target creature you control");
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,event.getRefInt()));
             });
         }
     }

--- a/release/Magarena/scripts/Decimator_Web.groovy
+++ b/release/Magarena/scripts/Decimator_Web.groovy
@@ -25,7 +25,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPlayer(game, {
                 game.doAction(new ChangeLifeAction(it, -2));
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.Poison, 1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.Poison, 1));
                 game.doAction(new MillLibraryAction(it, 6));
             });
         }

--- a/release/Magarena/scripts/Decree_of_Silence.groovy
+++ b/release/Magarena/scripts/Decree_of_Silence.groovy
@@ -15,7 +15,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new CounterItemOnStackAction(event.getRefCardOnStack()));
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Depletion,1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Depletion,1));
             if (event.getPermanent().getCounters(MagicCounterType.Depletion) >= 3) {
                 game.doAction(new SacrificeAction(event.getPermanent()));
             }

--- a/release/Magarena/scripts/Defy_Death.groovy
+++ b/release/Magarena/scripts/Defy_Death.groovy
@@ -19,7 +19,7 @@
                     final MagicPermanent perm ->
                     final MagicGame G = perm.getGame();
                     if (perm.hasSubType(MagicSubType.Angel)) {
-                        G.doAction(new ChangeCountersAction(perm,MagicCounterType.PlusOne,2));
+                        G.doAction(new ChangeCountersAction(event.getPlayer(),perm,MagicCounterType.PlusOne,2));
                     }
                 }));
             });

--- a/release/Magarena/scripts/Descendant_of_Masumaro.groovy
+++ b/release/Magarena/scripts/Descendant_of_Masumaro.groovy
@@ -14,11 +14,13 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPlayer(game, {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     event.getPermanent(),
                     MagicCounterType.PlusOne,
                     event.getPlayer().getHandSize()
                 ));
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     event.getPermanent(),
                     MagicCounterType.PlusOne,
                     -it.getHandSize()

--- a/release/Magarena/scripts/Desecration_Demon.groovy
+++ b/release/Magarena/scripts/Desecration_Demon.groovy
@@ -17,7 +17,7 @@
             if (event.isYes() && sac.isSatisfied()) {
                 game.addEvent(sac);
                 game.doAction(new TapAction(perm));
-                game.doAction(new ChangeCountersAction(perm,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),perm,MagicCounterType.PlusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Domesticated_Hydra.groovy
+++ b/release/Magarena/scripts/Domesticated_Hydra.groovy
@@ -25,7 +25,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent SN = event.getPermanent();
             if (MagicCondition.NOT_MONSTROUS_CONDITION.accept(SN)) {
-                game.doAction(new ChangeCountersAction(SN, MagicCounterType.PlusOne, event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), SN, MagicCounterType.PlusOne, event.getRefInt()));
                 game.doAction(ChangeStateAction.Set(SN, MagicPermanentState.Monstrous));
             }
         }

--- a/release/Magarena/scripts/Draining_Whelk.groovy
+++ b/release/Magarena/scripts/Draining_Whelk.groovy
@@ -14,7 +14,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetCardOnStack(game, {
                 game.doAction(new CounterItemOnStackAction(it));
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,it.getConvertedCost()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(),MagicCounterType.PlusOne,it.getConvertedCost()));
             });
         }
     }

--- a/release/Magarena/scripts/Duskwalker.groovy
+++ b/release/Magarena/scripts/Duskwalker.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,2));
                 game.doAction(new GainAbilityAction(permanent,MagicAbility.Fear,MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Dwarven_Armory.groovy
+++ b/release/Magarena/scripts/Dwarven_Armory.groovy
@@ -25,7 +25,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusTwo, 1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusTwo, 1));
             });
         }
     }

--- a/release/Magarena/scripts/Ebon_Praetor.groovy
+++ b/release/Magarena/scripts/Ebon_Praetor.groovy
@@ -26,12 +26,14 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.MinusTwo,
                 -1
             ));
             if (event.getRefPermanent().hasSubType(MagicSubType.Thrull)) {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     event.getPermanent(),
                     MagicCounterType.PlusOnePlusZero,
                     1

--- a/release/Magarena/scripts/Elder_Cathar.groovy
+++ b/release/Magarena/scripts/Elder_Cathar.groovy
@@ -16,7 +16,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 final int amount = it.hasSubType(MagicSubType.Human) ? 2 : 1;
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,amount));
             });
         }
     }

--- a/release/Magarena/scripts/Empyreal_Voyager.groovy
+++ b/release/Magarena/scripts/Empyreal_Voyager.groovy
@@ -11,7 +11,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Energy, event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Essence_Flare.groovy
+++ b/release/Magarena/scripts/Essence_Flare.groovy
@@ -17,7 +17,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processRefPermanent(game, {
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.MinusZeroMinusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.MinusZeroMinusOne,1));
             });
         }
     }

--- a/release/Magarena/scripts/Faerie_Squadron.groovy
+++ b/release/Magarena/scripts/Faerie_Squadron.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,2));
                 game.doAction(new GainAbilityAction(permanent,MagicAbility.Flying,MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Falkenrath_Aristocrat.groovy
+++ b/release/Magarena/scripts/Falkenrath_Aristocrat.groovy
@@ -32,7 +32,7 @@
                 event.getPermanent(),
                 MagicAbility.Indestructible
             ));
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Falkenrath_Torturer.groovy
+++ b/release/Magarena/scripts/Falkenrath_Torturer.groovy
@@ -32,7 +32,7 @@
                 event.getPermanent(),
                 MagicAbility.Flying
             ));
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Feat_of_Resistance.groovy
+++ b/release/Magarena/scripts/Feat_of_Resistance.groovy
@@ -1,6 +1,6 @@
 def action = {
     final MagicGame game, final MagicEvent event ->
-    game.doAction(new ChangeCountersAction(event.getRefPermanent(),MagicCounterType.PlusOne,1));
+    game.doAction(new ChangeCountersAction(event.getPlayer(),event.getRefPermanent(),MagicCounterType.PlusOne,1));
     game.doAction(new GainAbilityAction(
         event.getRefPermanent(),
         event.getChosenColor().getProtectionAbility()

--- a/release/Magarena/scripts/Force_Bubble.groovy
+++ b/release/Magarena/scripts/Force_Bubble.groovy
@@ -4,7 +4,7 @@
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicDamage damage) {
             if (permanent.isController(damage.getTarget())) {
                 final int amount = damage.replace();
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.Depletion,amount));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.Depletion,amount));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Forge_Armor.groovy
+++ b/release/Magarena/scripts/Forge_Armor.groovy
@@ -17,7 +17,7 @@
             event.processTargetPermanent(game, {
                 final int amount=event.getRefPermanent().getConvertedCost();
                 game.logAppendValue(event.getPlayer(),amount);
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusOne, amount));
             });
         }
     }

--- a/release/Magarena/scripts/Gallowbraid.groovy
+++ b/release/Magarena/scripts/Gallowbraid.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Gideon__Champion_of_Justice.groovy
+++ b/release/Magarena/scripts/Gideon__Champion_of_Justice.groovy
@@ -43,7 +43,7 @@ def PreventAllDamage = new PreventDamageTrigger() {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final int amt = event.getPlayer().getOpponent().getNrOfPermanents(MagicType.Creature);
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Loyalty,amt));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Loyalty,amt));
         }
     },
     new MagicPlaneswalkerActivation(0) {

--- a/release/Magarena/scripts/Gilder_Bairn.groovy
+++ b/release/Magarena/scripts/Gilder_Bairn.groovy
@@ -27,7 +27,7 @@ def TARGET_PERMANENT_WITH_COUNTERS = new MagicTargetChoice(
                 source,
                 TARGET_PERMANENT_WITH_COUNTERS,
                 this,
-                "Double the number of each kind of counter on target permanent\$."
+                "Doubles the number of each kind of counter on target permanent\$."
             );
         }
         @Override
@@ -36,6 +36,7 @@ def TARGET_PERMANENT_WITH_COUNTERS = new MagicTargetChoice(
                 for (final MagicCounterType counterType : MagicCounterType.values()) {
                     if (it.hasCounters(counterType)) {
                         game.doAction(new ChangeCountersAction(
+                            event.getPlayer(),
                             it,
                             counterType,
                             it.getCounters(counterType)

--- a/release/Magarena/scripts/Glacial_Chasm.groovy
+++ b/release/Magarena/scripts/Glacial_Chasm.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Gonti_s_Machinations.groovy
+++ b/release/Magarena/scripts/Gonti_s_Machinations.groovy
@@ -13,7 +13,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, 1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Energy, 1));
         }
     }
     ,

--- a/release/Magarena/scripts/Grave_Strength.groovy
+++ b/release/Magarena/scripts/Grave_Strength.groovy
@@ -15,7 +15,7 @@
             event.processTargetPermanent(game, {
                 game.doAction(new MillLibraryAction(event.getPlayer(),3));
                 final int amount = CREATURE_CARD_FROM_GRAVEYARD.filter(event).size();
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,amount))
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,amount))
             });
         }
     }

--- a/release/Magarena/scripts/Hamletback_Goliath.groovy
+++ b/release/Magarena/scripts/Hamletback_Goliath.groovy
@@ -16,7 +16,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
             }
         }
     }

--- a/release/Magarena/scripts/Hellkite_Hatchling.groovy
+++ b/release/Magarena/scripts/Hellkite_Hatchling.groovy
@@ -24,7 +24,7 @@
                 final MagicPermanent permanent=event.getPermanent();
                 event.processTargetPermanent(game, {
                     game.doAction(new SacrificeAction(it));
-                    game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne, 1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),permanent,MagicCounterType.PlusOne, 1));
                     game.doAction(new GainAbilityAction(permanent, MagicAbility.Flying, MagicStatic.Forever));
                     game.doAction(new GainAbilityAction(permanent, MagicAbility.Trample, MagicStatic.Forever));
                     final MagicEvent newEvent=executeTrigger(game, permanent, MagicPayedCost.NO_COST);

--- a/release/Magarena/scripts/Heroes__Bane.groovy
+++ b/release/Magarena/scripts/Heroes__Bane.groovy
@@ -22,7 +22,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent creature = event.getPermanent();
             final int amount = creature.getPower();
-            game.doAction(new ChangeCountersAction(creature,MagicCounterType.PlusOne,amount));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),creature,MagicCounterType.PlusOne,amount));
             game.logAppendX(event.getPlayer(),amount);
         }
     }

--- a/release/Magarena/scripts/Hooded_Hydra.groovy
+++ b/release/Magarena/scripts/Hooded_Hydra.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPermanent otherPermanent) {
             final MagicPlayer player = permanent.getController();
-            game.doAction(new ChangeCountersAction(permanent, MagicCounterType.PlusOne, 5));
+            game.doAction(new ChangeCountersAction(permanent.getController(), permanent, MagicCounterType.PlusOne, 5));
             game.logAppendMessage(player,"${player.getName()} puts 5 +1/+1 counters on ${permanent.getName()}")
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Huatli__Radiant_Champion.groovy
+++ b/release/Magarena/scripts/Huatli__Radiant_Champion.groovy
@@ -11,7 +11,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final int amount = event.getPlayer().getNrOfPermanents(MagicType.Creature);
-            game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.Loyalty, amount));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.Loyalty, amount));
         }
     }
 ]

--- a/release/Magarena/scripts/Hunger_of_the_Howlpack.groovy
+++ b/release/Magarena/scripts/Hunger_of_the_Howlpack.groovy
@@ -15,7 +15,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 final int amount = game.getCreatureDiedThisTurn() ? 3 : 1;
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,amount));
             });
         }
     }

--- a/release/Magarena/scripts/Hydra_Broodmaster.groovy
+++ b/release/Magarena/scripts/Hydra_Broodmaster.groovy
@@ -50,7 +50,7 @@ def PutHydra = new MagicTrigger<Integer>() {
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent SN = event.getPermanent();
             if (MagicCondition.NOT_MONSTROUS_CONDITION.accept(SN)) {
-                game.doAction(new ChangeCountersAction(SN, MagicCounterType.PlusOne, event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), SN, MagicCounterType.PlusOne, event.getRefInt()));
                 game.doAction(ChangeStateAction.Set(SN, MagicPermanentState.Monstrous));
                 game.executeTrigger(PutHydra, SN, SN, event.getRefInt());
             }

--- a/release/Magarena/scripts/Immaculate_Magistrate.groovy
+++ b/release/Magarena/scripts/Immaculate_Magistrate.groovy
@@ -24,7 +24,7 @@ def choice = Positive("target creature");
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 final int amount = event.getPlayer().getNrOfPermanents(MagicSubType.Elf);
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,amount));
             });
         }
     }

--- a/release/Magarena/scripts/Imminent_Doom.groovy
+++ b/release/Magarena/scripts/Imminent_Doom.groovy
@@ -18,7 +18,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTarget(game, {
                 game.doAction(new DealDamageAction(event.getSource(), it, event.getRefInt()));
-                game.doAction(new ChangeCountersAction(event.getSource(), MagicCounterType.Doom, 1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getSource(), MagicCounterType.Doom, 1));
             });
         }
     }

--- a/release/Magarena/scripts/Jinxed_Choker.groovy
+++ b/release/Magarena/scripts/Jinxed_Choker.groovy
@@ -13,7 +13,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPlayer(game, {
                 game.doAction(new GainControlAction(it,event.getPermanent()));
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Charge,1));
+                game.doAction(new ChangeCountersAction(it,event.getPermanent(),MagicCounterType.Charge,1));
             });
         }
     },
@@ -61,7 +61,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.Charge, event.isMode(1) ? 1 : -1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.Charge, event.isMode(1) ? 1 : -1));
         }
     }
 ]

--- a/release/Magarena/scripts/Kalonian_Hydra.groovy
+++ b/release/Magarena/scripts/Kalonian_Hydra.groovy
@@ -12,6 +12,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             CREATURE_YOU_CONTROL.filter(event) each {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     it,
                     MagicCounterType.PlusOne,
                     it.getCounters(MagicCounterType.PlusOne)

--- a/release/Magarena/scripts/Kavu_Predator.groovy
+++ b/release/Magarena/scripts/Kavu_Predator.groovy
@@ -13,7 +13,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Kavu_Titan.groovy
+++ b/release/Magarena/scripts/Kavu_Titan.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,3));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,3));
                 game.doAction(new GainAbilityAction(permanent,MagicAbility.Trample,MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Kresh_the_Bloodbraided.groovy
+++ b/release/Magarena/scripts/Kresh_the_Bloodbraided.groovy
@@ -16,7 +16,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
             }
         }
     }

--- a/release/Magarena/scripts/Lichenthrope.groovy
+++ b/release/Magarena/scripts/Lichenthrope.groovy
@@ -4,7 +4,7 @@
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicDamage damage) {
             if (damage.getTarget() == permanent) {
                 final int amount = damage.replace();
-                game.doAction(new ChangeCountersAction(permanent, MagicCounterType.MinusOne, amount));
+                game.doAction(new ChangeCountersAction(permanent.getController(), permanent, MagicCounterType.MinusOne, amount));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Lifecraft_Awakening.groovy
+++ b/release/Magarena/scripts/Lifecraft_Awakening.groovy
@@ -38,7 +38,7 @@ def ST = new MagicStatic(MagicLayer.Type) {
             event.processTargetPermanent(game, {
                 final int amount=event.getRefInt();
                 game.logAppendValue(event.getPlayer(),amount);
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusOne, amount));
                 if (!it.hasType(MagicType.Creature) && !it.hasSubType(MagicSubType.Vehicle)) {
                     game.doAction(new BecomesCreatureAction(it, PT, ST));
                 }

--- a/release/Magarena/scripts/Liliana_s_Influence.groovy
+++ b/release/Magarena/scripts/Liliana_s_Influence.groovy
@@ -40,7 +40,7 @@ def searchAction = {
             for (final MagicPlayer player : game.getPlayers().minus(event.getPlayer())) {
             for (final MagicPermanent permanent : player.getPermanents()) {
                 if (permanent.hasType(MagicType.Creature)) {
-                    game.doAction(new ChangeCountersAction(permanent, MagicCounterType.MinusOne, 1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), permanent, MagicCounterType.MinusOne, 1));
                 }
             }}
 

--- a/release/Magarena/scripts/Living_Armor.groovy
+++ b/release/Magarena/scripts/Living_Armor.groovy
@@ -25,6 +25,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     it,
                     MagicCounterType.PlusZeroPlusOne,
                     it.getConvertedCost()

--- a/release/Magarena/scripts/Llanowar_Elite.groovy
+++ b/release/Magarena/scripts/Llanowar_Elite.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,5));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,5));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Ludevic_s_Test_Subject.groovy
+++ b/release/Magarena/scripts/Ludevic_s_Test_Subject.groovy
@@ -24,10 +24,10 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent permanent = event.getPermanent();
-            game.doAction(new ChangeCountersAction(permanent,MagicCounterType.Hatchling,1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),permanent,MagicCounterType.Hatchling,1));
             final int counters = permanent.getCounters(MagicCounterType.Hatchling);
             if (counters >= 5) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.Hatchling,-counters));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),permanent,MagicCounterType.Hatchling,-counters));
                 game.doAction(new TransformAction(permanent));
             }
         }

--- a/release/Magarena/scripts/Luminarch_Ascension.groovy
+++ b/release/Magarena/scripts/Luminarch_Ascension.groovy
@@ -14,7 +14,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()){
-                game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.Quest,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.Quest,1));
             }
         }
     }

--- a/release/Magarena/scripts/Maelstrom_Djinn.groovy
+++ b/release/Magarena/scripts/Maelstrom_Djinn.groovy
@@ -11,7 +11,7 @@
 
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Time,2));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Time,2));
             game.doAction(new AddTriggerAction(event.getPermanent(), FadeVanishCounterTrigger.Time));
         }
     }

--- a/release/Magarena/scripts/Marrow_Chomper.groovy
+++ b/release/Magarena/scripts/Marrow_Chomper.groovy
@@ -24,7 +24,7 @@
                 final MagicPermanent permanent=event.getPermanent();
                 event.processTargetPermanent(game, {
                     game.doAction(new SacrificeAction(it));
-                    game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,2));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),permanent,MagicCounterType.PlusOne,2));
                     game.doAction(new ChangeLifeAction(event.getPlayer(),2));
                     final MagicEvent newEvent=executeTrigger(game,permanent,MagicPayedCost.NO_COST);
                     if (newEvent.isValid()) {

--- a/release/Magarena/scripts/Master_Biomancer.groovy
+++ b/release/Magarena/scripts/Master_Biomancer.groovy
@@ -13,7 +13,7 @@ def MUTANT = new MagicStatic(MagicLayer.Type) {
                 otherPermanent.isFriend(permanent)) {
 
                 final int amount = permanent.getPower();
-                game.doAction(new ChangeCountersAction(otherPermanent,MagicCounterType.PlusOne,amount));
+                game.doAction(new ChangeCountersAction(permanent.getController(),otherPermanent,MagicCounterType.PlusOne,amount));
                 game.doAction(new AddStaticAction(otherPermanent,MUTANT));
                 game.logAppendMessage(
                     permanent.getController(),

--- a/release/Magarena/scripts/Maulfist_Revolutionary.groovy
+++ b/release/Magarena/scripts/Maulfist_Revolutionary.groovy
@@ -44,7 +44,7 @@ def TARGET_PERMANENT_OR_PLAYER = new MagicTargetChoice(
                 TARGET_PERMANENT_OR_PLAYER,
                 this,
                 "For each kind of counter on target permanent or player\$, " +
-                "give that permanent or player another counter of that kind."
+                "PN gives that permanent or player another counter of that kind."
             );
         }
         @Override
@@ -52,7 +52,7 @@ def TARGET_PERMANENT_OR_PLAYER = new MagicTargetChoice(
             event.processTarget(game, {
                 for (final MagicCounterType counterType : MagicCounterType.values()) {
                     if (it.hasCounters(counterType)) {
-                        game.doAction(new ChangeCountersAction(it, counterType, 1));
+                        game.doAction(new ChangeCountersAction(event.getPlayer(), it, counterType, 1));
                     }
                 }
             });

--- a/release/Magarena/scripts/Maulfist_Revolutionary.groovy
+++ b/release/Magarena/scripts/Maulfist_Revolutionary.groovy
@@ -29,7 +29,7 @@ def TARGET_PERMANENT_OR_PLAYER = new MagicTargetChoice(
             event.processTarget(game, {
                 for (final MagicCounterType counterType : MagicCounterType.values()) {
                     if (it.hasCounters(counterType)) {
-                        game.doAction(new ChangeCountersAction(it, counterType, 1));
+                        game.doAction(new ChangeCountersAction(event.getPlayer(), it, counterType, 1));
                     }
                 }
             });

--- a/release/Magarena/scripts/Midnight_Oil.groovy
+++ b/release/Magarena/scripts/Midnight_Oil.groovy
@@ -15,7 +15,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new DrawAction(event.getPlayer(), 1));
-            game.doAction(new ChangeCountersAction(event.getSource(), MagicCounterType.Hour, -2));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getSource(), MagicCounterType.Hour, -2));
         }
     }
     ,

--- a/release/Magarena/scripts/Miraculous_Recovery.groovy
+++ b/release/Magarena/scripts/Miraculous_Recovery.groovy
@@ -17,7 +17,7 @@
                 game.doAction(new ReturnCardAction(MagicLocationType.Graveyard,it,event.getPlayer(),{
                     final MagicPermanent perm ->
                     final MagicGame G = perm.getGame();
-                    G.doAction(new ChangeCountersAction(perm,MagicCounterType.PlusOne,1));
+                    G.doAction(new ChangeCountersAction(event.getPlayer(),perm,MagicCounterType.PlusOne,1));
                 }));
             });
         }

--- a/release/Magarena/scripts/Misfortune.groovy
+++ b/release/Magarena/scripts/Misfortune.groovy
@@ -19,12 +19,12 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isMode(1)) {
                 CREATURE_YOU_CONTROL.filter(event.getRefPlayer()) each {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, 1));
+                    game.doAction(new ChangeCountersAction(event.getRefPlayer(), it, MagicCounterType.PlusOne, 1));
                 }
                 game.doAction(new ChangeLifeAction(event.getRefPlayer(), 4));
             } else if (event.isMode(2)) {
                 CREATURE_YOU_CONTROL.filter(event.getPlayer()) each {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.MinusOne, 1));
+                    game.doAction(new ChangeCountersAction(event.getRefPlayer(), it, MagicCounterType.MinusOne, 1));
                 }
                 game.doAction(new DealDamageAction(event.getSource(), event.getPlayer(), 4));
             }

--- a/release/Magarena/scripts/Necropolis.groovy
+++ b/release/Magarena/scripts/Necropolis.groovy
@@ -22,7 +22,7 @@ def A_CREATURE_CARD_FROM_GRAVEYARD = new MagicTargetChoice("a creature card from
             final MagicCard exiled = event.getRefCard();
             final int amount = exiled.getConvertedCost();
             game.logAppendX(event.getPlayer(), amount);
-            game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusZeroPlusOne, amount));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusZeroPlusOne, amount));
         }
     }
 ]

--- a/release/Magarena/scripts/Necropolis_Regent.groovy
+++ b/release/Magarena/scripts/Necropolis_Regent.groovy
@@ -15,7 +15,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Nemesis_of_Mortals.groovy
+++ b/release/Magarena/scripts/Nemesis_of_Mortals.groovy
@@ -26,7 +26,7 @@
 
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,5));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,5));
             game.doAction(ChangeStateAction.Set(
                 event.getPermanent(),
                 MagicPermanentState.Monstrous

--- a/release/Magarena/scripts/Oblivion_Stone.groovy
+++ b/release/Magarena/scripts/Oblivion_Stone.groovy
@@ -33,6 +33,7 @@ def NONLAND_PERMANENT_WITHOUT_FATE_COUNTER = new MagicPermanentFilterImpl() {
             game.doAction(new DestroyAction(NONLAND_PERMANENT_WITHOUT_FATE_COUNTER.filter(event)));
             PERMANENT.filter(event) each {
                 game.doAction(new ChangeCountersAction(
+                    event.getPlayer(),
                     it,
                     MagicCounterType.Fate,
                     -it.getCounters(MagicCounterType.Fate)

--- a/release/Magarena/scripts/Oran_Rief_Hydra.groovy
+++ b/release/Magarena/scripts/Oran_Rief_Hydra.groovy
@@ -16,6 +16,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/release/Magarena/scripts/Patron_of_the_Vein.groovy
+++ b/release/Magarena/scripts/Patron_of_the_Vein.groovy
@@ -23,7 +23,7 @@ def filter = MagicTargetFilterFactory.Permanent("Vampire you control")
                 MagicLocationType.Exile
             ));
             filter.filter(event) each {
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, 1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusOne, 1));
             }
         }
     }

--- a/release/Magarena/scripts/Phantasmal_Sphere.groovy
+++ b/release/Magarena/scripts/Phantasmal_Sphere.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.PlusOne,
                 1

--- a/release/Magarena/scripts/Phantom_Nomad.groovy
+++ b/release/Magarena/scripts/Phantom_Nomad.groovy
@@ -7,7 +7,7 @@
                 // Prevention effect.
                 damage.prevent();
 
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,-1));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,-1));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Phyrexian_Hydra.groovy
+++ b/release/Magarena/scripts/Phyrexian_Hydra.groovy
@@ -15,6 +15,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.MinusOne,
                 event.getRefInt()

--- a/release/Magarena/scripts/Phyrexian_Soulgorger.groovy
+++ b/release/Magarena/scripts/Phyrexian_Soulgorger.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Phytohydra.groovy
+++ b/release/Magarena/scripts/Phytohydra.groovy
@@ -4,7 +4,7 @@
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicDamage damage) {
             if (damage.getTarget() == permanent) {
                 final int amount = damage.replace();
-                game.doAction(new ChangeCountersAction(permanent, MagicCounterType.PlusOne, amount));
+                game.doAction(new ChangeCountersAction(permanent.getController(), permanent, MagicCounterType.PlusOne, amount));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Polar_Kraken.groovy
+++ b/release/Magarena/scripts/Polar_Kraken.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Pouncing_Kavu.groovy
+++ b/release/Magarena/scripts/Pouncing_Kavu.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,2));
                 game.doAction(new GainAbilityAction(permanent,MagicAbility.Haste,MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Pouncing_Wurm.groovy
+++ b/release/Magarena/scripts/Pouncing_Wurm.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,3));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,3));
                 game.doAction(new GainAbilityAction(permanent,MagicAbility.Haste,MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Prime_Speaker_Zegana.groovy
+++ b/release/Magarena/scripts/Prime_Speaker_Zegana.groovy
@@ -6,7 +6,7 @@
             CREATURE_YOU_CONTROL.except(permanent).filter(permanent) each {
                 amount = Math.max(amount,it.getPower());
             }
-            game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,amount));
+            game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,amount));
             game.logAppendMessage(permanent.getController(),permanent.getName()+" enters the battlefield with ("+amount+") +1/+1 counters on it.");
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Primordial_Hydra.groovy
+++ b/release/Magarena/scripts/Primordial_Hydra.groovy
@@ -12,6 +12,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/release/Magarena/scripts/Primordial_Ooze.groovy
+++ b/release/Magarena/scripts/Primordial_Ooze.groovy
@@ -2,7 +2,7 @@
     new AtYourUpkeepTrigger() {
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
-            game.doAction(new ChangeCountersAction(permanent, MagicCounterType.PlusOne, 1));
+            game.doAction(new ChangeCountersAction(permanent.getController(), permanent, MagicCounterType.PlusOne, 1));
             final int amount = permanent.getCounters(MagicCounterType.PlusOne);
             return new MagicEvent(
                 permanent,

--- a/release/Magarena/scripts/Prison_Barricade.groovy
+++ b/release/Magarena/scripts/Prison_Barricade.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent, MagicCounterType.PlusOne, 1));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent, MagicCounterType.PlusOne, 1));
                 game.doAction(new GainAbilityAction(permanent, MagicAbility.CanAttackWithDefender, MagicStatic.Forever));
             }
             return MagicEvent.NONE;

--- a/release/Magarena/scripts/Psychic_Vortex.groovy
+++ b/release/Magarena/scripts/Psychic_Vortex.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Quest_for_Ancient_Secrets.groovy
+++ b/release/Magarena/scripts/Quest_for_Ancient_Secrets.groovy
@@ -15,7 +15,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()){
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Quest,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Quest,1));
             }
         }
     },

--- a/release/Magarena/scripts/Rakish_Heir.groovy
+++ b/release/Magarena/scripts/Rakish_Heir.groovy
@@ -18,7 +18,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getRefPermanent(),MagicCounterType.PlusOne,1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getRefPermanent(),MagicCounterType.PlusOne,1));
         }
     }
 ]

--- a/release/Magarena/scripts/Ravaging_Riftwurm.groovy
+++ b/release/Magarena/scripts/Ravaging_Riftwurm.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.Time,3));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.Time,3));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Reaper_of_Sheoldred.groovy
+++ b/release/Magarena/scripts/Reaper_of_Sheoldred.groovy
@@ -13,7 +13,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Poison, 1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Poison, 1));
         }
     }
 ]

--- a/release/Magarena/scripts/Retaliator_Griffin.groovy
+++ b/release/Magarena/scripts/Retaliator_Griffin.groovy
@@ -17,6 +17,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/release/Magarena/scripts/Reverent_Hunter.groovy
+++ b/release/Magarena/scripts/Reverent_Hunter.groovy
@@ -12,6 +12,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent permanent = event.getPermanent();
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 permanent,
                 MagicCounterType.PlusOne,
                 permanent.getController().getDevotion(MagicColor.Green)

--- a/release/Magarena/scripts/Ring_of_Evos_Isle.groovy
+++ b/release/Magarena/scripts/Ring_of_Evos_Isle.groovy
@@ -17,7 +17,7 @@
             final MagicPermanent permanent=event.getPermanent();
             final MagicPermanent equipped=permanent.getEquippedCreature();
             if (equipped.isValid() && equipped.hasColor(MagicColor.Blue)) {
-                game.doAction(new ChangeCountersAction(equipped,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),equipped,MagicCounterType.PlusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Ring_of_Kalonia.groovy
+++ b/release/Magarena/scripts/Ring_of_Kalonia.groovy
@@ -17,7 +17,7 @@
             final MagicPermanent permanent=event.getPermanent();
             final MagicPermanent equipped=permanent.getEquippedCreature();
             if (equipped.isValid() && equipped.hasColor(MagicColor.Green)) {
-                game.doAction(new ChangeCountersAction(equipped,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),equipped,MagicCounterType.PlusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Ring_of_Thune.groovy
+++ b/release/Magarena/scripts/Ring_of_Thune.groovy
@@ -17,7 +17,7 @@
             final MagicPermanent permanent=event.getPermanent();
             final MagicPermanent equipped=permanent.getEquippedCreature();
             if (equipped.isValid() && equipped.hasColor(MagicColor.White)) {
-                game.doAction(new ChangeCountersAction(equipped,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),equipped,MagicCounterType.PlusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Ring_of_Valkas.groovy
+++ b/release/Magarena/scripts/Ring_of_Valkas.groovy
@@ -17,7 +17,7 @@
             final MagicPermanent permanent=event.getPermanent();
             final MagicPermanent equipped=permanent.getEquippedCreature();
             if (equipped.isValid() && equipped.hasColor(MagicColor.Red)) {
-                game.doAction(new ChangeCountersAction(equipped,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),equipped,MagicCounterType.PlusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Ring_of_Xathrid.groovy
+++ b/release/Magarena/scripts/Ring_of_Xathrid.groovy
@@ -17,7 +17,7 @@
             final MagicPermanent permanent=event.getPermanent();
             final MagicPermanent equipped=permanent.getEquippedCreature();
             if (equipped.isValid() && equipped.hasColor(MagicColor.Black)) {
-                game.doAction(new ChangeCountersAction(equipped,MagicCounterType.PlusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),equipped,MagicCounterType.PlusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Rogue_Skycaptain.groovy
+++ b/release/Magarena/scripts/Rogue_Skycaptain.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Wage,
                 1
@@ -23,7 +24,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent permanent = event.getPermanent();
             if (event.isNo()) {
-                game.doAction(new ChangeCountersAction(permanent, MagicCounterType.Wage, -permanent.getCounters(MagicCounterType.Wage)));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), permanent, MagicCounterType.Wage, -permanent.getCounters(MagicCounterType.Wage)));
                 game.doAction(new GainControlAction(event.getPlayer().getOpponent(), permanent));
             }
         }

--- a/release/Magarena/scripts/Rowdy_Crew.groovy
+++ b/release/Magarena/scripts/Rowdy_Crew.groovy
@@ -23,7 +23,7 @@
                 final MagicType type -> toDiscard.every({ it.hasType(type) })
             })) {
 
-                game.doAction(new ChangeCountersAction(event.getSource(), MagicCounterType.PlusOne, 2));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getSource(), MagicCounterType.PlusOne, 2));
             }
         }
     }

--- a/release/Magarena/scripts/Rubblebelt_Raiders.groovy
+++ b/release/Magarena/scripts/Rubblebelt_Raiders.groovy
@@ -16,7 +16,7 @@
             final int attackers = player.getNrOfPermanents(
                 ATTACKING_CREATURE_YOU_CONTROL
             );
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,attackers));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,attackers));
             game.logAppendValue(player,attackers);
         }
     }

--- a/release/Magarena/scripts/Salt_Road_Ambushers.groovy
+++ b/release/Magarena/scripts/Salt_Road_Ambushers.groovy
@@ -13,7 +13,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-                game.doAction(new ChangeCountersAction(event.getRefPermanent(),MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getRefPermanent(),MagicCounterType.PlusOne,2));
         }
     }
 ]

--- a/release/Magarena/scripts/Scavenging_Ooze.groovy
+++ b/release/Magarena/scripts/Scavenging_Ooze.groovy
@@ -29,7 +29,7 @@
                     MagicLocationType.Exile
                 ));
                 if (it.hasType(MagicType.Creature)) {
-                    game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,1));
                     game.doAction(new ChangeLifeAction(event.getPlayer(),1));
                 }
             });

--- a/release/Magarena/scripts/Scourge_of_Skola_Vale.groovy
+++ b/release/Magarena/scripts/Scourge_of_Skola_Vale.groovy
@@ -26,7 +26,7 @@
             final MagicPlayer player = event.getPlayer();
             final int amount=event.getRefPermanent().getToughness();
             game.logAppendValue(player,amount);
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,amount));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,amount));
         }
     }
 ]

--- a/release/Magarena/scripts/Sekki__Seasons__Guide.groovy
+++ b/release/Magarena/scripts/Sekki__Seasons__Guide.groovy
@@ -15,13 +15,14 @@
                 permanent,
                 amount,
                 this,
+                "PN removes RN +1/+1 counters from SN. " +
                 "PN creates RN 1/1 colorless Spirit creature tokens."
             );
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final int amount = event.getRefInt();
-            game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, -amount));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, -amount));
             game.doAction(new PlayTokensAction(event.getPlayer(), CardDefinitions.getToken("1/1 colorless Spirit creature token"), amount));
         }
     }

--- a/release/Magarena/scripts/Servant_of_the_Scale.groovy
+++ b/release/Magarena/scripts/Servant_of_the_Scale.groovy
@@ -13,7 +13,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.PlusOne, event.getRefInt()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.PlusOne, event.getRefInt()));
             });
         }
     }

--- a/release/Magarena/scripts/Shaman_of_the_Great_Hunt.groovy
+++ b/release/Magarena/scripts/Shaman_of_the_Great_Hunt.groovy
@@ -15,7 +15,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getRefPermanent(),MagicCounterType.PlusOne,1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getRefPermanent(),MagicCounterType.PlusOne,1));
         }
     }
 ]

--- a/release/Magarena/scripts/Sigil_Captain.groovy
+++ b/release/Magarena/scripts/Sigil_Captain.groovy
@@ -19,7 +19,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent creature = event.getRefPermanent();
             if (creature.getPower() == 1 && creature.getToughness() == 1) {
-                game.doAction(new ChangeCountersAction(creature,MagicCounterType.PlusOne,2));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),creature,MagicCounterType.PlusOne,2));
             }
         }
     }

--- a/release/Magarena/scripts/Simic_Fluxmage.groovy
+++ b/release/Magarena/scripts/Simic_Fluxmage.groovy
@@ -25,8 +25,8 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 if (event.getPermanent().hasCounters(MagicCounterType.PlusOne)) {
-                    game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,-1));
-                    game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,-1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,1));
                 }
             });
         }

--- a/release/Magarena/scripts/Skullmulcher.groovy
+++ b/release/Magarena/scripts/Skullmulcher.groovy
@@ -36,7 +36,7 @@ def drawCards = {
             if (event.isYes()) {
                 event.processTargetPermanent(game, {
                     game.doAction(new SacrificeAction(it));
-                    game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,1));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),permanent,MagicCounterType.PlusOne,1));
                     final MagicEvent newEvent=executeTrigger(game,permanent,MagicPayedCost.NO_COST);
                     if (newEvent.isValid()) {
                         game.addEvent(newEvent);

--- a/release/Magarena/scripts/Skyship_Plunderer.groovy
+++ b/release/Magarena/scripts/Skyship_Plunderer.groovy
@@ -29,7 +29,7 @@ def TARGET_PERMANENT_OR_PLAYER = new MagicTargetChoice(
             event.processTarget(game, {
                 for (final MagicCounterType counterType : MagicCounterType.values()) {
                     if (it.hasCounters(counterType)) {
-                        game.doAction(new ChangeCountersAction(it, counterType, 1));
+                        game.doAction(new ChangeCountersAction(event.getPlayer(), it, counterType, 1));
                     }
                 }
             });

--- a/release/Magarena/scripts/Soul_Scar_Mage.groovy
+++ b/release/Magarena/scripts/Soul_Scar_Mage.groovy
@@ -7,7 +7,7 @@
                 damage.getTargetPermanent().isController(permanent.getOpponent())) {
 
                 final int amount = damage.replace();
-                game.doAction(new ChangeCountersAction(damage.getTargetPermanent(), MagicCounterType.MinusOne, amount));
+                game.doAction(new ChangeCountersAction(permanent.getController(), damage.getTargetPermanent(), MagicCounterType.MinusOne, amount));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Soul_s_Might.groovy
+++ b/release/Magarena/scripts/Soul_s_Might.groovy
@@ -13,7 +13,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,it.getPower()));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,it.getPower()));
             });
         }
     }

--- a/release/Magarena/scripts/Soulcatchers__Aerie.groovy
+++ b/release/Magarena/scripts/Soulcatchers__Aerie.groovy
@@ -14,6 +14,7 @@
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             game.doAction(new ChangeCountersAction(
+                event.getPlayer(),
                 event.getPermanent(),
                 MagicCounterType.Feather,
                 1

--- a/release/Magarena/scripts/Soulstinger.groovy
+++ b/release/Magarena/scripts/Soulstinger.groovy
@@ -15,7 +15,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes()) {
                 event.processTargetPermanent(game, {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.MinusOne, event.getRefInt()));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.MinusOne, event.getRefInt()));
                 });
             }
         }

--- a/release/Magarena/scripts/Storm_Entity.groovy
+++ b/release/Magarena/scripts/Storm_Entity.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             final int amount = game.getSpellsCast();
-            game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,amount));
+            game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,amount));
             return MagicEvent.NONE;
         }
     }

--- a/release/Magarena/scripts/Sun_Droplet.groovy
+++ b/release/Magarena/scripts/Sun_Droplet.groovy
@@ -13,7 +13,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Charge,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Charge,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Sunbond.groovy
+++ b/release/Magarena/scripts/Sunbond.groovy
@@ -15,7 +15,7 @@ def trigger = new LifeIsGainedTrigger() {
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 [

--- a/release/Magarena/scripts/Szadek__Lord_of_Secrets.groovy
+++ b/release/Magarena/scripts/Szadek__Lord_of_Secrets.groovy
@@ -2,6 +2,7 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     final MagicTuple tup = event.getRefTuple();
     game.doAction(new ChangeCountersAction(
+        event.getPlayer(),
         event.getPermanent(),
         MagicCounterType.PlusOne,
         tup.getInt(0)

--- a/release/Magarena/scripts/Thought_Lash.groovy
+++ b/release/Magarena/scripts/Thought_Lash.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Torment_of_Venom.groovy
+++ b/release/Magarena/scripts/Torment_of_Venom.groovy
@@ -39,7 +39,7 @@ def action = {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
-                game.doAction(new ChangeCountersAction(it, MagicCounterType.MinusOne, 3));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.MinusOne, 3));
                 game.addEvent(new MagicEvent(
                     event.getSource(),
                     it.getController(),

--- a/release/Magarena/scripts/Tornado.groovy
+++ b/release/Magarena/scripts/Tornado.groovy
@@ -26,7 +26,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 game.doAction(new DestroyAction(it));
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Velocity,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Velocity,1));
             });
         }
     }

--- a/release/Magarena/scripts/Treasure_Map.groovy
+++ b/release/Magarena/scripts/Treasure_Map.groovy
@@ -26,10 +26,10 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent source = event.getPermanent();
             game.addEvent(new MagicScryEvent(event));
-            game.doAction(new ChangeCountersAction(source, MagicCounterType.Landmark, 1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), source, MagicCounterType.Landmark, 1));
             final int amount = source.getCounters(MagicCounterType.Landmark);
             if (amount >= 3) {
-                game.doAction(new ChangeCountersAction(source, MagicCounterType.Landmark, -amount));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), source, MagicCounterType.Landmark, -amount));
                 game.doAction(new TransformAction(source));
                 3.times {
                     game.doAction(new PlayTokenAction(

--- a/release/Magarena/scripts/Unbreathing_Horde.groovy
+++ b/release/Magarena/scripts/Unbreathing_Horde.groovy
@@ -4,7 +4,7 @@
         public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicDamage damage) {
             if (damage.getTarget() == permanent) {
                 damage.prevent();
-                game.doAction(new ChangeCountersAction(permanent, MagicCounterType.PlusOne,-1));
+                game.doAction(new ChangeCountersAction(permanent.getController(), permanent, MagicCounterType.PlusOne,-1));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Undergrowth_Champion.groovy
+++ b/release/Magarena/scripts/Undergrowth_Champion.groovy
@@ -4,7 +4,7 @@
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicDamage damage) {
             if (damage.getTarget() == permanent && permanent.hasCounters(MagicCounterType.PlusOne)) {
                 damage.prevent();
-                game.doAction(new ChangeCountersAction(permanent, MagicCounterType.PlusOne,-1));
+                game.doAction(new ChangeCountersAction(permanent.getController(), permanent, MagicCounterType.PlusOne,-1));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Unstable_Mutation.groovy
+++ b/release/Magarena/scripts/Unstable_Mutation.groovy
@@ -17,7 +17,7 @@
             final MagicPermanent permanent=event.getPermanent();
             final MagicPermanent enchanted=permanent.getEnchantedPermanent();
             if (enchanted.isValid()) {
-                game.doAction(new ChangeCountersAction(enchanted,MagicCounterType.MinusOne,1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),enchanted,MagicCounterType.MinusOne,1));
             }
         }
     }

--- a/release/Magarena/scripts/Vampire_Hexmage.groovy
+++ b/release/Magarena/scripts/Vampire_Hexmage.groovy
@@ -32,7 +32,7 @@ def TARGET_PERMANENT_WITH_COUNTERS = new MagicTargetChoice(
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 for (final MagicCounterType counterType : it.getCounterTypes()) {
-                    game.doAction(new ChangeCountersAction(it,counterType,-it.getCounters(counterType)));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(),it,counterType,-it.getCounters(counterType)));
                 }
             });
         }

--- a/release/Magarena/scripts/Varchild_s_War_Riders.groovy
+++ b/release/Magarena/scripts/Varchild_s_War_Riders.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Varolz__the_Scar_Striped.groovy
+++ b/release/Magarena/scripts/Varolz__the_Scar_Striped.groovy
@@ -29,7 +29,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             event.processTargetPermanent(game, {
                 final int amt = event.getRefCard().genPowerToughness().getPositivePower();
-                game.doAction(new ChangeCountersAction(it,MagicCounterType.PlusOne,amt));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),it,MagicCounterType.PlusOne,amt));
             });
         }
     }

--- a/release/Magarena/scripts/Venarian_Gold.groovy
+++ b/release/Magarena/scripts/Venarian_Gold.groovy
@@ -14,7 +14,7 @@
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicPermanent enchanted = event.getPermanent().getEnchantedPermanent();
             game.doAction(new TapAction(enchanted));
-            game.doAction(new ChangeCountersAction(enchanted, MagicCounterType.Sleep, event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), enchanted, MagicCounterType.Sleep, event.getRefInt()));
         }
     },
 
@@ -45,7 +45,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game,final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getRefPermanent(),MagicCounterType.Sleep,-1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getRefPermanent(),MagicCounterType.Sleep,-1));
         }
     }
 ]

--- a/release/Magarena/scripts/Vexing_Sphinx.groovy
+++ b/release/Magarena/scripts/Vexing_Sphinx.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/Vigor.groovy
+++ b/release/Magarena/scripts/Vigor.groovy
@@ -2,6 +2,7 @@ def action = {
     final MagicGame game, final MagicEvent event ->
     final MagicTuple tup = event.getRefTuple();
     game.doAction(new ChangeCountersAction(
+        event.getPlayer(),
         tup.getPermanent(1),
         MagicCounterType.PlusOne,
         tup.getInt(0)

--- a/release/Magarena/scripts/Vodalian_Serpent.groovy
+++ b/release/Magarena/scripts/Vodalian_Serpent.groovy
@@ -3,7 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPayedCost payedCost) {
             if (payedCost.isKicked()) {
-                game.doAction(new ChangeCountersAction(permanent,MagicCounterType.PlusOne,4));
+                game.doAction(new ChangeCountersAction(permanent.getController(),permanent,MagicCounterType.PlusOne,4));
             }
             return MagicEvent.NONE;
         }

--- a/release/Magarena/scripts/Vorel_of_the_Hull_Clade.groovy
+++ b/release/Magarena/scripts/Vorel_of_the_Hull_Clade.groovy
@@ -37,6 +37,7 @@ def TARGET_ARTIFACT_CREATURE_OR_LAND_WITH_COUNTERS = new MagicTargetChoice(
                 for (final MagicCounterType counterType : MagicCounterType.values()) {
                     if (it.hasCounters(counterType)) {
                         game.doAction(new ChangeCountersAction(
+                            event.getPlayer(),
                             it,
                             counterType,
                             it.getCounters(counterType)

--- a/release/Magarena/scripts/Vulturous_Zombie.groovy
+++ b/release/Magarena/scripts/Vulturous_Zombie.groovy
@@ -13,7 +13,7 @@
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,1));
+            game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,1));
         }
     }
 ]

--- a/release/Magarena/scripts/Wall_of_Shards.groovy
+++ b/release/Magarena/scripts/Wall_of_Shards.groovy
@@ -3,6 +3,7 @@
         @Override
         public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent,final MagicPlayer upkeepPlayer) {
             game.doAction(new ChangeCountersAction(
+                permanent.getController(),
                 permanent,
                 MagicCounterType.Age,
                 1

--- a/release/Magarena/scripts/War_Elemental.groovy
+++ b/release/Magarena/scripts/War_Elemental.groovy
@@ -23,7 +23,7 @@ def EFFECT = MagicRuleEventAction.create("Sacrifice SN.");
         }
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
-            game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(),MagicCounterType.PlusOne,event.getRefInt()));
         }
     }
 ]

--- a/release/Magarena/scripts/Warden_of_the_First_Tree.groovy
+++ b/release/Magarena/scripts/Warden_of_the_First_Tree.groovy
@@ -116,7 +116,7 @@ def AB2 = new MagicStatic(MagicLayer.Ability) {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.getPermanent().hasSubType(MagicSubType.Spirit)) {
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,5));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,5));
             }
         }
     }

--- a/src/magic/model/action/ChangeCountersAction.java
+++ b/src/magic/model/action/ChangeCountersAction.java
@@ -4,17 +4,20 @@ import magic.model.MagicCounterType;
 import magic.model.MagicGame;
 import magic.model.MagicObject;
 import magic.model.MagicPermanent;
+import magic.model.MagicSource;
 import magic.model.trigger.MagicCounterChangeTriggerData;
 import magic.model.trigger.MagicTriggerType;
 
 public class ChangeCountersAction extends MagicAction {
 
+    private final MagicSource source;
     private final MagicObject obj;
     private final MagicCounterType counterType;
     private int amount;
     private final boolean hasScore;
 
-    private ChangeCountersAction(final MagicObject obj, final MagicCounterType counterType, final int amount, final boolean hasScore) {
+    private ChangeCountersAction(final MagicSource source, final MagicObject obj, final MagicCounterType counterType, final int amount, final boolean hasScore) {
+        this.source = source;
         this.obj=obj;
         this.counterType=counterType;
 
@@ -26,11 +29,15 @@ public class ChangeCountersAction extends MagicAction {
     }
 
     public static ChangeCountersAction Enters(final MagicPermanent permanent, final MagicCounterType counterType, final int amount) {
-        return new ChangeCountersAction(permanent, counterType, amount, false);
+        return new ChangeCountersAction(permanent, permanent, counterType, amount, false);
     }
 
-    public ChangeCountersAction(final MagicObject obj, final MagicCounterType counterType, final int amount) {
-        this(obj, counterType, amount, true);
+    public ChangeCountersAction(final MagicSource source, final MagicObject obj, final MagicCounterType counterType, final int amount) {
+        this(source, obj, counterType, amount, true);
+    }
+
+    public MagicSource getSource() {
+        return source;
     }
 
     public MagicObject getObj() {

--- a/src/magic/model/action/ChangeCountersAction.java
+++ b/src/magic/model/action/ChangeCountersAction.java
@@ -3,8 +3,8 @@ package magic.model.action;
 import magic.model.MagicCounterType;
 import magic.model.MagicGame;
 import magic.model.MagicObject;
+import magic.model.MagicPlayer;
 import magic.model.MagicPermanent;
-import magic.model.MagicSource;
 import magic.model.trigger.MagicCounterChangeTriggerData;
 import magic.model.trigger.MagicTriggerType;
 

--- a/src/magic/model/action/ChangeCountersAction.java
+++ b/src/magic/model/action/ChangeCountersAction.java
@@ -10,14 +10,14 @@ import magic.model.trigger.MagicTriggerType;
 
 public class ChangeCountersAction extends MagicAction {
 
-    private final MagicSource source;
+    private final MagicPlayer player;
     private final MagicObject obj;
     private final MagicCounterType counterType;
     private int amount;
     private final boolean hasScore;
 
-    private ChangeCountersAction(final MagicSource source, final MagicObject obj, final MagicCounterType counterType, final int amount, final boolean hasScore) {
-        this.source = source;
+    private ChangeCountersAction(final MagicPlayer player, final MagicObject obj, final MagicCounterType counterType, final int amount, final boolean hasScore) {
+        this.player = player;
         this.obj=obj;
         this.counterType=counterType;
 
@@ -29,15 +29,15 @@ public class ChangeCountersAction extends MagicAction {
     }
 
     public static ChangeCountersAction Enters(final MagicPermanent permanent, final MagicCounterType counterType, final int amount) {
-        return new ChangeCountersAction(permanent, permanent, counterType, amount, false);
+        return new ChangeCountersAction(permanent.getController(), permanent, counterType, amount, false);
     }
 
-    public ChangeCountersAction(final MagicSource source, final MagicObject obj, final MagicCounterType counterType, final int amount) {
-        this(source, obj, counterType, amount, true);
+    public ChangeCountersAction(final MagicPlayer player, final MagicObject obj, final MagicCounterType counterType, final int amount) {
+        this(player, obj, counterType, amount, true);
     }
 
-    public MagicSource getSource() {
-        return source;
+    public MagicPlayer getPlayer() {
+        return player;
     }
 
     public MagicObject getObj() {
@@ -72,10 +72,10 @@ public class ChangeCountersAction extends MagicAction {
         }
 
         if (amount != 0) {
-            game.executeTrigger(MagicTriggerType.WhenOneOrMoreCountersAreChanged, new MagicCounterChangeTriggerData(obj, counterType, amount));
+            game.executeTrigger(MagicTriggerType.WhenOneOrMoreCountersAreChanged, new MagicCounterChangeTriggerData(player, obj, counterType, amount));
         }
         for (int i = 0; i < Math.abs(amount); i++) {
-            game.executeTrigger(MagicTriggerType.WhenACounterIsChanged, new MagicCounterChangeTriggerData(obj, counterType, amount));
+            game.executeTrigger(MagicTriggerType.WhenACounterIsChanged, new MagicCounterChangeTriggerData(player, obj, counterType, amount));
         }
         game.setStateCheckRequired();
     }

--- a/src/magic/model/action/DealDamageAction.java
+++ b/src/magic/model/action/DealDamageAction.java
@@ -80,7 +80,7 @@ public class DealDamageAction extends MagicAction {
 
         if (target.isPlaneswalkerPermanent()) {
             final MagicPermanent targetPermanent=(MagicPermanent)target;
-            game.doAction(new ChangeCountersAction(damage.getSource(),targetPermanent,MagicCounterType.Loyalty,-dealtAmount));
+            game.doAction(new ChangeCountersAction(damage.getSource().getController(),targetPermanent,MagicCounterType.Loyalty,-dealtAmount));
         }
 
         if (target.isCreaturePermanent()) {
@@ -89,7 +89,7 @@ public class DealDamageAction extends MagicAction {
                 game.doAction(ChangeStateAction.Set(targetPermanent,MagicPermanentState.CannotBeRegenerated));
             }
             if (source.hasAbility(MagicAbility.Wither)||source.hasAbility(MagicAbility.Infect)) {
-                game.doAction(new ChangeCountersAction(damage.getSource(),targetPermanent,MagicCounterType.MinusOne,dealtAmount));
+                game.doAction(new ChangeCountersAction(damage.getSource().getController(),targetPermanent,MagicCounterType.MinusOne,dealtAmount));
             } else {
                 oldDamage=targetPermanent.getDamage();
                 targetPermanent.setDamage(oldDamage+dealtAmount);
@@ -103,7 +103,7 @@ public class DealDamageAction extends MagicAction {
         if (target.isPlayer()) {
             final MagicPlayer targetPlayer = (MagicPlayer)target;
             if (source.hasAbility(MagicAbility.Infect)) {
-                game.doAction(new ChangeCountersAction(damage.getSource(),targetPlayer, MagicCounterType.Poison, dealtAmount));
+                game.doAction(new ChangeCountersAction(damage.getSource().getController(),targetPlayer, MagicCounterType.Poison, dealtAmount));
             } else {
                 game.doAction(new ChangeLifeAction(targetPlayer,-dealtAmount,true));
             }

--- a/src/magic/model/action/DealDamageAction.java
+++ b/src/magic/model/action/DealDamageAction.java
@@ -80,7 +80,7 @@ public class DealDamageAction extends MagicAction {
 
         if (target.isPlaneswalkerPermanent()) {
             final MagicPermanent targetPermanent=(MagicPermanent)target;
-            game.doAction(new ChangeCountersAction(targetPermanent,MagicCounterType.Loyalty,-dealtAmount));
+            game.doAction(new ChangeCountersAction(damage.getSource(),targetPermanent,MagicCounterType.Loyalty,-dealtAmount));
         }
 
         if (target.isCreaturePermanent()) {
@@ -89,7 +89,7 @@ public class DealDamageAction extends MagicAction {
                 game.doAction(ChangeStateAction.Set(targetPermanent,MagicPermanentState.CannotBeRegenerated));
             }
             if (source.hasAbility(MagicAbility.Wither)||source.hasAbility(MagicAbility.Infect)) {
-                game.doAction(new ChangeCountersAction(targetPermanent,MagicCounterType.MinusOne,dealtAmount));
+                game.doAction(new ChangeCountersAction(damage.getSource(),targetPermanent,MagicCounterType.MinusOne,dealtAmount));
             } else {
                 oldDamage=targetPermanent.getDamage();
                 targetPermanent.setDamage(oldDamage+dealtAmount);
@@ -103,7 +103,7 @@ public class DealDamageAction extends MagicAction {
         if (target.isPlayer()) {
             final MagicPlayer targetPlayer = (MagicPlayer)target;
             if (source.hasAbility(MagicAbility.Infect)) {
-                game.doAction(new ChangeCountersAction(targetPlayer, MagicCounterType.Poison, dealtAmount));
+                game.doAction(new ChangeCountersAction(damage.getSource(),targetPlayer, MagicCounterType.Poison, dealtAmount));
             } else {
                 game.doAction(new ChangeLifeAction(targetPlayer,-dealtAmount,true));
             }

--- a/src/magic/model/event/MagicAddCounterChosenEvent.java
+++ b/src/magic/model/event/MagicAddCounterChosenEvent.java
@@ -22,7 +22,7 @@ public class MagicAddCounterChosenEvent extends MagicEvent {
     private static final MagicEventAction EventAction = (final MagicGame game, final MagicEvent event) -> {
         event.processTargetPermanent(game, (final MagicPermanent perm) ->
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer(),
                 perm,
                 event.getRefCounterType(),
                 1

--- a/src/magic/model/event/MagicAddCounterChosenEvent.java
+++ b/src/magic/model/event/MagicAddCounterChosenEvent.java
@@ -22,6 +22,7 @@ public class MagicAddCounterChosenEvent extends MagicEvent {
     private static final MagicEventAction EventAction = (final MagicGame game, final MagicEvent event) -> {
         event.processTargetPermanent(game, (final MagicPermanent perm) ->
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 perm,
                 event.getRefCounterType(),
                 1

--- a/src/magic/model/event/MagicAddCounterEvent.java
+++ b/src/magic/model/event/MagicAddCounterEvent.java
@@ -20,7 +20,7 @@ public class MagicAddCounterEvent extends MagicEvent {
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
         final MagicTuple tup = event.getRefTuple();
         game.doAction(new ChangeCountersAction(
-            event.getSource(),
+            event.getPlayer(),
             event.getPermanent(),
             tup.getCounterType(1),
             tup.getInt(0)

--- a/src/magic/model/event/MagicAddCounterEvent.java
+++ b/src/magic/model/event/MagicAddCounterEvent.java
@@ -20,6 +20,7 @@ public class MagicAddCounterEvent extends MagicEvent {
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
         final MagicTuple tup = event.getRefTuple();
         game.doAction(new ChangeCountersAction(
+            event.getSource(),
             event.getPermanent(),
             tup.getCounterType(1),
             tup.getInt(0)

--- a/src/magic/model/event/MagicAwakenEvent.java
+++ b/src/magic/model/event/MagicAwakenEvent.java
@@ -51,7 +51,7 @@ public class MagicAwakenEvent extends MagicEvent {
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
         event.processTargetPermanent(game, (final MagicPermanent it) -> {
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer(),
                 it,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/event/MagicAwakenEvent.java
+++ b/src/magic/model/event/MagicAwakenEvent.java
@@ -51,6 +51,7 @@ public class MagicAwakenEvent extends MagicEvent {
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
         event.processTargetPermanent(game, (final MagicPermanent it) -> {
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 it,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/event/MagicBolsterEvent.java
+++ b/src/magic/model/event/MagicBolsterEvent.java
@@ -14,6 +14,7 @@ public class MagicBolsterEvent extends MagicEvent {
     public static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) ->
         event.processTargetPermanent(game, (final MagicPermanent creature) ->
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 creature,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/event/MagicBolsterEvent.java
+++ b/src/magic/model/event/MagicBolsterEvent.java
@@ -14,7 +14,7 @@ public class MagicBolsterEvent extends MagicEvent {
     public static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) ->
         event.processTargetPermanent(game, (final MagicPermanent creature) ->
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer(),
                 creature,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/event/MagicExploreEvent.java
+++ b/src/magic/model/event/MagicExploreEvent.java
@@ -37,7 +37,7 @@ public class MagicExploreEvent extends MagicEvent {
             if (top.isLand()) {
                 game.doAction(new ShiftCardAction(top, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
             } else {
-                game.doAction(new ChangeCountersAction(perm, MagicCounterType.PlusOne, 1));
+                game.doAction(new ChangeCountersAction(perm, perm, MagicCounterType.PlusOne, 1));
                 game.addEvent(new MagicEvent(
                     perm,
                     player,

--- a/src/magic/model/event/MagicExploreEvent.java
+++ b/src/magic/model/event/MagicExploreEvent.java
@@ -37,7 +37,7 @@ public class MagicExploreEvent extends MagicEvent {
             if (top.isLand()) {
                 game.doAction(new ShiftCardAction(top, MagicLocationType.OwnersLibrary, MagicLocationType.OwnersHand));
             } else {
-                game.doAction(new ChangeCountersAction(perm, perm, MagicCounterType.PlusOne, 1));
+                game.doAction(new ChangeCountersAction(player, perm, MagicCounterType.PlusOne, 1));
                 game.addEvent(new MagicEvent(
                     perm,
                     player,

--- a/src/magic/model/event/MagicLevelUpActivation.java
+++ b/src/magic/model/event/MagicLevelUpActivation.java
@@ -49,7 +49,7 @@ public class MagicLevelUpActivation extends MagicPermanentActivation {
 
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
-        game.doAction(new ChangeCountersAction(event.getSource(),event.getPermanent(),MagicCounterType.Level,1));
+        game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.Level,1));
     }
 
     private static final class MaximumCondition extends MagicCondition {

--- a/src/magic/model/event/MagicLevelUpActivation.java
+++ b/src/magic/model/event/MagicLevelUpActivation.java
@@ -49,7 +49,7 @@ public class MagicLevelUpActivation extends MagicPermanentActivation {
 
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
-        game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.Level,1));
+        game.doAction(new ChangeCountersAction(event.getSource(),event.getPermanent(),MagicCounterType.Level,1));
     }
 
     private static final class MaximumCondition extends MagicCondition {

--- a/src/magic/model/event/MagicMegamorphActivation.java
+++ b/src/magic/model/event/MagicMegamorphActivation.java
@@ -16,7 +16,7 @@ public class MagicMegamorphActivation extends MagicMorphActivation {
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         game.doAction(new TurnFaceUpAction(event.getPermanent()));
-        game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, 1));
+        game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(), MagicCounterType.PlusOne, 1));
         game.logAppendMessage(
             event.getPlayer(),
             MagicMessage.format("%s turns %s face up and puts a +1/+1 counter on it.", event.getPlayer(), event.getPermanent())

--- a/src/magic/model/event/MagicMegamorphActivation.java
+++ b/src/magic/model/event/MagicMegamorphActivation.java
@@ -16,7 +16,7 @@ public class MagicMegamorphActivation extends MagicMorphActivation {
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         game.doAction(new TurnFaceUpAction(event.getPermanent()));
-        game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(), MagicCounterType.PlusOne, 1));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, 1));
         game.logAppendMessage(
             event.getPlayer(),
             MagicMessage.format("%s turns %s face up and puts a +1/+1 counter on it.", event.getPlayer(), event.getPermanent())

--- a/src/magic/model/event/MagicOutlastActivation.java
+++ b/src/magic/model/event/MagicOutlastActivation.java
@@ -36,6 +36,6 @@ public class MagicOutlastActivation extends MagicPermanentActivation{
 
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
-        game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(), MagicCounterType.PlusOne, 1));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, 1));
     }
 }

--- a/src/magic/model/event/MagicOutlastActivation.java
+++ b/src/magic/model/event/MagicOutlastActivation.java
@@ -36,6 +36,6 @@ public class MagicOutlastActivation extends MagicPermanentActivation{
 
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
-        game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, 1));
+        game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(), MagicCounterType.PlusOne, 1));
     }
 }

--- a/src/magic/model/event/MagicPayEnergyEvent.java
+++ b/src/magic/model/event/MagicPayEnergyEvent.java
@@ -14,7 +14,7 @@ public class MagicPayEnergyEvent extends MagicEvent {
     private final MagicCondition cond;
 
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) ->
-        game.doAction(new ChangeCountersAction(event.getPlayer(), MagicCounterType.Energy, -event.getRefInt()));
+        game.doAction(new ChangeCountersAction(event.getSource(), event.getPlayer(), MagicCounterType.Energy, -event.getRefInt()));
 
     public MagicPayEnergyEvent(final MagicSource source,final int amount) {
         this(source, source.getController(), amount);

--- a/src/magic/model/event/MagicPayEnergyEvent.java
+++ b/src/magic/model/event/MagicPayEnergyEvent.java
@@ -14,7 +14,7 @@ public class MagicPayEnergyEvent extends MagicEvent {
     private final MagicCondition cond;
 
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) ->
-        game.doAction(new ChangeCountersAction(event.getSource(), event.getPlayer(), MagicCounterType.Energy, -event.getRefInt()));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPlayer(), MagicCounterType.Energy, -event.getRefInt()));
 
     public MagicPayEnergyEvent(final MagicSource source,final int amount) {
         this(source, source.getController(), amount);

--- a/src/magic/model/event/MagicPutCounterEvent.java
+++ b/src/magic/model/event/MagicPutCounterEvent.java
@@ -30,6 +30,7 @@ public class MagicPutCounterEvent extends MagicEvent {
         event.processTargetPermanent(game, (final MagicPermanent creature) -> {
             final MagicTuple tup = event.getRefTuple();
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 creature,
                 tup.getCounterType(1),
                 tup.getInt(0)
@@ -49,6 +50,7 @@ public class MagicPutCounterEvent extends MagicEvent {
     private static final MagicEventAction EventAction = (final MagicGame game, final MagicEvent event) -> {
         final MagicTuple tup = event.getRefTuple();
         game.doAction(new ChangeCountersAction(
+            event.getSource(),
             event.getPermanent(),
             tup.getCounterType(1),
             tup.getInt(0)

--- a/src/magic/model/event/MagicPutCounterEvent.java
+++ b/src/magic/model/event/MagicPutCounterEvent.java
@@ -30,7 +30,7 @@ public class MagicPutCounterEvent extends MagicEvent {
         event.processTargetPermanent(game, (final MagicPermanent creature) -> {
             final MagicTuple tup = event.getRefTuple();
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer(),
                 creature,
                 tup.getCounterType(1),
                 tup.getInt(0)
@@ -50,7 +50,7 @@ public class MagicPutCounterEvent extends MagicEvent {
     private static final MagicEventAction EventAction = (final MagicGame game, final MagicEvent event) -> {
         final MagicTuple tup = event.getRefTuple();
         game.doAction(new ChangeCountersAction(
-            event.getSource(),
+            event.getPlayer(),
             event.getPermanent(),
             tup.getCounterType(1),
             tup.getInt(0)

--- a/src/magic/model/event/MagicRemoveCounterChosenEvent.java
+++ b/src/magic/model/event/MagicRemoveCounterChosenEvent.java
@@ -27,6 +27,7 @@ public class MagicRemoveCounterChosenEvent extends MagicEvent {
     private static final MagicEventAction EventAction = (final MagicGame game, final MagicEvent event) -> {
         event.processTargetPermanent(game, (final MagicPermanent perm) ->
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 perm,
                 event.getRefCounterType(),
                 -1

--- a/src/magic/model/event/MagicRemoveCounterChosenEvent.java
+++ b/src/magic/model/event/MagicRemoveCounterChosenEvent.java
@@ -27,7 +27,7 @@ public class MagicRemoveCounterChosenEvent extends MagicEvent {
     private static final MagicEventAction EventAction = (final MagicGame game, final MagicEvent event) -> {
         event.processTargetPermanent(game, (final MagicPermanent perm) ->
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer(),
                 perm,
                 event.getRefCounterType(),
                 -1

--- a/src/magic/model/event/MagicRemoveCounterEvent.java
+++ b/src/magic/model/event/MagicRemoveCounterEvent.java
@@ -26,6 +26,7 @@ public class MagicRemoveCounterEvent extends MagicEvent {
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
         final MagicTuple tup = event.getRefTuple();
         game.doAction(new ChangeCountersAction(
+            event.getSource(),
             event.getPermanent(),
             tup.getCounterType(1),
             -tup.getInt(0)

--- a/src/magic/model/event/MagicRemoveCounterEvent.java
+++ b/src/magic/model/event/MagicRemoveCounterEvent.java
@@ -26,7 +26,7 @@ public class MagicRemoveCounterEvent extends MagicEvent {
     private static final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
         final MagicTuple tup = event.getRefTuple();
         game.doAction(new ChangeCountersAction(
-            event.getSource(),
+            event.getPlayer(),
             event.getPermanent(),
             tup.getCounterType(1),
             -tup.getInt(0)

--- a/src/magic/model/event/MagicRuleEventAction.java
+++ b/src/magic/model/event/MagicRuleEventAction.java
@@ -447,7 +447,7 @@ public enum MagicRuleEventAction {
         "Exile",
         (game, event) -> {
             game.doAction(new ChangeCardDestinationAction(event.getCardOnStack(), MagicLocationType.Exile));
-            game.doAction(new ChangeCountersAction(event.getSource(), event.getCardOnStack().getCard(), MagicCounterType.Time, 3));
+            game.doAction(new ChangeCountersAction(event.getPlayer(), event.getCardOnStack().getCard(), MagicCounterType.Time, 3));
         }
     ),
     ExilePlayerGraveyard(
@@ -1373,7 +1373,7 @@ public enum MagicRuleEventAction {
                 final int amount = count.getAmount(event);
                 for (final MagicPermanent it : ARG.permanents(event, matcher, filter)) {
                     game.doAction(new ChangeCountersAction(
-                        event.getSource(),
+                        event.getPlayer(),
                         it,
                         counterType,
                         amount
@@ -1440,7 +1440,7 @@ public enum MagicRuleEventAction {
                 final int amount = count.getAmount(event);
                 for (final MagicPermanent it : ARG.permanents(event, matcher, filter)) {
                     game.doAction(new ChangeCountersAction(
-                        event.getSource(),
+                        event.getPlayer(),
                         it,
                         counterType,
                         -amount
@@ -1462,7 +1462,7 @@ public enum MagicRuleEventAction {
                 for (final MagicPermanent it : ARG.permanents(event, matcher, filter)) {
                     final int amount = it.getCounters(counterType);
                     game.doAction(new ChangeCountersAction(
-                        event.getSource(),
+                        event.getPlayer(),
                         it,
                         counterType,
                         -amount
@@ -2524,7 +2524,7 @@ public enum MagicRuleEventAction {
             return (game, event) -> {
                 final MagicPermanent SN = event.getPermanent();
                 if (MagicCondition.NOT_MONSTROUS_CONDITION.accept(SN)) {
-                    game.doAction(new ChangeCountersAction(SN, SN, MagicCounterType.PlusOne, amount));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), SN, MagicCounterType.PlusOne, amount));
                     game.doAction(ChangeStateAction.Set(SN, MagicPermanentState.Monstrous));
                 }
             };
@@ -3164,7 +3164,7 @@ public enum MagicRuleEventAction {
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
-                    game.doAction(new ChangeCountersAction(event.getSource(), it, MagicCounterType.Poison, amount));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.Poison, amount));
                 }
             };
         }
@@ -3184,7 +3184,7 @@ public enum MagicRuleEventAction {
                 final int multiplier = eachCount.getPositiveAmount(event);
                 final int total = amount * multiplier;
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
-                    game.doAction(new ChangeCountersAction(event.getSource(), it, MagicCounterType.Energy, total));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.Energy, total));
                 }
             };
         }
@@ -3201,7 +3201,7 @@ public enum MagicRuleEventAction {
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
-                    game.doAction(new ChangeCountersAction(event.getSource(), it, MagicCounterType.Experience, amount));
+                    game.doAction(new ChangeCountersAction(event.getPlayer(), it, MagicCounterType.Experience, amount));
                 }
             };
         }

--- a/src/magic/model/event/MagicRuleEventAction.java
+++ b/src/magic/model/event/MagicRuleEventAction.java
@@ -447,7 +447,7 @@ public enum MagicRuleEventAction {
         "Exile",
         (game, event) -> {
             game.doAction(new ChangeCardDestinationAction(event.getCardOnStack(), MagicLocationType.Exile));
-            game.doAction(new ChangeCountersAction(event.getCardOnStack().getCard(), MagicCounterType.Time, 3));
+            game.doAction(new ChangeCountersAction(event.getSource(), event.getCardOnStack().getCard(), MagicCounterType.Time, 3));
         }
     ),
     ExilePlayerGraveyard(
@@ -1373,6 +1373,7 @@ public enum MagicRuleEventAction {
                 final int amount = count.getAmount(event);
                 for (final MagicPermanent it : ARG.permanents(event, matcher, filter)) {
                     game.doAction(new ChangeCountersAction(
+                        event.getSource(),
                         it,
                         counterType,
                         amount
@@ -1439,6 +1440,7 @@ public enum MagicRuleEventAction {
                 final int amount = count.getAmount(event);
                 for (final MagicPermanent it : ARG.permanents(event, matcher, filter)) {
                     game.doAction(new ChangeCountersAction(
+                        event.getSource(),
                         it,
                         counterType,
                         -amount
@@ -1460,6 +1462,7 @@ public enum MagicRuleEventAction {
                 for (final MagicPermanent it : ARG.permanents(event, matcher, filter)) {
                     final int amount = it.getCounters(counterType);
                     game.doAction(new ChangeCountersAction(
+                        event.getSource(),
                         it,
                         counterType,
                         -amount
@@ -2521,7 +2524,7 @@ public enum MagicRuleEventAction {
             return (game, event) -> {
                 final MagicPermanent SN = event.getPermanent();
                 if (MagicCondition.NOT_MONSTROUS_CONDITION.accept(SN)) {
-                    game.doAction(new ChangeCountersAction(SN, MagicCounterType.PlusOne, amount));
+                    game.doAction(new ChangeCountersAction(SN, SN, MagicCounterType.PlusOne, amount));
                     game.doAction(ChangeStateAction.Set(SN, MagicPermanentState.Monstrous));
                 }
             };
@@ -3161,7 +3164,7 @@ public enum MagicRuleEventAction {
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.Poison, amount));
+                    game.doAction(new ChangeCountersAction(event.getSource(), it, MagicCounterType.Poison, amount));
                 }
             };
         }
@@ -3181,7 +3184,7 @@ public enum MagicRuleEventAction {
                 final int multiplier = eachCount.getPositiveAmount(event);
                 final int total = amount * multiplier;
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.Energy, total));
+                    game.doAction(new ChangeCountersAction(event.getSource(), it, MagicCounterType.Energy, total));
                 }
             };
         }
@@ -3198,7 +3201,7 @@ public enum MagicRuleEventAction {
             final MagicTargetFilter<MagicPlayer> filter = ARG.playersParse(matcher);
             return (game, event) -> {
                 for (final MagicPlayer it : ARG.players(event, matcher, filter)) {
-                    game.doAction(new ChangeCountersAction(it, MagicCounterType.Experience, amount));
+                    game.doAction(new ChangeCountersAction(event.getSource(), it, MagicCounterType.Experience, amount));
                 }
             };
         }

--- a/src/magic/model/event/MagicScavengeActivation.java
+++ b/src/magic/model/event/MagicScavengeActivation.java
@@ -61,7 +61,7 @@ public class MagicScavengeActivation extends MagicCardAbilityActivation {
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         event.processTargetPermanent(game, (final MagicPermanent perm) ->
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer(),
                 perm,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/event/MagicScavengeActivation.java
+++ b/src/magic/model/event/MagicScavengeActivation.java
@@ -61,6 +61,7 @@ public class MagicScavengeActivation extends MagicCardAbilityActivation {
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         event.processTargetPermanent(game, (final MagicPermanent perm) ->
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 perm,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/event/MagicSuspendActivation.java
+++ b/src/magic/model/event/MagicSuspendActivation.java
@@ -56,6 +56,6 @@ public class MagicSuspendActivation extends MagicCardAbilityActivation {
     private void suspend(final MagicGame game, final MagicEvent event) {
         final MagicCard card = event.getCard();
         game.doAction(new ShiftCardAction(card, MagicLocationType.OwnersHand, MagicLocationType.Exile));
-        game.doAction(new ChangeCountersAction(card, card, MagicCounterType.Time, event.getRefInt()));
+        game.doAction(new ChangeCountersAction(card.getController(), card, MagicCounterType.Time, event.getRefInt()));
     }
 }

--- a/src/magic/model/event/MagicSuspendActivation.java
+++ b/src/magic/model/event/MagicSuspendActivation.java
@@ -56,6 +56,6 @@ public class MagicSuspendActivation extends MagicCardAbilityActivation {
     private void suspend(final MagicGame game, final MagicEvent event) {
         final MagicCard card = event.getCard();
         game.doAction(new ShiftCardAction(card, MagicLocationType.OwnersHand, MagicLocationType.Exile));
-        game.doAction(new ChangeCountersAction(card, MagicCounterType.Time, event.getRefInt()));
+        game.doAction(new ChangeCountersAction(card, card, MagicCounterType.Time, event.getRefInt()));
     }
 }

--- a/src/magic/model/trigger/AtEndOfCombatTrigger.java
+++ b/src/magic/model/trigger/AtEndOfCombatTrigger.java
@@ -108,7 +108,7 @@ public abstract class AtEndOfCombatTrigger extends MagicTrigger<MagicPlayer> {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.getPermanent().hasCounters(MagicCounterType.PlusOne)) {
-                game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,-1));
+                game.doAction(new ChangeCountersAction(event.getSource(),event.getPermanent(),MagicCounterType.PlusOne,-1));
             }
         }
     };

--- a/src/magic/model/trigger/AtEndOfCombatTrigger.java
+++ b/src/magic/model/trigger/AtEndOfCombatTrigger.java
@@ -108,7 +108,7 @@ public abstract class AtEndOfCombatTrigger extends MagicTrigger<MagicPlayer> {
         @Override
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.getPermanent().hasCounters(MagicCounterType.PlusOne)) {
-                game.doAction(new ChangeCountersAction(event.getSource(),event.getPermanent(),MagicCounterType.PlusOne,-1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(),event.getPermanent(),MagicCounterType.PlusOne,-1));
             }
         }
     };

--- a/src/magic/model/trigger/AtUpkeepTrigger.java
+++ b/src/magic/model/trigger/AtUpkeepTrigger.java
@@ -87,7 +87,7 @@ public abstract class AtUpkeepTrigger extends MagicTrigger<MagicPlayer> {
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCard card = event.getCard();
             if (card.isInExile() && card.hasAbility(MagicAbility.Suspend) && card.hasCounters(MagicCounterType.Time)) {
-                game.doAction(new ChangeCountersAction(event.getSource(), card, MagicCounterType.Time, -1));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), card, MagicCounterType.Time, -1));
                 game.logAppendMessage(event.getPlayer(), "Remove a time counter, there are " + card.getCounters(MagicCounterType.Time) + " time counters left.");
                 if (!card.hasCounters(MagicCounterType.Time)) {
                     game.doAction(new EnqueueTriggerAction(new MagicEvent(

--- a/src/magic/model/trigger/AtUpkeepTrigger.java
+++ b/src/magic/model/trigger/AtUpkeepTrigger.java
@@ -87,7 +87,7 @@ public abstract class AtUpkeepTrigger extends MagicTrigger<MagicPlayer> {
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             final MagicCard card = event.getCard();
             if (card.isInExile() && card.hasAbility(MagicAbility.Suspend) && card.hasCounters(MagicCounterType.Time)) {
-                game.doAction(new ChangeCountersAction(card, MagicCounterType.Time, -1));
+                game.doAction(new ChangeCountersAction(event.getSource(), card, MagicCounterType.Time, -1));
                 game.logAppendMessage(event.getPlayer(), "Remove a time counter, there are " + card.getCounters(MagicCounterType.Time) + " time counters left.");
                 if (!card.hasCounters(MagicCounterType.Time)) {
                     game.doAction(new EnqueueTriggerAction(new MagicEvent(

--- a/src/magic/model/trigger/BloodthirstTrigger.java
+++ b/src/magic/model/trigger/BloodthirstTrigger.java
@@ -32,7 +32,6 @@ public class BloodthirstTrigger extends EntersBattlefieldTrigger {
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         game.doAction(ChangeCountersAction.Enters(
-            event.getSource(),
             event.getPermanent(),
             MagicCounterType.PlusOne,
             amount

--- a/src/magic/model/trigger/BloodthirstTrigger.java
+++ b/src/magic/model/trigger/BloodthirstTrigger.java
@@ -32,6 +32,7 @@ public class BloodthirstTrigger extends EntersBattlefieldTrigger {
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
         game.doAction(ChangeCountersAction.Enters(
+            event.getSource(),
             event.getPermanent(),
             MagicCounterType.PlusOne,
             amount

--- a/src/magic/model/trigger/CumulativeUpkeepTrigger.java
+++ b/src/magic/model/trigger/CumulativeUpkeepTrigger.java
@@ -28,7 +28,7 @@ public class CumulativeUpkeepTrigger extends AtYourUpkeepTrigger {
     @Override
     public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicPlayer upkeepPlayer) {
         game.doAction(new ChangeCountersAction(
-            permanent,
+            permanent.getController(),
             permanent,
             MagicCounterType.Age,
             1

--- a/src/magic/model/trigger/CumulativeUpkeepTrigger.java
+++ b/src/magic/model/trigger/CumulativeUpkeepTrigger.java
@@ -29,6 +29,7 @@ public class CumulativeUpkeepTrigger extends AtYourUpkeepTrigger {
     public MagicEvent executeTrigger(final MagicGame game, final MagicPermanent permanent, final MagicPlayer upkeepPlayer) {
         game.doAction(new ChangeCountersAction(
             permanent,
+            permanent,
             MagicCounterType.Age,
             1
         ));

--- a/src/magic/model/trigger/DamageIsDealtTrigger.java
+++ b/src/magic/model/trigger/DamageIsDealtTrigger.java
@@ -163,7 +163,7 @@ public abstract class DamageIsDealtTrigger extends MagicTrigger<MagicDamage> {
 
             @Override
             public void executeEvent(final MagicGame game, final MagicEvent event) {
-                game.doAction(new ChangeCountersAction(event.getSource(), event.getRefPlayer(), MagicCounterType.Poison, n));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getRefPlayer(), MagicCounterType.Poison, n));
             }
         };
     }
@@ -192,7 +192,7 @@ public abstract class DamageIsDealtTrigger extends MagicTrigger<MagicDamage> {
 
             @Override
             public void executeEvent(final MagicGame game, final MagicEvent event) {
-                game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(), MagicCounterType.PlusOne, n));
+                game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(), MagicCounterType.PlusOne, n));
                 game.doAction(ChangeStateAction.Set(event.getPermanent(), MagicPermanentState.Renowned));
             }
         };

--- a/src/magic/model/trigger/DamageIsDealtTrigger.java
+++ b/src/magic/model/trigger/DamageIsDealtTrigger.java
@@ -163,7 +163,7 @@ public abstract class DamageIsDealtTrigger extends MagicTrigger<MagicDamage> {
 
             @Override
             public void executeEvent(final MagicGame game, final MagicEvent event) {
-                game.doAction(new ChangeCountersAction(event.getRefPlayer(), MagicCounterType.Poison, n));
+                game.doAction(new ChangeCountersAction(event.getSource(), event.getRefPlayer(), MagicCounterType.Poison, n));
             }
         };
     }
@@ -192,7 +192,7 @@ public abstract class DamageIsDealtTrigger extends MagicTrigger<MagicDamage> {
 
             @Override
             public void executeEvent(final MagicGame game, final MagicEvent event) {
-                game.doAction(new ChangeCountersAction(event.getPermanent(), MagicCounterType.PlusOne, n));
+                game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(), MagicCounterType.PlusOne, n));
                 game.doAction(ChangeStateAction.Set(event.getPermanent(), MagicPermanentState.Renowned));
             }
         };

--- a/src/magic/model/trigger/DethroneTrigger.java
+++ b/src/magic/model/trigger/DethroneTrigger.java
@@ -30,6 +30,6 @@ public class DethroneTrigger extends ThisAttacksTrigger {
 
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
-        game.doAction(new ChangeCountersAction(event.getPermanent(),MagicCounterType.PlusOne,1));
+        game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(),MagicCounterType.PlusOne,1));
     }
 }

--- a/src/magic/model/trigger/DethroneTrigger.java
+++ b/src/magic/model/trigger/DethroneTrigger.java
@@ -30,6 +30,6 @@ public class DethroneTrigger extends ThisAttacksTrigger {
 
     @Override
     public void executeEvent(final MagicGame game, final MagicEvent event) {
-        game.doAction(new ChangeCountersAction(event.getSource(), event.getPermanent(),MagicCounterType.PlusOne,1));
+        game.doAction(new ChangeCountersAction(event.getPlayer(), event.getPermanent(),MagicCounterType.PlusOne,1));
     }
 }

--- a/src/magic/model/trigger/DevourTrigger.java
+++ b/src/magic/model/trigger/DevourTrigger.java
@@ -41,7 +41,7 @@ public class DevourTrigger extends EntersBattlefieldTrigger {
                 final MagicPermanent permanent = event.getPermanent();
                 game.doAction(new SacrificeAction(creature));
                 game.doAction(new ChangeCountersAction(
-                    event.getSource(),
+                    event.getPlayer(),
                     permanent,
                     MagicCounterType.PlusOne,
                     amount

--- a/src/magic/model/trigger/DevourTrigger.java
+++ b/src/magic/model/trigger/DevourTrigger.java
@@ -41,6 +41,7 @@ public class DevourTrigger extends EntersBattlefieldTrigger {
                 final MagicPermanent permanent = event.getPermanent();
                 game.doAction(new SacrificeAction(creature));
                 game.doAction(new ChangeCountersAction(
+                    event.getSource(),
                     permanent,
                     MagicCounterType.PlusOne,
                     amount

--- a/src/magic/model/trigger/EntersBattlefieldTrigger.java
+++ b/src/magic/model/trigger/EntersBattlefieldTrigger.java
@@ -138,6 +138,7 @@ public abstract class EntersBattlefieldTrigger extends MagicTrigger<MagicPayedCo
             private final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
                 if (event.isYes()) {
                     game.doAction(new ChangeCountersAction(
+                        event.getSource(),
                         event.getPermanent(),
                         MagicCounterType.PlusOne,
                         event.getRefInt()

--- a/src/magic/model/trigger/EntersBattlefieldTrigger.java
+++ b/src/magic/model/trigger/EntersBattlefieldTrigger.java
@@ -138,7 +138,7 @@ public abstract class EntersBattlefieldTrigger extends MagicTrigger<MagicPayedCo
             private final MagicEventAction EVENT_ACTION = (final MagicGame game, final MagicEvent event) -> {
                 if (event.isYes()) {
                     game.doAction(new ChangeCountersAction(
-                        event.getSource(),
+                        event.getPlayer(),
                         event.getPermanent(),
                         MagicCounterType.PlusOne,
                         event.getRefInt()

--- a/src/magic/model/trigger/FadeVanishCounterTrigger.java
+++ b/src/magic/model/trigger/FadeVanishCounterTrigger.java
@@ -64,6 +64,7 @@ public class FadeVanishCounterTrigger extends AtUpkeepTrigger {
 
     private static final MagicEventAction REMOVE_TIME_COUNTER = (final MagicGame game, final MagicEvent event) ->
         game.doAction(new ChangeCountersAction(
+            event.getSource(),
             event.getPermanent(),
             MagicCounterType.Time,
             -1
@@ -71,6 +72,7 @@ public class FadeVanishCounterTrigger extends AtUpkeepTrigger {
 
     private static final MagicEventAction REMOVE_AND_SAC = (final MagicGame game, final MagicEvent event) -> {
         game.doAction(new ChangeCountersAction(
+            event.getSource(),
             event.getPermanent(),
             MagicCounterType.Time,
             -1
@@ -80,6 +82,7 @@ public class FadeVanishCounterTrigger extends AtUpkeepTrigger {
 
     private static final MagicEventAction REMOVE_FADE_COUNTER = (final MagicGame game, final MagicEvent event) ->
         game.doAction(new ChangeCountersAction(
+            event.getSource(),
             event.getPermanent(),
             MagicCounterType.Fade,
             -1

--- a/src/magic/model/trigger/FadeVanishCounterTrigger.java
+++ b/src/magic/model/trigger/FadeVanishCounterTrigger.java
@@ -64,7 +64,7 @@ public class FadeVanishCounterTrigger extends AtUpkeepTrigger {
 
     private static final MagicEventAction REMOVE_TIME_COUNTER = (final MagicGame game, final MagicEvent event) ->
         game.doAction(new ChangeCountersAction(
-            event.getSource(),
+            event.getPlayer(),
             event.getPermanent(),
             MagicCounterType.Time,
             -1
@@ -72,7 +72,7 @@ public class FadeVanishCounterTrigger extends AtUpkeepTrigger {
 
     private static final MagicEventAction REMOVE_AND_SAC = (final MagicGame game, final MagicEvent event) -> {
         game.doAction(new ChangeCountersAction(
-            event.getSource(),
+            event.getPlayer(),
             event.getPermanent(),
             MagicCounterType.Time,
             -1
@@ -82,7 +82,7 @@ public class FadeVanishCounterTrigger extends AtUpkeepTrigger {
 
     private static final MagicEventAction REMOVE_FADE_COUNTER = (final MagicGame game, final MagicEvent event) ->
         game.doAction(new ChangeCountersAction(
-            event.getSource(),
+            event.getPlayer(),
             event.getPermanent(),
             MagicCounterType.Fade,
             -1

--- a/src/magic/model/trigger/MagicCounterChangeTriggerData.java
+++ b/src/magic/model/trigger/MagicCounterChangeTriggerData.java
@@ -2,6 +2,7 @@ package magic.model.trigger;
 
 import magic.model.MagicCounterType;
 import magic.model.MagicObject;
+import magic.model.MagicPlayer;
 
 public class MagicCounterChangeTriggerData {
 

--- a/src/magic/model/trigger/MagicCounterChangeTriggerData.java
+++ b/src/magic/model/trigger/MagicCounterChangeTriggerData.java
@@ -5,11 +5,13 @@ import magic.model.MagicObject;
 
 public class MagicCounterChangeTriggerData {
 
+    public final MagicPlayer player;
     public final MagicObject obj;
     public final MagicCounterType counterType;
     public final int amount;
 
-    public MagicCounterChangeTriggerData(final MagicObject aObj, final MagicCounterType aCounterType, final int aAmount) {
+    public MagicCounterChangeTriggerData(final MagicPlayer aPlayer, final MagicObject aObj, final MagicCounterType aCounterType, final int aAmount) {
+        this.player = aPlayer;
         this.obj = aObj;
         this.counterType = aCounterType;
         this.amount = aAmount;

--- a/src/magic/model/trigger/ModularTrigger.java
+++ b/src/magic/model/trigger/ModularTrigger.java
@@ -39,6 +39,7 @@ public class ModularTrigger extends ThisDiesTrigger {
         if (event.isYes()) {
             event.processTargetPermanent(game, (final MagicPermanent creature) ->
                 game.doAction(new ChangeCountersAction(
+                    event.getSource(),
                     creature,
                     MagicCounterType.PlusOne,
                     event.getRefInt()

--- a/src/magic/model/trigger/ModularTrigger.java
+++ b/src/magic/model/trigger/ModularTrigger.java
@@ -39,7 +39,7 @@ public class ModularTrigger extends ThisDiesTrigger {
         if (event.isYes()) {
             event.processTargetPermanent(game, (final MagicPermanent creature) ->
                 game.doAction(new ChangeCountersAction(
-                    event.getSource(),
+                    event.getPlayer(),
                     creature,
                     MagicCounterType.PlusOne,
                     event.getRefInt()

--- a/src/magic/model/trigger/OtherEntersBattlefieldTrigger.java
+++ b/src/magic/model/trigger/OtherEntersBattlefieldTrigger.java
@@ -73,7 +73,7 @@ public abstract class OtherEntersBattlefieldTrigger extends MagicTrigger<MagicPe
             if (event.getRefPermanent().getPowerValue() > event.getPermanent().getPowerValue() ||
                 event.getRefPermanent().getToughnessValue() > event.getPermanent().getToughnessValue()) {
                     game.doAction(new ChangeCountersAction(
-                        event.getSource(),
+                        event.getPlayer(),
                         event.getPermanent(),
                         MagicCounterType.PlusOne,
                         1
@@ -101,13 +101,13 @@ public abstract class OtherEntersBattlefieldTrigger extends MagicTrigger<MagicPe
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes() && event.getPermanent().hasCounters(MagicCounterType.PlusOne)) {
                 game.doAction(new ChangeCountersAction(
-                    event.getSource(),
+                    event.getPlayer(),
                     event.getPermanent(),
                     MagicCounterType.PlusOne,
                     -1
                 ));
                 game.doAction(new ChangeCountersAction(
-                    event.getSource(),
+                    event.getPlayer(),
                     event.getRefPermanent(),
                     MagicCounterType.PlusOne,
                     1

--- a/src/magic/model/trigger/OtherEntersBattlefieldTrigger.java
+++ b/src/magic/model/trigger/OtherEntersBattlefieldTrigger.java
@@ -73,6 +73,7 @@ public abstract class OtherEntersBattlefieldTrigger extends MagicTrigger<MagicPe
             if (event.getRefPermanent().getPowerValue() > event.getPermanent().getPowerValue() ||
                 event.getRefPermanent().getToughnessValue() > event.getPermanent().getToughnessValue()) {
                     game.doAction(new ChangeCountersAction(
+                        event.getSource(),
                         event.getPermanent(),
                         MagicCounterType.PlusOne,
                         1
@@ -100,11 +101,13 @@ public abstract class OtherEntersBattlefieldTrigger extends MagicTrigger<MagicPe
         public void executeEvent(final MagicGame game, final MagicEvent event) {
             if (event.isYes() && event.getPermanent().hasCounters(MagicCounterType.PlusOne)) {
                 game.doAction(new ChangeCountersAction(
+                    event.getSource(),
                     event.getPermanent(),
                     MagicCounterType.PlusOne,
                     -1
                 ));
                 game.doAction(new ChangeCountersAction(
+                    event.getSource(),
                     event.getRefPermanent(),
                     MagicCounterType.PlusOne,
                     1

--- a/src/magic/model/trigger/TributeTrigger.java
+++ b/src/magic/model/trigger/TributeTrigger.java
@@ -20,7 +20,7 @@ public abstract class TributeTrigger extends EntersBattlefieldTrigger {
         final MagicPermanent permanent = event.getPermanent();
         if (event.isYes()) {
             game.doAction(new ChangeCountersAction(
-                event.getSource(),
+                event.getPlayer().getOpponent(),
                 permanent,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/model/trigger/TributeTrigger.java
+++ b/src/magic/model/trigger/TributeTrigger.java
@@ -20,6 +20,7 @@ public abstract class TributeTrigger extends EntersBattlefieldTrigger {
         final MagicPermanent permanent = event.getPermanent();
         if (event.isYes()) {
             game.doAction(new ChangeCountersAction(
+                event.getSource(),
                 permanent,
                 MagicCounterType.PlusOne,
                 event.getRefInt()

--- a/src/magic/test/TestSoulbond.java
+++ b/src/magic/test/TestSoulbond.java
@@ -48,7 +48,7 @@ class TestSoulbond extends TestGameBuilder {
         createPermanent(P,"Assault Griffin",false,1);
         createPermanent(P,"Hagra Diabolist",false,1);
         final MagicPermanent la = createPermanent(P, "Legacy's Allure", false, 1);
-        game.doAction(new ChangeCountersAction(la, MagicCounterType.Charge, 3));
+        game.doAction(new ChangeCountersAction(P, la, MagicCounterType.Charge, 3));
         addToHand(P,"Wingcrafter",1);
         addToHand(P,"Eager Cadet",1);
 

--- a/src/magic/test/TestTyreal.java
+++ b/src/magic/test/TestTyreal.java
@@ -41,8 +41,8 @@ class TestTyreal extends TestGameBuilder {
     createPermanent(P, "Rupture Spire", false, 10);
     createPermanent(P, "Mad Auntie", false, 1);
     final MagicPermanent la = createPermanent(P, "Legacy's Allure", false, 1);
-    game.doAction(new ChangeCountersAction(la, MagicCounterType.Charge, 1));
-    //game.doAction(new MagicChangeCountersAction(la, MagicCounterType.Charge, 1));
+    game.doAction(new ChangeCountersAction(P, la, MagicCounterType.Charge, 1));
+    //game.doAction(new MagicChangeCountersAction(P, la, MagicCounterType.Charge, 1));
     //createPermanent(P, "Mad Auntie", false, 1);
     // createPermanent(P,"Jayemdae Tome",false,1);
 


### PR DESCRIPTION
This adds a `player` argument to `ChangeCountersAction` and `MagicCounterChangeTriggerData` so that abilities that check for "you put counter" is possible.

At first, I thought about adding `source` argument to infer the player, but some abilities cause the opponent to put counter (like Tribute). I found that the oracle text always have "a player puts counters" so it would be more appropriate to add `player` argument.

Fixes #1518 