### PR TITLE
Unlimited-number cards

### DIFF
--- a/release/Magarena/scripts/Rat_Colony.txt
+++ b/release/Magarena/scripts/Rat_Colony.txt
@@ -6,7 +6,6 @@ type=Creature
 subtype=Rat
 cost={1}{B}
 pt=2/1
-ability=SN gets +1/+0 for each other Rat you control.;\
-        A deck can have any number of cards named Rat Colony.
+ability=SN gets +1/+0 for each other Rat you control.
 timing=main
 oracle=Rat Colony gets +1/+0 for each other Rat you control.\nA deck can have any number of cards named Rat Colony.

--- a/src/magic/model/MagicCardDefinition.java
+++ b/src/magic/model/MagicCardDefinition.java
@@ -159,8 +159,7 @@ public class MagicCardDefinition implements MagicAbilityStore, IRenderableCard {
 
     public boolean canHaveAnyNumberInDeck() {
         return hasType(MagicType.Basic)
-                || name.equals("Relentless Rats")
-                || name.equals("Shadowborn Apostle");
+                || MagicDeckConstructionRule.isUnlimitedCard(name);
     }
 
     protected void initialize() {}

--- a/src/magic/model/MagicDeckConstructionRule.java
+++ b/src/magic/model/MagicDeckConstructionRule.java
@@ -1,7 +1,10 @@
 package magic.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public enum MagicDeckConstructionRule {
 
@@ -31,13 +34,40 @@ public enum MagicDeckConstructionRule {
 
         final MagicCondensedDeck countedDeck = new MagicCondensedDeck(deck);
         for (final MagicCondensedCardDefinition countedCard : countedDeck) {
-            if (countedCard.getNumCopies() > 4 && !countedCard.getCard().isBasic() && !"Shadowborn Apostle".equals(countedCard.getCard().getName()) && !"Relentless Rats".equals(countedCard.getCard().getName())) {
+            if (countedCard.getNumCopies() > 4 && !countedCard.getCard().isBasic() && !isUnlimitedCard(countedCard.getCard().getName())) {
                 brokenRules.add(FourCopyLimit);
                 break;
             }
         }
 
         return brokenRules;
+    }
+
+    private static final Set<String> UNLIMITED_CARDS = new HashSet<>(Arrays.asList(
+            "Shadowborn Apostle", "Rat Colony", "Relentless Rats"
+    ));
+
+    /**
+     * @return true if card does have "A deck can have any number of this card" feature
+     */
+    public static boolean isUnlimitedCard(String countedCard) {
+        return UNLIMITED_CARDS.contains(countedCard);
+    }
+
+    /**
+     * @return list of cards that can be in deck any number of times, separated by given string
+     */
+    public static String unlimitedCardList(String separator) {
+        StringBuilder out = new StringBuilder();
+        boolean first = true;
+        for (String i : UNLIMITED_CARDS) {
+            if (!first) {
+                out.append(separator);
+            }
+            out.append(i);
+            first = false;
+        }
+        return out.toString();
     }
 
     public static String getRulesText(final List<MagicDeckConstructionRule> rules) {

--- a/src/magic/ui/widget/deck/legality/LegalityPanel.java
+++ b/src/magic/ui/widget/deck/legality/LegalityPanel.java
@@ -10,6 +10,7 @@ import javax.swing.JPanel;
 import magic.data.MagicIcon;
 import magic.model.MagicCardDefinition;
 import magic.model.MagicDeck;
+import magic.model.MagicDeckConstructionRule;
 import magic.translate.MText;
 import magic.ui.MagicImages;
 import magic.ui.screen.deck.editor.IDeckEditorView;
@@ -122,11 +123,12 @@ public class LegalityPanel extends JPanel
             add(getIconLabel(MagicIcon.ILLEGAL, MText.get(_S2)));
             add(getIconLabel(MagicIcon.BANNED, MText.get(_S3)));
             add(getIconLabel(MagicIcon.RESTRICTED, MText.get(_S4), MText.get(_S5)));
+            String unlimitedList = MagicDeckConstructionRule.unlimitedCardList("</i> " + MText.get(_S9) + " <i>");
             add(getIconLabel(MagicIcon.RESTRICTED, MText.get(_S6),
-                    String.format("<html><b>%s</b><br>%s<br><i>Relentless Rats</i> %s <i>Shadowborn Apostle</i>.</html>",
+                    String.format("<html><b>%s</b><br>%s<br><i>%s</i>.</html>",
                             MText.get(_S7),
                             MText.get(_S8),
-                            MText.get(_S9))
+                            unlimitedList)
             ));
         }
 


### PR DESCRIPTION
Refactoring: Store list of "can be any times in deck" cards in one central location.
Add Rat Colony to the list and also as an implemented card.

I thought also of adding all parseable Dominaria cards, but I am not sure what script/process is used for that. So this contains only the refactoring and the Rat Colony