### PR TITLE
Follow symlinks when loading decks

### DIFF
--- a/src/magic/utility/DeckUtils.java
+++ b/src/magic/utility/DeckUtils.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import magic.model.MagicRandom;
 import magic.utility.MagicFileSystem.DataPath;
 import org.apache.commons.io.FilenameUtils;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
 public class DeckUtils {
 
@@ -269,7 +271,8 @@ public class DeckUtils {
     public static List<File> getDeckFiles() {
         try {
             DeckFileVisitor dfv = new DeckFileVisitor();
-            Files.walkFileTree(MagicFileSystem.getDataPath(DataPath.DECKS), dfv);
+            Files.walkFileTree(MagicFileSystem.getDataPath(DataPath.DECKS), Collections.singleton(FOLLOW_LINKS),
+                    Integer.MAX_VALUE, dfv);
             return dfv.getFiles();
         } catch (IOException ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
Currently magarena does not follow symlinks when loading decks (and for example failing to load any decks if the directory "decks" itself is a symlink to another directory with actual decks).

This patch tells it to follow symlinks when looking for decks.

In theory, the only disadvantage that this could have is if there would be infinite link loop under the decks directory with symlinks, but I don't think that would be the usual case