### PR TITLE
Add Saga mechanic

### DIFF
--- a/release/Magarena/scripts/History_of_Benalia.txt
+++ b/release/Magarena/scripts/History_of_Benalia.txt
@@ -5,7 +5,7 @@ rarity=M
 type=Enchantment
 subtype=Saga
 cost={1}{W}{W}
-ability=Create a 2/2 white Knight creature token with vigilance.;\
-        Knights you control get +2/+1 until end of turn.
+ability=I, II — Create a 2/2 white Knight creature token with vigilance.;\
+        III — Knights you control get +2/+1 until end of turn.
 timing=enchantment
 oracle=I, II — Create a 2/2 white Knight creature token with vigilance.\nIII — Knights you control get +2/+1 until end of turn.

--- a/src/magic/data/RomanToInt.java
+++ b/src/magic/data/RomanToInt.java
@@ -3,10 +3,6 @@ package magic.data;
 public class RomanToInt {
 
     public static int convert(String num) {
-        if (num == null) {
-            return 1;
-        }
-
         // Only support 1-3 for now since Sagas only have these numbers
         switch (num) {
             case "I": return 1;

--- a/src/magic/data/RomanToInt.java
+++ b/src/magic/data/RomanToInt.java
@@ -1,0 +1,18 @@
+package magic.data;
+
+public class RomanToInt {
+
+    public static int convert(String num) {
+        if (num == null) {
+            return 1;
+        }
+
+        // Only support 1-3 for now since Sagas only have these numbers
+        switch (num) {
+            case "I": return 1;
+            case "II": return 2;
+            case "III": return 3;
+            default: throw new RuntimeException("unknown roman numeral \"" + num + "\"");
+        }
+    }
+}

--- a/src/magic/model/ARG.java
+++ b/src/magic/model/ARG.java
@@ -1,9 +1,11 @@
 package magic.model;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import magic.data.EnglishToInt;
+import magic.data.RomanToInt;
 import magic.model.action.MagicPlayMod;
 import magic.model.event.MagicEvent;
 import magic.model.stack.MagicItemOnStack;
@@ -320,4 +322,11 @@ public class ARG {
             return MagicTargetFilterFactory.SPELL_OR_ABILITY;
         }
     }
+
+    public static final String CHAPTERS = "(?<chapters>I+(, I+)*)";
+    public static int[] chapters(final Matcher m) {
+        final String[] chapters = m.group("chapters").split(", ");
+        return Arrays.stream(chapters).mapToInt(RomanToInt::convert).toArray();
+    }
+
 }

--- a/src/magic/model/IRenderableCard.java
+++ b/src/magic/model/IRenderableCard.java
@@ -78,6 +78,10 @@ public interface IRenderableCard {
         return hasType(MagicType.Sorcery);
     }
 
+    default boolean isSaga() {
+        return isEnchantment() && hasSubType(MagicSubType.Saga);
+    }
+
     default boolean isHidden() {
         return getCardDefinition().isHidden();
     }

--- a/src/magic/model/MagicAbility.java
+++ b/src/magic/model/MagicAbility.java
@@ -639,6 +639,16 @@ public enum MagicAbility {
             card.add(MagicStatic.Ascend);
         }
     },
+    Chapter(ARG.CHAPTERS + " — " + ARG.EFFECT, 0) {
+        @Override
+        protected void addAbilityImpl(final MagicAbilityStore card, final Matcher arg) {
+            final int[] chapters = ARG.chapters(arg);
+            final MagicSourceEvent sourceEvent = MagicRuleEventAction.create(ARG.effect(arg));
+            for (int chapter : chapters) {
+                card.add(SagaChapterTrigger.create(chapter, sourceEvent));
+            }
+        }
+    },
 
     // abilities that involve SN
     ShockLand("As SN enters the battlefield, you may " + ARG.COST + "\\. If you don't, SN enters the battlefield tapped\\.", -10) {

--- a/src/magic/model/MagicCardDefinition.java
+++ b/src/magic/model/MagicCardDefinition.java
@@ -242,7 +242,6 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
         }
         if (isSaga() && etbTriggers.isEmpty()) {
             add(new EntersWithCounterTrigger(MagicCounterType.Lore, 1));
-            add(AtBeginOfFirstMainPhaseTrigger.Saga);
         }
         if (requiresGroovy != null) {
             CardProperty.LOAD_GROOVY_CODE.setProperty(this, requiresGroovy);

--- a/src/magic/model/MagicCardDefinition.java
+++ b/src/magic/model/MagicCardDefinition.java
@@ -242,6 +242,7 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
         }
         if (isSaga() && etbTriggers.isEmpty()) {
             add(new EntersWithCounterTrigger(MagicCounterType.Lore, 1));
+            add(AtBeginOfFirstMainPhaseTrigger.Saga);
         }
         if (requiresGroovy != null) {
             CardProperty.LOAD_GROOVY_CODE.setProperty(this, requiresGroovy);

--- a/src/magic/model/MagicCardDefinition.java
+++ b/src/magic/model/MagicCardDefinition.java
@@ -515,10 +515,6 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
         return isEnchantment() && hasSubType(MagicSubType.Aura);
     }
 
-    public boolean isSaga() {
-        return isEnchantment() && hasSubType(MagicSubType.Saga);
-    }
-
     public boolean isSpell() {
         return isInstant()||isSorcery();
     }

--- a/src/magic/model/MagicCardDefinition.java
+++ b/src/magic/model/MagicCardDefinition.java
@@ -9,6 +9,7 @@ import magic.model.event.*;
 import magic.model.mstatic.MagicCDA;
 import magic.model.mstatic.MagicStatic;
 import magic.model.condition.MagicCondition;
+import magic.model.trigger.AtBeginOfFirstMainPhaseTrigger;
 import magic.model.trigger.EntersBattlefieldTrigger;
 import magic.model.trigger.EntersWithCounterTrigger;
 import magic.model.trigger.MagicTrigger;
@@ -238,6 +239,10 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
                 MagicCounterType.Loyalty,
                 startingLoyalty
             ));
+        }
+        if (isSaga()) {
+            add(new EntersWithCounterTrigger(MagicCounterType.Lore, 1));
+            add(AtBeginOfFirstMainPhaseTrigger.Saga);
         }
         if (requiresGroovy != null) {
             CardProperty.LOAD_GROOVY_CODE.setProperty(this, requiresGroovy);
@@ -508,6 +513,10 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
 
     public boolean isAura() {
         return isEnchantment() && hasSubType(MagicSubType.Aura);
+    }
+
+    public boolean isSaga() {
+        return isEnchantment() && hasSubType(MagicSubType.Saga);
     }
 
     public boolean isSpell() {

--- a/src/magic/model/MagicCardDefinition.java
+++ b/src/magic/model/MagicCardDefinition.java
@@ -240,7 +240,7 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
                 startingLoyalty
             ));
         }
-        if (isSaga()) {
+        if (isSaga() && etbTriggers.isEmpty()) {
             add(new EntersWithCounterTrigger(MagicCounterType.Lore, 1));
             add(AtBeginOfFirstMainPhaseTrigger.Saga);
         }

--- a/src/magic/model/MagicPermanent.java
+++ b/src/magic/model/MagicPermanent.java
@@ -1182,10 +1182,6 @@ public class MagicPermanent extends MagicObjectImpl implements MagicSource, Magi
         return isEnchantment() && hasSubType(MagicSubType.Aura);
     }
 
-    public boolean isSaga() {
-        return isEnchantment() && hasSubType(MagicSubType.Saga);
-    }
-
     public boolean isFaceDown() {
         return hasState(MagicPermanentState.FaceDown);
     }

--- a/src/magic/model/MagicPermanent.java
+++ b/src/magic/model/MagicPermanent.java
@@ -883,6 +883,19 @@ public class MagicPermanent extends MagicObjectImpl implements MagicSource, Magi
             game.addDelayedAction(new RemoveFromPlayAction(this, MagicLocationType.Graveyard));
         }
 
+        // Only support Sagas with 3 chapters for now.
+        // The comprehensive rules doesn't say that all Sagas must have exactly 3 chapters though.
+        if (isSaga() && getCounters(MagicCounterType.Lore) >= 3 &&
+                game.getStack().stream().noneMatch(item -> item.getSource() == this) &&
+                game.getPendingStack().stream().noneMatch(item -> item.getSource() == this)) {
+
+            game.logAppendMessage(
+                getController(),
+                MagicMessage.format("Sacrifice %s.", this)
+            );
+            game.addDelayedAction(new SacrificeAction(this));
+        }
+
         // +1/+1 and -1/-1 counters cancel each other out.
         final int plusCounters = getCounters(MagicCounterType.PlusOne);
         if (plusCounters > 0) {
@@ -1166,6 +1179,10 @@ public class MagicPermanent extends MagicObjectImpl implements MagicSource, Magi
 
     public boolean isAura() {
         return isEnchantment() && hasSubType(MagicSubType.Aura);
+    }
+
+    public boolean isSaga() {
+        return isEnchantment() && hasSubType(MagicSubType.Saga);
     }
 
     public boolean isFaceDown() {

--- a/src/magic/model/MagicPermanent.java
+++ b/src/magic/model/MagicPermanent.java
@@ -888,7 +888,7 @@ public class MagicPermanent extends MagicObjectImpl implements MagicSource, Magi
         // The comprehensive rules doesn't say that all Sagas must have exactly 3 chapters though.
         if (isSaga() && getCounters(MagicCounterType.Lore) >= 3 &&
                 game.getStack().stream().noneMatch(item -> item.getSource() == this) &&
-                game.getPendingStack().stream().noneMatch(item -> item.getSource() == this)) {
+                game.getPendingTriggers().stream().noneMatch(item -> item.getSource() == this)) {
 
             game.logAppendMessage(
                 getController(),

--- a/src/magic/model/MagicPermanent.java
+++ b/src/magic/model/MagicPermanent.java
@@ -20,6 +20,7 @@ import magic.model.action.ChangeCountersAction;
 import magic.model.action.ChangeStateAction;
 import magic.model.action.DestroyAction;
 import magic.model.action.RemoveFromPlayAction;
+import magic.model.action.SacrificeAction;
 import magic.model.action.SoulbondAction;
 import magic.model.choice.MagicTargetChoice;
 import magic.model.event.MagicActivation;

--- a/src/magic/model/phase/MagicMainPhase.java
+++ b/src/magic/model/phase/MagicMainPhase.java
@@ -1,6 +1,10 @@
 package magic.model.phase;
 
+import magic.model.MagicCounterType;
 import magic.model.MagicGame;
+import magic.model.MagicPermanent;
+import magic.model.MagicPlayer;
+import magic.model.action.ChangeCountersAction;
 import magic.model.trigger.MagicTriggerType;
 
 public class MagicMainPhase extends MagicPhase {
@@ -22,7 +26,14 @@ public class MagicMainPhase extends MagicPhase {
 
     @Override
     public void executeBeginStep(final MagicGame game) {
+
+        final MagicPlayer player = game.getTurnPlayer();
+
         if (this == FIRST_INSTANCE) {
+            player.getPermanents().stream().filter(MagicPermanent::isSaga).forEach(
+                permanent -> game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1))
+            );
+
             game.executeTrigger(MagicTriggerType.AtBeginOfFirstMainPhase,game.getTurnPlayer());
         }
 

--- a/src/magic/model/phase/MagicMainPhase.java
+++ b/src/magic/model/phase/MagicMainPhase.java
@@ -1,6 +1,7 @@
 package magic.model.phase;
 
 import magic.model.MagicGame;
+import magic.model.trigger.MagicTriggerType;
 
 public class MagicMainPhase extends MagicPhase {
 
@@ -21,6 +22,10 @@ public class MagicMainPhase extends MagicPhase {
 
     @Override
     public void executeBeginStep(final MagicGame game) {
+        if (this == FIRST_INSTANCE) {
+            game.executeTrigger(MagicTriggerType.AtBeginOfFirstMainPhase,game.getTurnPlayer());
+        }
+
         game.setStep(MagicStep.ActivePlayer);
     }
 

--- a/src/magic/model/phase/MagicMainPhase.java
+++ b/src/magic/model/phase/MagicMainPhase.java
@@ -1,10 +1,6 @@
 package magic.model.phase;
 
-import magic.model.MagicCounterType;
 import magic.model.MagicGame;
-import magic.model.MagicPermanent;
-import magic.model.MagicPlayer;
-import magic.model.action.ChangeCountersAction;
 import magic.model.trigger.MagicTriggerType;
 
 public class MagicMainPhase extends MagicPhase {
@@ -26,14 +22,7 @@ public class MagicMainPhase extends MagicPhase {
 
     @Override
     public void executeBeginStep(final MagicGame game) {
-
-        final MagicPlayer player = game.getTurnPlayer();
-
         if (this == FIRST_INSTANCE) {
-            player.getPermanents().stream().filter(MagicPermanent::isSaga).forEach(
-                permanent -> game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1))
-            );
-
             game.executeTrigger(MagicTriggerType.AtBeginOfFirstMainPhase,game.getTurnPlayer());
         }
 

--- a/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
+++ b/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
@@ -19,16 +19,18 @@ public abstract class AtBeginOfFirstMainPhaseTrigger extends MagicTrigger<MagicP
         return MagicTriggerType.AtBeginOfFirstMainPhase;
     }
 
-    public static final AtBeginOfFirstMainPhaseTrigger LoreCounter = new AtBeginOfFirstMainPhaseTrigger() {
-        @Override
-        public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
-            return permanent.isController(player);
-        }
-        @Override
-        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
-            game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1));
-            return MagicEvent.NONE;
-        }
-    };
+    public static final AtBeginOfFirstMainPhaseTrigger YourAddCounter(final MagicCounterType counterType) {
+        return new AtBeginOfFirstMainPhaseTrigger() {
+            @Override
+            public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
+                return permanent.isController(player);
+            }
+            @Override
+            public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
+                game.doAction(new ChangeCountersAction(player, permanent, counterType, 1));
+                return MagicEvent.NONE;
+            }
+        };
+    }
 
 }

--- a/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
+++ b/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
@@ -19,16 +19,4 @@ public abstract class AtBeginOfFirstMainPhaseTrigger extends MagicTrigger<MagicP
         return MagicTriggerType.AtBeginOfFirstMainPhase;
     }
 
-    public static final AtBeginOfFirstMainPhaseTrigger Saga = new AtBeginOfFirstMainPhaseTrigger() {
-        @Override
-        public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
-            return permanent.isController(player);
-        }
-        @Override
-        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
-            game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1));
-            return MagicEvent.NONE;
-        }
-    };
-
 }

--- a/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
+++ b/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
@@ -19,18 +19,16 @@ public abstract class AtBeginOfFirstMainPhaseTrigger extends MagicTrigger<MagicP
         return MagicTriggerType.AtBeginOfFirstMainPhase;
     }
 
-    public static final AtBeginOfFirstMainPhaseTrigger YourAddCounter(final MagicCounterType counterType) {
-        return new AtBeginOfFirstMainPhaseTrigger() {
-            @Override
-            public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
-                return permanent.isController(player);
-            }
-            @Override
-            public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
-                game.doAction(new ChangeCountersAction(player, permanent, counterType, 1));
-                return MagicEvent.NONE;
-            }
-        };
-    }
+    public static final AtBeginOfFirstMainPhaseTrigger Saga = new AtBeginOfFirstMainPhaseTrigger() {
+        @Override
+        public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
+            return permanent.isController(player);
+        }
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
+            game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1));
+            return MagicEvent.NONE;
+        }
+    };
 
 }

--- a/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
+++ b/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
@@ -19,4 +19,16 @@ public abstract class AtBeginOfFirstMainPhaseTrigger extends MagicTrigger<MagicP
         return MagicTriggerType.AtBeginOfFirstMainPhase;
     }
 
+    public static final AtBeginOfFirstMainPhaseTrigger Saga = new AtBeginOfFirstMainPhaseTrigger() {
+        @Override
+        public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
+            return permanent.isController(player);
+        }
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
+            game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1));
+            return MagicEvent.NONE;
+        }
+    };
+
 }

--- a/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
+++ b/src/magic/model/trigger/AtBeginOfFirstMainPhaseTrigger.java
@@ -1,0 +1,34 @@
+package magic.model.trigger;
+
+import magic.model.MagicCounterType;
+import magic.model.MagicGame;
+import magic.model.MagicPermanent;
+import magic.model.MagicPlayer;
+import magic.model.action.ChangeCountersAction;
+import magic.model.event.MagicEvent;
+
+public abstract class AtBeginOfFirstMainPhaseTrigger extends MagicTrigger<MagicPlayer> {
+    public AtBeginOfFirstMainPhaseTrigger(final int priority) {
+        super(priority);
+    }
+
+    public AtBeginOfFirstMainPhaseTrigger() {}
+
+    @Override
+    public MagicTriggerType getType() {
+        return MagicTriggerType.AtBeginOfFirstMainPhase;
+    }
+
+    public static final AtBeginOfFirstMainPhaseTrigger LoreCounter = new AtBeginOfFirstMainPhaseTrigger() {
+        @Override
+        public boolean accept(final MagicPermanent permanent, final MagicPlayer player) {
+            return permanent.isController(player);
+        }
+        @Override
+        public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicPlayer player) {
+            game.doAction(new ChangeCountersAction(player, permanent, MagicCounterType.Lore, 1));
+            return MagicEvent.NONE;
+        }
+    };
+
+}

--- a/src/magic/model/trigger/MagicTriggerType.java
+++ b/src/magic/model/trigger/MagicTriggerType.java
@@ -5,6 +5,7 @@ public enum MagicTriggerType {
     AtUpkeep,               // player
     AtDraw,                 // player
     AtEndOfTurn,            // player
+    AtBeginOfFirstMainPhase,     // player
     AtBeginOfCombat,        // player
     AtEndOfCombat,          // player
     WhenDamageIsDealt,      // damage

--- a/src/magic/model/trigger/SagaChapterTrigger.java
+++ b/src/magic/model/trigger/SagaChapterTrigger.java
@@ -1,0 +1,43 @@
+package magic.model.trigger;
+
+import magic.model.MagicCounterType;
+import magic.model.MagicGame;
+import magic.model.MagicPermanent;
+import magic.model.event.MagicEvent;
+import magic.model.event.MagicSourceEvent;
+import magic.model.target.MagicTargetFilter;
+
+public abstract class SagaChapterTrigger extends OneOrMoreCountersArePutTrigger {
+
+    protected int chapter;
+
+    public SagaChapterTrigger(final int priority, final int chapter) {
+        super(priority);
+        this.chapter = chapter;
+    }
+
+    public SagaChapterTrigger(final int chapter) {
+        this.chapter = chapter;
+    }
+
+    @Override
+    public boolean accept(final MagicPermanent permanent, final MagicCounterChangeTriggerData data) {
+        final int current = permanent.getCounters(MagicCounterType.Lore);
+        final int before = current - data.amount;
+        return super.accept(permanent, data) &&
+            permanent == data.obj &&
+            data.counterType == MagicCounterType.Lore &&
+            before < chapter &&
+            current >= chapter;
+    }
+
+    public static SagaChapterTrigger create(final int chapter, final MagicSourceEvent sourceEvent) {
+        return new SagaChapterTrigger(chapter) {
+            @Override
+            public MagicEvent executeTrigger(final MagicGame game,final MagicPermanent permanent, final MagicCounterChangeTriggerData data) {
+                return sourceEvent.getTriggerEvent(permanent);
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
- Added putting lore counter on Saga when it enters the battlefield
- Added the turn-based action that puts a lore counter on Saga at beginning of first main phase
  - `AtBeginOfFirstMainPhaseTrigger` is actually unnecessary, but it's already added in earlier commits so I keep it here
- Added the state-based action where the Saga is sacrificed after resolving the third chapter
  - Although the comprehensive rules doesn't specify that all Sagas have exactly three chapters, I only check for the third chapter for now
- Added `SagaChapterTrigger` to represent chapter ability
- Added `RomanToInt` class to convert roman numeral, currently only support I, II, and III.
- Added chapter ability to card script
- Tested in-game using History of Benalia, which is also added in this pull request.

Fixes #1538 