### PR TITLE
Add missing cards (GRN, C18 + few others)

### DIFF
--- a/release/Magarena/scripts_missing/Accorder_Paladin.txt
+++ b/release/Magarena/scripts_missing/Accorder_Paladin.txt
@@ -1,0 +1,11 @@
+name=Accorder Paladin
+image=https://img.scryfall.com/cards/normal/en/mbs/1.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Knight
+cost={1}{W}
+pt=3/1
+ability=Battle cry
+timing=main
+oracle=Battle cry

--- a/release/Magarena/scripts_missing/Affectionate_Indrik.txt
+++ b/release/Magarena/scripts_missing/Affectionate_Indrik.txt
@@ -1,0 +1,11 @@
+name=Affectionate Indrik
+image=https://img.scryfall.com/cards/normal/front/b/4/b4c8ddc1-d95c-499f-b1d1-f608f8f07b02.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Beast
+cost={5}{G}
+pt=4/4
+ability=When SN enters the battlefield, you may have it fight target creature you don't control.
+timing=main
+oracle=When Affectionate Indrik enters the battlefield, you may have it fight target creature you don't control.

--- a/release/Magarena/scripts_missing/Aminatou__the_Fateshifter.txt
+++ b/release/Magarena/scripts_missing/Aminatou__the_Fateshifter.txt
@@ -1,0 +1,14 @@
+name=Aminatou, the Fateshifter
+image=https://img.scryfall.com/cards/normal/en/c18/37.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Aminatou
+cost={W}{U}{B}
+loyalty=3
+ability=+1: Draw a card, then put a card from your hand on top of your library.;\
+        −1: Exile another target permanent you own, then return it to the battlefield under your control.;\
+        −6: Choose left or right. Each player gains control of all nonland permanents other than SN controlled by the next player in the chosen direction.;\
+        SN can be your commander.
+timing=main
+oracle=+1: Draw a card, then put a card from your hand on top of your library.\n−1: Exile another target permanent you own, then return it to the battlefield under your control.\n−6: Choose left or right. Each player gains control of all nonland permanents other than Aminatou, the Fateshifter controlled by the next player in the chosen direction.\nAminatou, the Fateshifter can be your commander.

--- a/release/Magarena/scripts_missing/Aminatou_s_Augury.txt
+++ b/release/Magarena/scripts_missing/Aminatou_s_Augury.txt
@@ -1,0 +1,9 @@
+name=Aminatou's Augury
+image=https://img.scryfall.com/cards/normal/en/c18/6.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={6}{U}{U}
+effect=Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a card of that type from among the exiled cards without paying its mana cost.
+timing=main
+oracle=Exile the top eight cards of your library. You may put a land card from among them onto the battlefield. Until end of turn, for each nonland card type, you may cast a card of that type from among the exiled cards without paying its mana cost.

--- a/release/Magarena/scripts_missing/Amulet_of_Quoz.txt
+++ b/release/Magarena/scripts_missing/Amulet_of_Quoz.txt
@@ -1,0 +1,10 @@
+name=Amulet of Quoz
+image=https://img.scryfall.com/cards/normal/en/ice/308.jpg
+value=2.500
+rarity=R
+type=Artifact
+cost={6}
+ability=Remove SN from your deck before playing if you're not playing for ante.;\
+        {T}, Sacrifice SN: Target opponent may ante the top card of their library. If they don't, you flip a coin. If you win the flip, that player loses the game. If you lose the flip, you lose the game. Activate this ability only during your upkeep.
+timing=artifact
+oracle=Remove Amulet of Quoz from your deck before playing if you're not playing for ante.\n{T}, Sacrifice Amulet of Quoz: Target opponent may ante the top card of their library. If they don't, you flip a coin. If you win the flip, that player loses the game. If you lose the flip, you lose the game. Activate this ability only during your upkeep.

--- a/release/Magarena/scripts_missing/Amulet_of_Quoz.txt
+++ b/release/Magarena/scripts_missing/Amulet_of_Quoz.txt
@@ -8,3 +8,4 @@ ability=Remove SN from your deck before playing if you're not playing for ante.;
         {T}, Sacrifice SN: Target opponent may ante the top card of their library. If they don't, you flip a coin. If you win the flip, that player loses the game. If you lose the flip, you lose the game. Activate this ability only during your upkeep.
 timing=artifact
 oracle=Remove Amulet of Quoz from your deck before playing if you're not playing for ante.\n{T}, Sacrifice Amulet of Quoz: Target opponent may ante the top card of their library. If they don't, you flip a coin. If you win the flip, that player loses the game. If you lose the flip, you lose the game. Activate this ability only during your upkeep.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Ancient_Stone_Idol.txt
+++ b/release/Magarena/scripts_missing/Ancient_Stone_Idol.txt
@@ -1,0 +1,14 @@
+name=Ancient Stone Idol
+image=https://img.scryfall.com/cards/normal/en/c18/53.jpg
+value=2.500
+rarity=R
+type=Artifact,Creature
+subtype=Golem
+cost={10}
+pt=12/12
+ability=Flash;\
+        This spell costs {1} less to cast for each attacking creature.;\
+        Trample;\
+        When SN dies, create a 6/12 colorless Construct artifact creature token with trample.
+timing=flash
+oracle=Flash\nThis spell costs {1} less to cast for each attacking creature.\nTrample\nWhen Ancient Stone Idol dies, create a 6/12 colorless Construct artifact creature token with trample.

--- a/release/Magarena/scripts_missing/Arboretum_Elemental.txt
+++ b/release/Magarena/scripts_missing/Arboretum_Elemental.txt
@@ -1,0 +1,12 @@
+name=Arboretum Elemental
+image=https://img.scryfall.com/cards/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elemental
+cost={7}{G}{G}
+pt=7/5
+ability=Convoke;\
+        Hexproof
+timing=main
+oracle=Convoke\nHexproof

--- a/release/Magarena/scripts_missing/Arclight_Phoenix.txt
+++ b/release/Magarena/scripts_missing/Arclight_Phoenix.txt
@@ -1,0 +1,12 @@
+name=Arclight Phoenix
+image=https://img.scryfall.com/cards/normal/front/7/8/787de9ce-02c5-4a17-a88b-d38e83dbeb0b.jpg
+value=2.500
+rarity=M
+type=Creature
+subtype=Phoenix
+cost={3}{R}
+pt=3/2
+ability=Flying, haste;\
+        At the beginning of combat on your turn, if you've cast three or more instant and sorcery spells this turn, return SN from your graveyard to the battlefield.
+timing=main
+oracle=Flying, haste\nAt the beginning of combat on your turn, if you've cast three or more instant and sorcery spells this turn, return Arclight Phoenix from your graveyard to the battlefield.

--- a/release/Magarena/scripts_missing/Arixmethes__Slumbering_Isle.txt
+++ b/release/Magarena/scripts_missing/Arixmethes__Slumbering_Isle.txt
@@ -1,0 +1,14 @@
+name=Arixmethes, Slumbering Isle
+image=https://img.scryfall.com/cards/normal/en/c18/38.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Kraken
+cost={2}{G}{U}
+pt=12/12
+ability=SN enters the battlefield tapped with five slumber counters on it.;\
+        As long as Arixmethes has a slumber counter on it, it's a land.;\
+        Whenever you cast a spell, you may remove a slumber counter from Arixmethes.;\
+        {T}: Add {G}{U}.
+timing=main
+oracle=Arixmethes, Slumbering Isle enters the battlefield tapped with five slumber counters on it.\nAs long as Arixmethes has a slumber counter on it, it's a land.\nWhenever you cast a spell, you may remove a slumber counter from Arixmethes.\n{T}: Add {G}{U}.

--- a/release/Magarena/scripts_missing/Artful_Takedown.txt
+++ b/release/Magarena/scripts_missing/Artful_Takedown.txt
@@ -1,0 +1,9 @@
+name=Artful Takedown
+image=https://img.scryfall.com/cards/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={2}{U}{B}
+effect=Choose one or both — (1) Tap target creature. (2) Target creature gets -2/-4 until end of turn.
+timing=removal
+oracle=Choose one or both —\n• Tap target creature.\n• Target creature gets -2/-4 until end of turn.

--- a/release/Magarena/scripts_missing/Assassin_s_Trophy.txt
+++ b/release/Magarena/scripts_missing/Assassin_s_Trophy.txt
@@ -1,0 +1,9 @@
+name=Assassin's Trophy
+image=https://img.scryfall.com/cards/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={B}{G}
+effect=Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle their library.
+timing=removal
+oracle=Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle their library.

--- a/release/Magarena/scripts_missing/Assemble.txt
+++ b/release/Magarena/scripts_missing/Assemble.txt
@@ -1,0 +1,11 @@
+name=Assemble
+image=https://img.scryfall.com/cards/large/front/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={4}{G}{W}
+split=Assure
+effect=Create three 2/2 green and white Elf Knight creature tokens with vigilance.
+timing=removal
+oracle=Create three 2/2 green and white Elf Knight creature tokens with vigilance.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Assure.txt
+++ b/release/Magarena/scripts_missing/Assure.txt
@@ -1,0 +1,11 @@
+name=Assure
+image=https://img.scryfall.com/cards/large/front/a/d/ad454e7a-06c9-4694-ae68-7b1431e00077.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={G/W}{G/W}
+split=Assemble
+effect=Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.
+timing=removal
+oracle=Put a +1/+1 counter on target creature. That creature gains indestructible until end of turn.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Attendant_of_Vraska.txt
+++ b/release/Magarena/scripts_missing/Attendant_of_Vraska.txt
@@ -1,0 +1,11 @@
+name=Attendant of Vraska
+image=https://img.scryfall.com/cards/normal/front/7/f/7f4840f1-3db3-4ba6-b75b-bbd87251a3af.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Zombie,Soldier
+cost={1}{B}{G}
+pt=3/3
+ability=When SN dies, if you control a Vraska planeswalker, you gain life equal to SN's power.
+timing=main
+oracle=When Attendant of Vraska dies, if you control a Vraska planeswalker, you gain life equal to Attendant of Vraska's power.

--- a/release/Magarena/scripts_missing/Aurelia__Exemplar_of_Justice.txt
+++ b/release/Magarena/scripts_missing/Aurelia__Exemplar_of_Justice.txt
@@ -1,0 +1,13 @@
+name=Aurelia, Exemplar of Justice
+image=https://img.scryfall.com/cards/normal/front/a/8/a8e9f4d2-bba5-4061-8ae7-a68b912f2c11.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Angel
+cost={2}{R}{W}
+pt=2/5
+ability=Flying;\
+        Mentor;\
+        At the beginning of combat on your turn, choose up to one target creature you control. Until end of turn, that creature gets +2/+0, gains trample if it's red, and gains vigilance if it's white.
+timing=main
+oracle=Flying\nMentor\nAt the beginning of combat on your turn, choose up to one target creature you control. Until end of turn, that creature gets +2/+0, gains trample if it's red, and gains vigilance if it's white.

--- a/release/Magarena/scripts_missing/Barging_Sergeant.txt
+++ b/release/Magarena/scripts_missing/Barging_Sergeant.txt
@@ -1,0 +1,12 @@
+name=Barging Sergeant
+image=https://img.scryfall.com/cards/normal/front/5/2/52a54ebc-008a-4180-a023-2e1d5318780c.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Minotaur,Soldier
+cost={4}{R}
+pt=4/2
+ability=Haste;\
+        Mentor
+timing=fmain
+oracle=Haste\nMentor

--- a/release/Magarena/scripts_missing/Barrier_of_Bones.txt
+++ b/release/Magarena/scripts_missing/Barrier_of_Bones.txt
@@ -1,0 +1,12 @@
+name=Barrier of Bones
+image=https://img.scryfall.com/cards/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Skeleton,Wall
+cost={B}
+pt=0/3
+ability=Defender;\
+        When SN enters the battlefield, surveil 1.
+timing=smain
+oracle=Defender\nWhen Barrier of Bones enters the battlefield, surveil 1.

--- a/release/Magarena/scripts_missing/Bartizan_Bats.txt
+++ b/release/Magarena/scripts_missing/Bartizan_Bats.txt
@@ -1,0 +1,11 @@
+name=Bartizan Bats
+image=https://img.scryfall.com/cards/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Bat
+cost={3}{B}
+pt=3/1
+ability=Flying
+timing=main
+oracle=Flying

--- a/release/Magarena/scripts_missing/Beacon_Bolt.txt
+++ b/release/Magarena/scripts_missing/Beacon_Bolt.txt
@@ -1,0 +1,9 @@
+name=Beacon Bolt
+image=https://img.scryfall.com/cards/normal/front/3/9/39c9e4b5-364b-4c0b-bb47-266563a6abf2.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={1}{U}{R}
+effect=SN deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.~Jump-start
+timing=main
+oracle=Beacon Bolt deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\nJump-start

--- a/release/Magarena/scripts_missing/Beamsplitter_Mage.txt
+++ b/release/Magarena/scripts_missing/Beamsplitter_Mage.txt
@@ -1,0 +1,11 @@
+name=Beamsplitter Mage
+image=https://img.scryfall.com/cards/normal/front/8/f/8f1801f2-ea6e-4196-858e-2afc456cf6a0.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Vedalken,Wizard
+cost={U}{R}
+pt=2/2
+ability=Whenever you cast an instant or sorcery spell that targets only SN, if you control one or more other creatures that spell could target, choose one of those creatures. Copy that spell. The copy targets the chosen creature.
+timing=main
+oracle=Whenever you cast an instant or sorcery spell that targets only Beamsplitter Mage, if you control one or more other creatures that spell could target, choose one of those creatures. Copy that spell. The copy targets the chosen creature.

--- a/release/Magarena/scripts_missing/Beast_Whisperer.txt
+++ b/release/Magarena/scripts_missing/Beast_Whisperer.txt
@@ -1,0 +1,11 @@
+name=Beast Whisperer
+image=https://img.scryfall.com/cards/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Elf,Druid
+cost={2}{G}{G}
+pt=2/3
+ability=Whenever you cast a creature spell, draw a card.
+timing=main
+oracle=Whenever you cast a creature spell, draw a card.

--- a/release/Magarena/scripts_missing/Blade_Instructor.txt
+++ b/release/Magarena/scripts_missing/Blade_Instructor.txt
@@ -1,0 +1,11 @@
+name=Blade Instructor
+image=https://img.scryfall.com/cards/normal/front/9/b/9b1c7f07-8d39-425b-8ae9-b3ab317cc0fe.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Soldier
+cost={2}{W}
+pt=3/1
+ability=Mentor
+timing=main
+oracle=Mentor

--- a/release/Magarena/scripts_missing/Blood_Operative.txt
+++ b/release/Magarena/scripts_missing/Blood_Operative.txt
@@ -1,0 +1,13 @@
+name=Blood Operative
+image=https://img.scryfall.com/cards/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Vampire,Assassin
+cost={1}{B}{B}
+pt=3/1
+ability=Lifelink;\
+        When SN enters the battlefield, you may exile target card from a graveyard.;\
+        Whenever you surveil, if SN is in your graveyard, you may pay 3 life. If you do, return SN to your hand.
+timing=main
+oracle=Lifelink\nWhen Blood Operative enters the battlefield, you may exile target card from a graveyard.\nWhenever you surveil, if Blood Operative is in your graveyard, you may pay 3 life. If you do, return Blood Operative to your hand.

--- a/release/Magarena/scripts_missing/Bloodtracker.txt
+++ b/release/Magarena/scripts_missing/Bloodtracker.txt
@@ -1,0 +1,13 @@
+name=Bloodtracker
+image=https://img.scryfall.com/cards/normal/en/c18/14.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Vampire,Wizard
+cost={3}{B}
+pt=2/2
+ability=Flying;\
+        {B}, Pay 2 life: Put a +1/+1 counter on SN.;\
+        When SN leaves the battlefield, draw a card for each +1/+1 counter on it.
+timing=main
+oracle=Flying\n{B}, Pay 2 life: Put a +1/+1 counter on Bloodtracker.\nWhen Bloodtracker leaves the battlefield, draw a card for each +1/+1 counter on it.

--- a/release/Magarena/scripts_missing/Book_Devourer.txt
+++ b/release/Magarena/scripts_missing/Book_Devourer.txt
@@ -1,0 +1,12 @@
+name=Book Devourer
+image=https://img.scryfall.com/cards/normal/front/0/1/01dfe640-5bd2-4d0b-8977-887b2ed4c2dd.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Beast
+cost={5}{R}
+pt=4/5
+ability=Trample;\
+        Whenever SN deals combat damage to a player, you may discard all the cards in your hand. If you do, draw that many cards.
+timing=main
+oracle=Trample\nWhenever Book Devourer deals combat damage to a player, you may discard all the cards in your hand. If you do, draw that many cards.

--- a/release/Magarena/scripts_missing/Boreas_Charger.txt
+++ b/release/Magarena/scripts_missing/Boreas_Charger.txt
@@ -1,0 +1,12 @@
+name=Boreas Charger
+image=https://img.scryfall.com/cards/normal/en/c18/1.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Pegasus
+cost={2}{W}
+pt=2/1
+ability=Flying;\
+        When SN leaves the battlefield, choose an opponent who controls more lands than you. Search your library for a number of Plains cards equal to the difference and reveal them. Put one of them onto the battlefield tapped and the rest into your hand. Then shuffle your library.
+timing=main
+oracle=Flying\nWhen Boreas Charger leaves the battlefield, choose an opponent who controls more lands than you. Search your library for a number of Plains cards equal to the difference and reveal them. Put one of them onto the battlefield tapped and the rest into your hand. Then shuffle your library.

--- a/release/Magarena/scripts_missing/Boros_Challenger.txt
+++ b/release/Magarena/scripts_missing/Boros_Challenger.txt
@@ -1,0 +1,12 @@
+name=Boros Challenger
+image=https://img.scryfall.com/cards/normal/front/6/2/626e9cd3-8b1d-46f6-8bcd-4be10ba2e8a4.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Soldier
+cost={R}{W}
+pt=2/3
+ability=Mentor;\
+        {2}{R}{W}: SN gets +1/+1 until end of turn.
+timing=main
+oracle=Mentor\n{2}{R}{W}: Boros Challenger gets +1/+1 until end of turn.

--- a/release/Magarena/scripts_missing/Boros_Locket.txt
+++ b/release/Magarena/scripts_missing/Boros_Locket.txt
@@ -1,0 +1,10 @@
+name=Boros Locket
+image=https://img.scryfall.com/cards/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg
+value=2.500
+rarity=C
+type=Artifact
+cost={3}
+ability={T}: Add {R} or {W}.;\
+        {R/W}{R/W}{R/W}{R/W}, {T}, Sacrifice SN: Draw two cards.
+timing=artifact
+oracle={T}: Add {R} or {W}.\n{R/W}{R/W}{R/W}{R/W}, {T}, Sacrifice Boros Locket: Draw two cards.

--- a/release/Magarena/scripts_missing/Bounty_Agent.txt
+++ b/release/Magarena/scripts_missing/Bounty_Agent.txt
@@ -1,0 +1,12 @@
+name=Bounty Agent
+image=https://img.scryfall.com/cards/normal/front/6/e/6e938121-5917-4b67-9014-74fca106a471.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Human,Soldier
+cost={1}{W}
+pt=2/2
+ability=Vigilance;\
+        {T}, Sacrifice SN: Destroy target legendary permanent that's an artifact, creature, or enchantment.
+timing=main
+oracle=Vigilance\n{T}, Sacrifice Bounty Agent: Destroy target legendary permanent that's an artifact, creature, or enchantment.

--- a/release/Magarena/scripts_missing/Bounty_of_Might.txt
+++ b/release/Magarena/scripts_missing/Bounty_of_Might.txt
@@ -1,0 +1,9 @@
+name=Bounty of Might
+image=https://img.scryfall.com/cards/normal/front/e/9/e9a950d8-e6e2-42d6-83d7-a60c15d2035d.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={4}{G}{G}
+effect=Target creature gets +3/+3 until end of turn.~Target creature gets +3/+3 until end of turn.~Target creature gets +3/+3 until end of turn.
+timing=removal
+oracle=Target creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.\nTarget creature gets +3/+3 until end of turn.

--- a/release/Magarena/scripts_missing/Bronze_Tablet.txt
+++ b/release/Magarena/scripts_missing/Bronze_Tablet.txt
@@ -1,0 +1,11 @@
+name=Bronze Tablet
+image=https://img.scryfall.com/cards/normal/en/atq/42.jpg
+value=2.500
+rarity=R
+type=Artifact
+cost={6}
+ability=Remove SN from your deck before playing if you're not playing for ante.;\
+        SN enters the battlefield tapped.;\
+        {4}, {T}: Exile SN and target nontoken permanent an opponent owns. That player may pay 10 life. If they do, put SN into its owner's graveyard. Otherwise, that player owns SN and you own the other exiled card.
+timing=artifact
+oracle=Remove Bronze Tablet from your deck before playing if you're not playing for ante.\nBronze Tablet enters the battlefield tapped.\n{4}, {T}: Exile Bronze Tablet and target nontoken permanent an opponent owns. That player may pay 10 life. If they do, put Bronze Tablet into its owner's graveyard. Otherwise, that player owns Bronze Tablet and you own the other exiled card.

--- a/release/Magarena/scripts_missing/Bronze_Tablet.txt
+++ b/release/Magarena/scripts_missing/Bronze_Tablet.txt
@@ -9,3 +9,4 @@ ability=Remove SN from your deck before playing if you're not playing for ante.;
         {4}, {T}: Exile SN and target nontoken permanent an opponent owns. That player may pay 10 life. If they do, put SN into its owner's graveyard. Otherwise, that player owns SN and you own the other exiled card.
 timing=artifact
 oracle=Remove Bronze Tablet from your deck before playing if you're not playing for ante.\nBronze Tablet enters the battlefield tapped.\n{4}, {T}: Exile Bronze Tablet and target nontoken permanent an opponent owns. That player may pay 10 life. If they do, put Bronze Tablet into its owner's graveyard. Otherwise, that player owns Bronze Tablet and you own the other exiled card.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Brudiclad__Telchor_Engineer.txt
+++ b/release/Magarena/scripts_missing/Brudiclad__Telchor_Engineer.txt
@@ -1,0 +1,12 @@
+name=Brudiclad, Telchor Engineer
+image=https://img.scryfall.com/cards/normal/en/c18/39.jpg
+value=2.500
+rarity=M
+type=Legendary,Artifact,Creature
+subtype=Artificer
+cost={4}{U}{R}
+pt=4/4
+ability=Creature tokens you control have haste.;\
+        At the beginning of combat on your turn, create a 2/1 blue Myr artifact creature token. Then you may choose a token you control. If you do, each other token you control becomes a copy of that token.
+timing=main
+oracle=Creature tokens you control have haste.\nAt the beginning of combat on your turn, create a 2/1 blue Myr artifact creature token. Then you may choose a token you control. If you do, each other token you control becomes a copy of that token.

--- a/release/Magarena/scripts_missing/Burglar_Rat.txt
+++ b/release/Magarena/scripts_missing/Burglar_Rat.txt
@@ -1,0 +1,11 @@
+name=Burglar Rat
+image=https://img.scryfall.com/cards/normal/front/e/9/e9f7f218-fd2a-4233-8753-065ddc314f2d.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Rat
+cost={1}{B}
+pt=1/1
+ability=When SN enters the battlefield, each opponent discards a card.
+timing=main
+oracle=When Burglar Rat enters the battlefield, each opponent discards a card.

--- a/release/Magarena/scripts_missing/Camaraderie.txt
+++ b/release/Magarena/scripts_missing/Camaraderie.txt
@@ -1,0 +1,9 @@
+name=Camaraderie
+image=https://img.scryfall.com/cards/normal/front/8/9/890a2fa9-1141-4a4c-85af-05723aba5e39.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={4}{G}{W}
+effect=You gain X life and draw X cards, where X is the number of creatures you control. Creatures you control get +1/+1 until end of turn.
+timing=main
+oracle=You gain X life and draw X cards, where X is the number of creatures you control. Creatures you control get +1/+1 until end of turn.

--- a/release/Magarena/scripts_missing/Candlelight_Vigil.txt
+++ b/release/Magarena/scripts_missing/Candlelight_Vigil.txt
@@ -1,0 +1,12 @@
+name=Candlelight Vigil
+image=https://img.scryfall.com/cards/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg
+value=2.500
+rarity=C
+type=Enchantment
+subtype=Aura
+cost={3}{W}
+ability=Enchant creature;\
+        Enchanted creature gets +3/+2 and has vigilance.
+timing=aura
+enchant=default,creature
+oracle=Enchant creature\nEnchanted creature gets +3/+2 and has vigilance.

--- a/release/Magarena/scripts_missing/Capture_Sphere.txt
+++ b/release/Magarena/scripts_missing/Capture_Sphere.txt
@@ -1,0 +1,14 @@
+name=Capture Sphere
+image=https://img.scryfall.com/cards/normal/front/5/a/5a799ac8-5798-4a26-81c1-763d6dcfcbe8.jpg
+value=2.500
+rarity=C
+type=Enchantment
+subtype=Aura
+cost={3}{U}
+ability=Flash;\
+        Enchant creature;\
+        When SN enters the battlefield, tap enchanted creature.;\
+        Enchanted creature doesn't untap during its controller's untap step.
+timing=flash
+enchant=default,creature
+oracle=Flash\nEnchant creature\nWhen Capture Sphere enters the battlefield, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.

--- a/release/Magarena/scripts_missing/Centaur_Peacemaker.txt
+++ b/release/Magarena/scripts_missing/Centaur_Peacemaker.txt
@@ -1,0 +1,11 @@
+name=Centaur Peacemaker
+image=https://img.scryfall.com/cards/normal/front/0/e/0e630e9b-7817-4255-9de1-795b2a788d80.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Centaur,Cleric
+cost={1}{G}{W}
+pt=3/3
+ability=When SN enters the battlefield, each player gains 4 life.
+timing=main
+oracle=When Centaur Peacemaker enters the battlefield, each player gains 4 life.

--- a/release/Magarena/scripts_missing/Chamber_Sentry.txt
+++ b/release/Magarena/scripts_missing/Chamber_Sentry.txt
@@ -1,0 +1,13 @@
+name=Chamber Sentry
+image=https://img.scryfall.com/cards/normal/front/1/5/15dfd5f2-5298-4cf4-80fe-43db9be24f57.jpg
+value=2.500
+rarity=R
+type=Artifact,Creature
+subtype=Construct
+cost={X}
+pt=0/0
+ability=SN enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.;\
+        {X}, {T}, Remove X +1/+1 counters from SN: It deals X damage to any target.;\
+        {W}{U}{B}{R}{G}: Return SN from your graveyard to your hand.
+timing=main
+oracle=Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.\n{X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.\n{W}{U}{B}{R}{G}: Return Chamber Sentry from your graveyard to your hand.

--- a/release/Magarena/scripts_missing/Chance_for_Glory.txt
+++ b/release/Magarena/scripts_missing/Chance_for_Glory.txt
@@ -1,0 +1,9 @@
+name=Chance for Glory
+image=https://img.scryfall.com/cards/normal/front/8/5/85edf6f9-b863-41e2-bb51-857ea2798090.jpg
+value=2.500
+rarity=M
+type=Instant
+cost={1}{R}{W}
+effect=Creatures you control gain indestructible. Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.
+timing=removal
+oracle=Creatures you control gain indestructible. Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.

--- a/release/Magarena/scripts_missing/Chaos_Orb.txt
+++ b/release/Magarena/scripts_missing/Chaos_Orb.txt
@@ -1,0 +1,9 @@
+name=Chaos Orb
+image=https://img.scryfall.com/cards/normal/en/lea/235.jpg
+value=2.500
+rarity=R
+type=Artifact
+cost={2}
+ability={1}, {T}: If SN is on the battlefield, flip SN onto the battlefield from a height of at least one foot. If SN turns over completely at least once during the flip, destroy all nontoken permanents it touches. Then destroy SN.
+timing=artifact
+oracle={1}, {T}: If Chaos Orb is on the battlefield, flip Chaos Orb onto the battlefield from a height of at least one foot. If Chaos Orb turns over completely at least once during the flip, destroy all nontoken permanents it touches. Then destroy Chaos Orb.

--- a/release/Magarena/scripts_missing/Charnel_Troll.txt
+++ b/release/Magarena/scripts_missing/Charnel_Troll.txt
@@ -1,0 +1,13 @@
+name=Charnel Troll
+image=https://img.scryfall.com/cards/normal/front/7/1/71fec229-e22c-4655-8640-02d0ec472be0.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Troll
+cost={1}{B}{G}
+pt=4/4
+ability=Trample;\
+        At the beginning of your upkeep, exile a creature card from your graveyard. If you do, put a +1/+1 counter on SN. Otherwise, sacrifice it.;\
+        {B}{G}, Discard a creature card: Put a +1/+1 counter on SN.
+timing=main
+oracle=Trample\nAt the beginning of your upkeep, exile a creature card from your graveyard. If you do, put a +1/+1 counter on Charnel Troll. Otherwise, sacrifice it.\n{B}{G}, Discard a creature card: Put a +1/+1 counter on Charnel Troll.

--- a/release/Magarena/scripts_missing/Chemister_s_Insight.txt
+++ b/release/Magarena/scripts_missing/Chemister_s_Insight.txt
@@ -1,0 +1,9 @@
+name=Chemister's Insight
+image=https://img.scryfall.com/cards/normal/front/0/e/0e13a295-0d51-4b56-8c58-0896eb41c567.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={3}{U}
+effect=Draw two cards.~Jump-start
+timing=removal
+oracle=Draw two cards.\nJump-start

--- a/release/Magarena/scripts_missing/Circuitous_Route.txt
+++ b/release/Magarena/scripts_missing/Circuitous_Route.txt
@@ -1,0 +1,9 @@
+name=Circuitous Route
+image=https://img.scryfall.com/cards/normal/front/5/a/5a970429-6369-4422-a343-00b30267f09d.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={3}{G}
+effect=Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle your library.
+timing=main
+oracle=Search your library for up to two basic land cards and/or Gate cards, put them onto the battlefield tapped, then shuffle your library.

--- a/release/Magarena/scripts_missing/Citywatch_Sphinx.txt
+++ b/release/Magarena/scripts_missing/Citywatch_Sphinx.txt
@@ -1,0 +1,12 @@
+name=Citywatch Sphinx
+image=https://img.scryfall.com/cards/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Sphinx
+cost={5}{U}
+pt=5/4
+ability=Flying;\
+        When SN dies, surveil 2.
+timing=main
+oracle=Flying\nWhen Citywatch Sphinx dies, surveil 2.

--- a/release/Magarena/scripts_missing/Citywide_Bust.txt
+++ b/release/Magarena/scripts_missing/Citywide_Bust.txt
@@ -1,0 +1,9 @@
+name=Citywide Bust
+image=https://img.scryfall.com/cards/normal/front/a/9/a995200f-1e9d-4ff3-9e04-4a4309e0e09c.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={1}{W}{W}
+effect=Destroy all creatures with toughness 4 or greater.
+timing=main
+oracle=Destroy all creatures with toughness 4 or greater.

--- a/release/Magarena/scripts_missing/Collar_the_Culprit.txt
+++ b/release/Magarena/scripts_missing/Collar_the_Culprit.txt
@@ -1,0 +1,9 @@
+name=Collar the Culprit
+image=https://img.scryfall.com/cards/normal/front/c/d/cdf305b7-d1f7-4770-9201-8f3fb6735cd9.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={3}{W}
+effect=Destroy target creature with toughness 4 or greater.
+timing=removal
+oracle=Destroy target creature with toughness 4 or greater.

--- a/release/Magarena/scripts_missing/Command_the_Storm.txt
+++ b/release/Magarena/scripts_missing/Command_the_Storm.txt
@@ -1,0 +1,9 @@
+name=Command the Storm
+image=https://img.scryfall.com/cards/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={4}{R}
+effect=SN deals 5 damage to target creature.
+timing=removal
+oracle=Command the Storm deals 5 damage to target creature.

--- a/release/Magarena/scripts_missing/Conclave_Cavalier.txt
+++ b/release/Magarena/scripts_missing/Conclave_Cavalier.txt
@@ -1,0 +1,12 @@
+name=Conclave Cavalier
+image=https://img.scryfall.com/cards/normal/front/b/6/b658a309-d14c-4e20-8c76-e7b3c5156bf2.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Centaur,Knight
+cost={G}{G}{W}{W}
+pt=4/4
+ability=Vigilance;\
+        When SN dies, create two 2/2 green and white Elf Knight creature tokens with vigilance.
+timing=main
+oracle=Vigilance\nWhen Conclave Cavalier dies, create two 2/2 green and white Elf Knight creature tokens with vigilance.

--- a/release/Magarena/scripts_missing/Conclave_Guildmage.txt
+++ b/release/Magarena/scripts_missing/Conclave_Guildmage.txt
@@ -1,0 +1,12 @@
+name=Conclave Guildmage
+image=https://img.scryfall.com/cards/normal/front/2/7/279e551d-3ac3-48d5-9822-1d05159c8905.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Cleric
+cost={G}{W}
+pt=2/2
+ability={G}, {T}: Creatures you control gain trample until end of turn.;\
+        {5}{W}, {T}: Create a 2/2 green and white Elf Knight creature token with vigilance.
+timing=main
+oracle={G}, {T}: Creatures you control gain trample until end of turn.\n{5}{W}, {T}: Create a 2/2 green and white Elf Knight creature token with vigilance.

--- a/release/Magarena/scripts_missing/Conclave_Tribunal.txt
+++ b/release/Magarena/scripts_missing/Conclave_Tribunal.txt
@@ -1,0 +1,10 @@
+name=Conclave Tribunal
+image=https://img.scryfall.com/cards/normal/front/9/d/9d9fda5d-df8f-45d6-b8f0-33f903c4bf83.jpg
+value=2.500
+rarity=U
+type=Enchantment
+cost={3}{W}
+ability=Convoke;\
+        When SN enters the battlefield, exile target nonland permanent an opponent controls until SN leaves the battlefield.
+timing=enchantment
+oracle=Convoke\nWhen Conclave Tribunal enters the battlefield, exile target nonland permanent an opponent controls until Conclave Tribunal leaves the battlefield.

--- a/release/Magarena/scripts_missing/Concoct.txt
+++ b/release/Magarena/scripts_missing/Concoct.txt
@@ -1,0 +1,11 @@
+name=Concoct
+image=https://img.scryfall.com/cards/large/front/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={3}{U}{B}
+split=Connive
+effect=Surveil 3, then return a creature card from your graveyard to the battlefield.
+timing=main
+oracle=Surveil 3, then return a creature card from your graveyard to the battlefield.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Connive.txt
+++ b/release/Magarena/scripts_missing/Connive.txt
@@ -1,0 +1,11 @@
+name=Connive
+image=https://img.scryfall.com/cards/large/front/8/9/890ac54c-6fd7-4e46-8ce4-8926c6975f60.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={2}{U/B}{U/B}
+split=Concoct
+effect=Gain control of target creature with power 2 or less.
+timing=main
+oracle=Gain control of target creature with power 2 or less.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Contract_from_Below.txt
+++ b/release/Magarena/scripts_missing/Contract_from_Below.txt
@@ -7,3 +7,4 @@ cost={B}
 effect=Remove SN from your deck before playing if you're not playing for ante.~Discard your hand, ante the top card of your library, then draw seven cards.
 timing=main
 oracle=Remove Contract from Below from your deck before playing if you're not playing for ante.\nDiscard your hand, ante the top card of your library, then draw seven cards.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Contract_from_Below.txt
+++ b/release/Magarena/scripts_missing/Contract_from_Below.txt
@@ -1,0 +1,9 @@
+name=Contract from Below
+image=https://img.scryfall.com/cards/normal/en/lea/96.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={B}
+effect=Remove SN from your deck before playing if you're not playing for ante.~Discard your hand, ante the top card of your library, then draw seven cards.
+timing=main
+oracle=Remove Contract from Below from your deck before playing if you're not playing for ante.\nDiscard your hand, ante the top card of your library, then draw seven cards.

--- a/release/Magarena/scripts_missing/Cosmotronic_Wave.txt
+++ b/release/Magarena/scripts_missing/Cosmotronic_Wave.txt
@@ -1,0 +1,9 @@
+name=Cosmotronic Wave
+image=https://img.scryfall.com/cards/normal/front/6/9/69c5bafa-8cd8-4158-98e0-46dc74c027c0.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={3}{R}
+effect=SN deals 1 damage to each creature your opponents control. Creatures your opponents control can't block this turn.
+timing=main
+oracle=Cosmotronic Wave deals 1 damage to each creature your opponents control. Creatures your opponents control can't block this turn.

--- a/release/Magarena/scripts_missing/Coveted_Jewel.txt
+++ b/release/Magarena/scripts_missing/Coveted_Jewel.txt
@@ -1,0 +1,11 @@
+name=Coveted Jewel
+image=https://img.scryfall.com/cards/normal/en/c18/54.jpg
+value=2.500
+rarity=R
+type=Artifact
+cost={6}
+ability=When SN enters the battlefield, draw three cards.;\
+        {T}: Add three mana of any one color.;\
+        Whenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of SN. Untap it.
+timing=artifact
+oracle=When Coveted Jewel enters the battlefield, draw three cards.\n{T}: Add three mana of any one color.\nWhenever one or more creatures an opponent controls attack you and aren't blocked, that player draws three cards and gains control of Coveted Jewel. Untap it.

--- a/release/Magarena/scripts_missing/Crackling_Drake.txt
+++ b/release/Magarena/scripts_missing/Crackling_Drake.txt
@@ -1,0 +1,13 @@
+name=Crackling Drake
+image=https://img.scryfall.com/cards/normal/front/f/0/f00fa3a7-e3e2-4b23-a126-a076e75b5dbd.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Drake
+cost={U}{U}{R}{R}
+pt=*/4
+ability=Flying;\
+        SN's power is equal to the total number of instant and sorcery cards you own in exile and in your graveyard.;\
+        When SN enters the battlefield, draw a card.
+timing=main
+oracle=Flying\nCrackling Drake's power is equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\nWhen Crackling Drake enters the battlefield, draw a card.

--- a/release/Magarena/scripts_missing/Crash_of_Rhino_Beetles.txt
+++ b/release/Magarena/scripts_missing/Crash_of_Rhino_Beetles.txt
@@ -1,0 +1,12 @@
+name=Crash of Rhino Beetles
+image=https://img.scryfall.com/cards/normal/en/c18/29.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Insect
+cost={4}{G}
+pt=5/5
+ability=Trample;\
+        SN gets +10/+10 as long as you control ten or more lands.
+timing=main
+oracle=Trample\nCrash of Rhino Beetles gets +10/+10 as long as you control ten or more lands.

--- a/release/Magarena/scripts_missing/Creeping_Chill.txt
+++ b/release/Magarena/scripts_missing/Creeping_Chill.txt
@@ -1,0 +1,9 @@
+name=Creeping Chill
+image=https://img.scryfall.com/cards/normal/front/f/5/f5456173-7a08-4b5c-8450-7123375f4a86.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={3}{B}
+effect=SN deals 3 damage to each opponent and you gain 3 life.~When SN is put into your graveyard from your library, you may exile it. If you do, SN deals 3 damage to each opponent and you gain 3 life.
+timing=main
+oracle=Creeping Chill deals 3 damage to each opponent and you gain 3 life.\nWhen Creeping Chill is put into your graveyard from your library, you may exile it. If you do, Creeping Chill deals 3 damage to each opponent and you gain 3 life.

--- a/release/Magarena/scripts_missing/Crush_Contraband.txt
+++ b/release/Magarena/scripts_missing/Crush_Contraband.txt
@@ -1,0 +1,9 @@
+name=Crush Contraband
+image=https://img.scryfall.com/cards/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={3}{W}
+effect=Choose one or both — (1) Exile target artifact. (2) Exile target enchantment.
+timing=removal
+oracle=Choose one or both —\n• Exile target artifact.\n• Exile target enchantment.

--- a/release/Magarena/scripts_missing/Darkblade_Agent.txt
+++ b/release/Magarena/scripts_missing/Darkblade_Agent.txt
@@ -1,0 +1,11 @@
+name=Darkblade Agent
+image=https://img.scryfall.com/cards/normal/front/f/0/f0b610c5-61e5-43df-a87b-3eaaa915402b.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Assassin
+cost={1}{U}{B}
+pt=2/3
+ability=As long as you've surveilled this turn, SN has deathtouch and "Whenever this creature deals combat damage to a player, you draw a card."
+timing=main
+oracle=As long as you've surveilled this turn, Darkblade Agent has deathtouch and "Whenever this creature deals combat damage to a player, you draw a card."

--- a/release/Magarena/scripts_missing/Darkpact.txt
+++ b/release/Magarena/scripts_missing/Darkpact.txt
@@ -1,0 +1,9 @@
+name=Darkpact
+image=https://img.scryfall.com/cards/normal/en/lea/99.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={B}{B}{B}
+effect=Remove SN from your deck before playing if you're not playing for ante.~You own target card in the ante. Exchange that card with the top card of your library.
+timing=main
+oracle=Remove Darkpact from your deck before playing if you're not playing for ante.\nYou own target card in the ante. Exchange that card with the top card of your library.

--- a/release/Magarena/scripts_missing/Darkpact.txt
+++ b/release/Magarena/scripts_missing/Darkpact.txt
@@ -7,3 +7,4 @@ cost={B}{B}{B}
 effect=Remove SN from your deck before playing if you're not playing for ante.~You own target card in the ante. Exchange that card with the top card of your library.
 timing=main
 oracle=Remove Darkpact from your deck before playing if you're not playing for ante.\nYou own target card in the ante. Exchange that card with the top card of your library.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Dawn_of_Hope.txt
+++ b/release/Magarena/scripts_missing/Dawn_of_Hope.txt
@@ -1,0 +1,10 @@
+name=Dawn of Hope
+image=https://img.scryfall.com/cards/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={1}{W}
+ability=Whenever you gain life, you may pay {2}. If you do, draw a card.;\
+        {3}{W}: Create a 1/1 white Soldier creature token with lifelink.
+timing=enchantment
+oracle=Whenever you gain life, you may pay {2}. If you do, draw a card.\n{3}{W}: Create a 1/1 white Soldier creature token with lifelink.

--- a/release/Magarena/scripts_missing/Dazzling_Lights.txt
+++ b/release/Magarena/scripts_missing/Dazzling_Lights.txt
@@ -1,0 +1,9 @@
+name=Dazzling Lights
+image=https://img.scryfall.com/cards/normal/front/a/9/a9d4639a-b634-469e-a848-35e3a3dfd47e.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={U}
+effect=Target creature gets -3/-0 until end of turn.~Surveil 2.
+timing=removal
+oracle=Target creature gets -3/-0 until end of turn.\nSurveil 2.

--- a/release/Magarena/scripts_missing/Deadly_Visit.txt
+++ b/release/Magarena/scripts_missing/Deadly_Visit.txt
@@ -1,0 +1,9 @@
+name=Deadly Visit
+image=https://img.scryfall.com/cards/normal/front/4/6/462fe190-5264-42d8-bd27-23c5aa0c641f.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={3}{B}{B}
+effect=Destroy target creature.~Surveil 2.
+timing=main
+oracle=Destroy target creature.\nSurveil 2.

--- a/release/Magarena/scripts_missing/Deafening_Clarion.txt
+++ b/release/Magarena/scripts_missing/Deafening_Clarion.txt
@@ -1,0 +1,9 @@
+name=Deafening Clarion
+image=https://img.scryfall.com/cards/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={1}{R}{W}
+effect=Choose one or both — (1) SN deals 3 damage to each creature. (2) Creatures you control gain lifelink until end of turn.
+timing=main
+oracle=Choose one or both —\n• Deafening Clarion deals 3 damage to each creature.\n• Creatures you control gain lifelink until end of turn.

--- a/release/Magarena/scripts_missing/Demonic_Attorney.txt
+++ b/release/Magarena/scripts_missing/Demonic_Attorney.txt
@@ -1,0 +1,9 @@
+name=Demonic Attorney
+image=https://img.scryfall.com/cards/normal/en/lea/102.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={1}{B}{B}
+effect=Remove SN from your deck before playing if you're not playing for ante.~Each player antes the top card of their library.
+timing=main
+oracle=Remove Demonic Attorney from your deck before playing if you're not playing for ante.\nEach player antes the top card of their library.

--- a/release/Magarena/scripts_missing/Demonic_Attorney.txt
+++ b/release/Magarena/scripts_missing/Demonic_Attorney.txt
@@ -7,3 +7,4 @@ cost={1}{B}{B}
 effect=Remove SN from your deck before playing if you're not playing for ante.~Each player antes the top card of their library.
 timing=main
 oracle=Remove Demonic Attorney from your deck before playing if you're not playing for ante.\nEach player antes the top card of their library.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Demotion.txt
+++ b/release/Magarena/scripts_missing/Demotion.txt
@@ -1,0 +1,12 @@
+name=Demotion
+image=https://img.scryfall.com/cards/normal/front/6/9/69202217-ef36-4d6c-bbd0-ebbb2ade51f7.jpg
+value=2.500
+rarity=U
+type=Enchantment
+subtype=Aura
+cost={W}
+ability=Enchant creature;\
+        Enchanted creature can't block, and its activated abilities can't be activated.
+timing=aura
+enchant=default,creature
+oracle=Enchant creature\nEnchanted creature can't block, and its activated abilities can't be activated.

--- a/release/Magarena/scripts_missing/Devious_Cover_Up.txt
+++ b/release/Magarena/scripts_missing/Devious_Cover_Up.txt
@@ -1,0 +1,9 @@
+name=Devious Cover-Up
+image=https://img.scryfall.com/cards/large/front/2/1/21ac6b0a-b1a5-439d-b65e-5f04e1826c80.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={2}{U}{U}
+effect=Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may shuffle up to four target cards from your graveyard into your library.
+timing=counter
+oracle=Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may shuffle up to four target cards from your graveyard into your library.

--- a/release/Magarena/scripts_missing/Devkarin_Dissident.txt
+++ b/release/Magarena/scripts_missing/Devkarin_Dissident.txt
@@ -1,0 +1,11 @@
+name=Devkarin Dissident
+image=https://img.scryfall.com/cards/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Elf,Warrior
+cost={1}{G}
+pt=2/2
+ability={4}{G}: SN gets +2/+2 until end of turn.
+timing=main
+oracle={4}{G}: Devkarin Dissident gets +2/+2 until end of turn.

--- a/release/Magarena/scripts_missing/Dimir_Informant.txt
+++ b/release/Magarena/scripts_missing/Dimir_Informant.txt
@@ -1,0 +1,11 @@
+name=Dimir Informant
+image=https://img.scryfall.com/cards/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Rogue
+cost={2}{U}
+pt=1/4
+ability=When SN enters the battlefield, surveil 2.
+timing=main
+oracle=When Dimir Informant enters the battlefield, surveil 2.

--- a/release/Magarena/scripts_missing/Dimir_Locket.txt
+++ b/release/Magarena/scripts_missing/Dimir_Locket.txt
@@ -1,0 +1,10 @@
+name=Dimir Locket
+image=https://img.scryfall.com/cards/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg
+value=2.500
+rarity=C
+type=Artifact
+cost={3}
+ability={T}: Add {U} or {B}.;\
+        {U/B}{U/B}{U/B}{U/B}, {T}, Sacrifice SN: Draw two cards.
+timing=artifact
+oracle={T}: Add {U} or {B}.\n{U/B}{U/B}{U/B}{U/B}, {T}, Sacrifice Dimir Locket: Draw two cards.

--- a/release/Magarena/scripts_missing/Dimir_Spybug.txt
+++ b/release/Magarena/scripts_missing/Dimir_Spybug.txt
@@ -1,0 +1,13 @@
+name=Dimir Spybug
+image=https://img.scryfall.com/cards/normal/front/7/c/7c18c450-0bfb-4ba6-9212-b5833fce63a2.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Insect
+cost={U}{B}
+pt=1/1
+ability=Flying;\
+        Menace;\
+        Whenever you surveil, put a +1/+1 counter on SN.
+timing=main
+oracle=Flying\nMenace\nWhenever you surveil, put a +1/+1 counter on Dimir Spybug.

--- a/release/Magarena/scripts_missing/Direct_Current.txt
+++ b/release/Magarena/scripts_missing/Direct_Current.txt
@@ -1,0 +1,9 @@
+name=Direct Current
+image=https://img.scryfall.com/cards/normal/front/1/6/166b0d75-824c-4c04-833b-7f7c69569a18.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={1}{R}{R}
+effect=SN deals 2 damage to any target.~Jump-start
+timing=main
+oracle=Direct Current deals 2 damage to any target.\nJump-start

--- a/release/Magarena/scripts_missing/Discovery.txt
+++ b/release/Magarena/scripts_missing/Discovery.txt
@@ -1,0 +1,11 @@
+name=Discovery
+image=https://img.scryfall.com/cards/large/front/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={1}{U/B}
+split=Dispersal
+effect=Surveil 2, then draw a card.
+timing=main
+oracle=Surveil 2, then draw a card.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Disinformation_Campaign.txt
+++ b/release/Magarena/scripts_missing/Disinformation_Campaign.txt
@@ -1,0 +1,10 @@
+name=Disinformation Campaign
+image=https://img.scryfall.com/cards/normal/front/6/9/69a79ff3-58ed-4cc2-9ebc-0edbb86cd6fb.jpg
+value=2.500
+rarity=U
+type=Enchantment
+cost={1}{U}{B}
+ability=When SN enters the battlefield, you draw a card and each opponent discards a card.;\
+        Whenever you surveil, return SN to its owner's hand.
+timing=enchantment
+oracle=When Disinformation Campaign enters the battlefield, you draw a card and each opponent discards a card.\nWhenever you surveil, return Disinformation Campaign to its owner's hand.

--- a/release/Magarena/scripts_missing/Dispersal.txt
+++ b/release/Magarena/scripts_missing/Dispersal.txt
@@ -1,0 +1,11 @@
+name=Dispersal
+image=https://img.scryfall.com/cards/large/front/a/c/ace631d1-897a-417e-8628-0170713f03d3.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={3}{U}{B}
+split=Discovery
+effect=Each opponent returns a nonland permanent they control with the highest converted mana cost among permanents they control to its owner's hand, then discards a card.
+timing=removal
+oracle=Each opponent returns a nonland permanent they control with the highest converted mana cost among permanents they control to its owner's hand, then discards a card.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/District_Guide.txt
+++ b/release/Magarena/scripts_missing/District_Guide.txt
@@ -1,0 +1,11 @@
+name=District Guide
+image=https://img.scryfall.com/cards/normal/front/c/1/c150deec-3287-40ef-9b9c-c22bf5d70b02.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Scout
+cost={2}{G}
+pt=2/2
+ability=When SN enters the battlefield, you may search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.
+timing=main
+oracle=When District Guide enters the battlefield, you may search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.

--- a/release/Magarena/scripts_missing/Divine_Visitation.txt
+++ b/release/Magarena/scripts_missing/Divine_Visitation.txt
@@ -1,0 +1,9 @@
+name=Divine Visitation
+image=https://img.scryfall.com/cards/normal/front/d/a/da3789d4-3621-44a1-bb72-8e3bbac8bf72.jpg
+value=2.500
+rarity=M
+type=Enchantment
+cost={3}{W}{W}
+ability=If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.
+timing=enchantment
+oracle=If one or more creature tokens would be created under your control, that many 4/4 white Angel creature tokens with flying and vigilance are created instead.

--- a/release/Magarena/scripts_missing/Doom_Whisperer.txt
+++ b/release/Magarena/scripts_missing/Doom_Whisperer.txt
@@ -1,0 +1,12 @@
+name=Doom Whisperer
+image=https://img.scryfall.com/cards/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg
+value=2.500
+rarity=M
+type=Creature
+subtype=Nightmare,Demon
+cost={3}{B}{B}
+pt=6/6
+ability=Flying, trample;\
+        Pay 2 life: Surveil 2.
+timing=main
+oracle=Flying, trample\nPay 2 life: Surveil 2.

--- a/release/Magarena/scripts_missing/Douser_of_Lights.txt
+++ b/release/Magarena/scripts_missing/Douser_of_Lights.txt
@@ -1,0 +1,10 @@
+name=Douser of Lights
+image=https://img.scryfall.com/cards/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Horror
+cost={4}{B}
+pt=4/5
+timing=main
+oracle=NONE

--- a/release/Magarena/scripts_missing/Dream_Eater.txt
+++ b/release/Magarena/scripts_missing/Dream_Eater.txt
@@ -1,0 +1,13 @@
+name=Dream Eater
+image=https://img.scryfall.com/cards/normal/front/9/f/9f3a4677-7683-4f63-af31-b76491ec9f9c.jpg
+value=2.500
+rarity=M
+type=Creature
+subtype=Nightmare,Sphinx
+cost={4}{U}{U}
+pt=4/3
+ability=Flash;\
+        Flying;\
+        When SN enters the battlefield, surveil 4. When you do, you may return target nonland permanent an opponent controls to its owner's hand.
+timing=flash
+oracle=Flash\nFlying\nWhen Dream Eater enters the battlefield, surveil 4. When you do, you may return target nonland permanent an opponent controls to its owner's hand.

--- a/release/Magarena/scripts_missing/Drowned_Secrets.txt
+++ b/release/Magarena/scripts_missing/Drowned_Secrets.txt
@@ -1,0 +1,9 @@
+name=Drowned Secrets
+image=https://img.scryfall.com/cards/normal/front/b/f/bfc98428-7a0f-445f-9d48-eeb76c3e10d6.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={1}{U}
+ability=Whenever you cast a blue spell, target player puts the top two cards of their library into their graveyard.
+timing=enchantment
+oracle=Whenever you cast a blue spell, target player puts the top two cards of their library into their graveyard.

--- a/release/Magarena/scripts_missing/Echo_Storm.txt
+++ b/release/Magarena/scripts_missing/Echo_Storm.txt
@@ -1,0 +1,9 @@
+name=Echo Storm
+image=https://img.scryfall.com/cards/normal/en/c18/7.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={3}{U}{U}
+effect=When you cast this spell, copy it for each time you've cast your commander from the command zone this game. You may choose new targets for the copies.~Create a token that's a copy of target artifact.
+timing=main
+oracle=When you cast this spell, copy it for each time you've cast your commander from the command zone this game. You may choose new targets for the copies.\nCreate a token that's a copy of target artifact.

--- a/release/Magarena/scripts_missing/Electrostatic_Field.txt
+++ b/release/Magarena/scripts_missing/Electrostatic_Field.txt
@@ -1,0 +1,12 @@
+name=Electrostatic Field
+image=https://img.scryfall.com/cards/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Wall
+cost={1}{R}
+pt=0/4
+ability=Defender;\
+        Whenever you cast an instant or sorcery spell, SN deals 1 damage to each opponent.
+timing=smain
+oracle=Defender\nWhenever you cast an instant or sorcery spell, Electrostatic Field deals 1 damage to each opponent.

--- a/release/Magarena/scripts_missing/Emissary_of_Grudges.txt
+++ b/release/Magarena/scripts_missing/Emissary_of_Grudges.txt
@@ -1,0 +1,13 @@
+name=Emissary of Grudges
+image=https://img.scryfall.com/cards/normal/en/c18/20.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Efreet
+cost={5}{R}
+pt=6/5
+ability=Flying, haste;\
+        As SN enters the battlefield, secretly choose an opponent.;\
+        Reveal the player you chose: Choose new targets for target spell or ability if it's controlled by the chosen player and if it targets you or a permanent you control. Activate this ability only once.
+timing=main
+oracle=Flying, haste\nAs Emissary of Grudges enters the battlefield, secretly choose an opponent.\nReveal the player you chose: Choose new targets for target spell or ability if it's controlled by the chosen player and if it targets you or a permanent you control. Activate this ability only once.

--- a/release/Magarena/scripts_missing/Emmara__Soul_of_the_Accord.txt
+++ b/release/Magarena/scripts_missing/Emmara__Soul_of_the_Accord.txt
@@ -1,0 +1,11 @@
+name=Emmara, Soul of the Accord
+image=https://img.scryfall.com/cards/normal/front/7/1/7110419d-0ed3-4446-b61c-e9e54463b3b2.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Elf,Cleric
+cost={G}{W}
+pt=2/2
+ability=Whenever SN becomes tapped, create a 1/1 white Soldier creature token with lifelink.
+timing=main
+oracle=Whenever Emmara, Soul of the Accord becomes tapped, create a 1/1 white Soldier creature token with lifelink.

--- a/release/Magarena/scripts_missing/Empyrial_Storm.txt
+++ b/release/Magarena/scripts_missing/Empyrial_Storm.txt
@@ -1,0 +1,9 @@
+name=Empyrial Storm
+image=https://img.scryfall.com/cards/normal/en/c18/2.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={4}{W}{W}
+effect=When you cast this spell, copy it for each time you've cast your commander from the command zone this game.~Create a 4/4 white Angel creature token with flying.
+timing=main
+oracle=When you cast this spell, copy it for each time you've cast your commander from the command zone this game.\nCreate a 4/4 white Angel creature token with flying.

--- a/release/Magarena/scripts_missing/Enchanter_s_Bane.txt
+++ b/release/Magarena/scripts_missing/Enchanter_s_Bane.txt
@@ -1,0 +1,9 @@
+name=Enchanter's Bane
+image=https://img.scryfall.com/cards/normal/en/c18/21.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={1}{R}
+ability=At the beginning of your end step, target enchantment deals damage equal to its converted mana cost to its controller unless that player sacrifices it.
+timing=enchantment
+oracle=At the beginning of your end step, target enchantment deals damage equal to its converted mana cost to its controller unless that player sacrifices it.

--- a/release/Magarena/scripts_missing/Endless_Atlas.txt
+++ b/release/Magarena/scripts_missing/Endless_Atlas.txt
@@ -1,0 +1,9 @@
+name=Endless Atlas
+image=https://img.scryfall.com/cards/normal/en/c18/55.jpg
+value=2.500
+rarity=R
+type=Artifact
+cost={2}
+ability={2}, {T}: Draw a card. Activate this ability only if you control three or more lands with the same name.
+timing=artifact
+oracle={2}, {T}: Draw a card. Activate this ability only if you control three or more lands with the same name.

--- a/release/Magarena/scripts_missing/Enhanced_Surveillance.txt
+++ b/release/Magarena/scripts_missing/Enhanced_Surveillance.txt
@@ -1,0 +1,10 @@
+name=Enhanced Surveillance
+image=https://img.scryfall.com/cards/normal/front/9/7/971d254e-da25-494b-a16d-3d7d6bb75c73.jpg
+value=2.500
+rarity=U
+type=Enchantment
+cost={1}{U}
+ability=You may look at an additional two cards each time you surveil.;\
+        Exile SN: Shuffle your graveyard into your library.
+timing=enchantment
+oracle=You may look at an additional two cards each time you surveil.\nExile Enhanced Surveillance: Shuffle your graveyard into your library.

--- a/release/Magarena/scripts_missing/Entreat_the_Dead.txt
+++ b/release/Magarena/scripts_missing/Entreat_the_Dead.txt
@@ -1,0 +1,10 @@
+name=Entreat the Dead
+image=https://img.scryfall.com/cards/normal/en/c18/15.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={X}{X}{B}{B}{B}
+ability=Miracle {X}{B}{B}
+effect=Return X target creature cards from your graveyard to the battlefield.
+timing=main
+oracle=Return X target creature cards from your graveyard to the battlefield.\nMiracle {X}{B}{B}

--- a/release/Magarena/scripts_missing/Erratic_Cyclops.txt
+++ b/release/Magarena/scripts_missing/Erratic_Cyclops.txt
@@ -1,0 +1,12 @@
+name=Erratic Cyclops
+image=https://img.scryfall.com/cards/normal/front/c/3/c310df89-d894-40ab-ae34-7d0bfd19a1af.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Cyclops,Shaman
+cost={3}{R}
+pt=0/8
+ability=Trample;\
+        Whenever you cast an instant or sorcery spell, SN gets +X/+0 until end of turn, where X is that spell's converted mana cost.
+timing=main
+oracle=Trample\nWhenever you cast an instant or sorcery spell, Erratic Cyclops gets +X/+0 until end of turn, where X is that spell's converted mana cost.

--- a/release/Magarena/scripts_missing/Erstwhile_Trooper.txt
+++ b/release/Magarena/scripts_missing/Erstwhile_Trooper.txt
@@ -1,0 +1,11 @@
+name=Erstwhile Trooper
+image=https://img.scryfall.com/cards/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Zombie,Soldier
+cost={1}{B}{G}
+pt=2/2
+ability=Discard a creature card: SN gets +2/+2 and gains trample until end of turn. Activate this ability only once each turn.
+timing=main
+oracle=Discard a creature card: Erstwhile Trooper gets +2/+2 and gains trample until end of turn. Activate this ability only once each turn.

--- a/release/Magarena/scripts_missing/Estrid__the_Masked.txt
+++ b/release/Magarena/scripts_missing/Estrid__the_Masked.txt
@@ -1,0 +1,14 @@
+name=Estrid, the Masked
+image=https://img.scryfall.com/cards/normal/en/c18/40.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Estrid
+cost={1}{G}{W}{U}
+loyalty=3
+ability=+2: Untap each enchanted permanent you control.;\
+        −1: Create a white Aura enchantment token named Mask attached to another target permanent. The token has enchant permanent and totem armor.;\
+        −7: Put the top seven cards of your library into your graveyard. Return all non-Aura enchantment cards from your graveyard to the battlefield, then do the same for Aura cards.;\
+        SN can be your commander.
+timing=main
+oracle=+2: Untap each enchanted permanent you control.\n−1: Create a white Aura enchantment token named Mask attached to another target permanent. The token has enchant permanent and totem armor.\n−7: Put the top seven cards of your library into your graveyard. Return all non-Aura enchantment cards from your graveyard to the battlefield, then do the same for Aura cards.\nEstrid, the Masked can be your commander.

--- a/release/Magarena/scripts_missing/Estrid_s_Invocation.txt
+++ b/release/Magarena/scripts_missing/Estrid_s_Invocation.txt
@@ -1,0 +1,9 @@
+name=Estrid's Invocation
+image=https://img.scryfall.com/cards/normal/en/c18/8.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={2}{U}
+ability=You may have SN enter the battlefield as a copy of any enchantment you control, except it has "At the beginning of your upkeep, you may exile this enchantment. If you do, return it to the battlefield under its owner's control."
+timing=enchantment
+oracle=You may have Estrid's Invocation enter the battlefield as a copy of any enchantment you control, except it has "At the beginning of your upkeep, you may exile this enchantment. If you do, return it to the battlefield under its owner's control."

--- a/release/Magarena/scripts_missing/Etrata__the_Silencer.txt
+++ b/release/Magarena/scripts_missing/Etrata__the_Silencer.txt
@@ -1,0 +1,12 @@
+name=Etrata, the Silencer
+image=https://img.scryfall.com/cards/normal/front/f/a/fa36b142-e67e-49da-9080-c5994e275266.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Vampire,Assassin
+cost={2}{U}{B}
+pt=3/5
+ability=SN can't be blocked.;\
+        Whenever Etrata deals combat damage to a player, exile target creature that player controls and put a hit counter on that card. That player loses the game if they own three or more exiled cards with hit counters on them. Etrata's owner shuffles Etrata into their library.
+timing=main
+oracle=Etrata, the Silencer can't be blocked.\nWhenever Etrata deals combat damage to a player, exile target creature that player controls and put a hit counter on that card. That player loses the game if they own three or more exiled cards with hit counters on them. Etrata's owner shuffles Etrata into their library.

--- a/release/Magarena/scripts_missing/Ever_Watching_Threshold.txt
+++ b/release/Magarena/scripts_missing/Ever_Watching_Threshold.txt
@@ -1,0 +1,9 @@
+name=Ever-Watching Threshold
+image=https://img.scryfall.com/cards/large/en/c18/9.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={2}{U}
+ability=Whenever an opponent attacks you and/or a planeswalker you control with one or more creatures, draw a card.
+timing=enchantment
+oracle=Whenever an opponent attacks you and/or a planeswalker you control with one or more creatures, draw a card.

--- a/release/Magarena/scripts_missing/Expansion.txt
+++ b/release/Magarena/scripts_missing/Expansion.txt
@@ -1,0 +1,11 @@
+name=Expansion
+image=https://img.scryfall.com/cards/large/front/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={U/R}{U/R}
+split=Explosion
+effect=Copy target instant or sorcery spell with converted mana cost 4 or less. You may choose new targets for the copy.
+timing=removal
+oracle=Copy target instant or sorcery spell with converted mana cost 4 or less. You may choose new targets for the copy.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Experimental_Frenzy.txt
+++ b/release/Magarena/scripts_missing/Experimental_Frenzy.txt
@@ -1,0 +1,12 @@
+name=Experimental Frenzy
+image=https://img.scryfall.com/cards/normal/front/4/b/4b8f32e2-5dc8-4f1b-8a69-d3ae06378ed8.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={3}{R}
+ability=You may look at the top card of your library any time.;\
+        You may play the top card of your library.;\
+        You can't play cards from your hand.;\
+        {3}{R}: Destroy SN.
+timing=enchantment
+oracle=You may look at the top card of your library any time.\nYou may play the top card of your library.\nYou can't play cards from your hand.\n{3}{R}: Destroy Experimental Frenzy.

--- a/release/Magarena/scripts_missing/Explosion.txt
+++ b/release/Magarena/scripts_missing/Explosion.txt
@@ -1,0 +1,11 @@
+name=Explosion
+image=https://img.scryfall.com/cards/large/front/e/0/e0644c92-4d67-475e-8c8e-0e2c493682fb.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={X}{U}{U}{R}{R}
+split=Expansion
+effect=SN deals X damage to any target. Target player draws X cards.
+timing=removal
+oracle=Explosion deals X damage to any target. Target player draws X cards.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Falling_Star.txt
+++ b/release/Magarena/scripts_missing/Falling_Star.txt
@@ -1,0 +1,9 @@
+name=Falling Star
+image=https://img.scryfall.com/cards/normal/en/leg/145.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={2}{R}
+effect=Flip SN onto the playing area from a height of at least one foot. SN deals 3 damage to each creature it lands on. Tap all creatures dealt damage by SN. If SN doesn't turn completely over at least once during the flip, it has no effect.
+timing=main
+oracle=Flip Falling Star onto the playing area from a height of at least one foot. Falling Star deals 3 damage to each creature it lands on. Tap all creatures dealt damage by Falling Star. If Falling Star doesn't turn completely over at least once during the flip, it has no effect.

--- a/release/Magarena/scripts_missing/Fearless_Halberdier.txt
+++ b/release/Magarena/scripts_missing/Fearless_Halberdier.txt
@@ -1,0 +1,10 @@
+name=Fearless Halberdier
+image=https://img.scryfall.com/cards/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Warrior
+cost={2}{R}
+pt=3/2
+timing=main
+oracle=NONE

--- a/release/Magarena/scripts_missing/Finality.txt
+++ b/release/Magarena/scripts_missing/Finality.txt
@@ -1,0 +1,11 @@
+name=Finality
+image=https://img.scryfall.com/cards/normal/front/2/7/27446bd7-74d6-4831-8bb9-1c71b19aecf7.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={4}{B}{G}
+split=Find
+effect=You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.
+timing=main
+oracle=You may put two +1/+1 counters on a creature you control. Then all creatures get -4/-4 until end of turn.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Find.txt
+++ b/release/Magarena/scripts_missing/Find.txt
@@ -1,0 +1,11 @@
+name=Find
+image=https://img.scryfall.com/cards/normal/front/2/7/27446bd7-74d6-4831-8bb9-1c71b19aecf7.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={B/G}{B/G}
+split=Finality
+effect=Return up to two target creature cards from your graveyard to your hand.
+timing=main
+oracle=Return up to two target creature cards from your graveyard to your hand.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Fire_Urchin.txt
+++ b/release/Magarena/scripts_missing/Fire_Urchin.txt
@@ -1,0 +1,12 @@
+name=Fire Urchin
+image=https://img.scryfall.com/cards/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Elemental
+cost={1}{R}
+pt=1/3
+ability=Trample;\
+        Whenever you cast an instant or sorcery spell, SN gets +1/+0 until end of turn.
+timing=main
+oracle=Trample\nWhenever you cast an instant or sorcery spell, Fire Urchin gets +1/+0 until end of turn.

--- a/release/Magarena/scripts_missing/Firemind_s_Research.txt
+++ b/release/Magarena/scripts_missing/Firemind_s_Research.txt
@@ -1,0 +1,11 @@
+name=Firemind's Research
+image=https://img.scryfall.com/cards/normal/front/8/7/87c63615-5e84-409d-bb85-47af89b13714.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={U}{R}
+ability=Whenever you cast an instant or sorcery spell, put a charge counter on SN.;\
+        {1}{U}, Remove two charge counters from SN: Draw a card.;\
+        {1}{R}, Remove five charge counters from SN: It deals 5 damage to any target.
+timing=enchantment
+oracle=Whenever you cast an instant or sorcery spell, put a charge counter on Firemind's Research.\n{1}{U}, Remove two charge counters from Firemind's Research: Draw a card.\n{1}{R}, Remove five charge counters from Firemind's Research: It deals 5 damage to any target.

--- a/release/Magarena/scripts_missing/Flight_of_Equenauts.txt
+++ b/release/Magarena/scripts_missing/Flight_of_Equenauts.txt
@@ -1,0 +1,12 @@
+name=Flight of Equenauts
+image=https://img.scryfall.com/cards/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Knight
+cost={7}{W}
+pt=4/5
+ability=Convoke;\
+        Flying
+timing=main
+oracle=Convoke\nFlying

--- a/release/Magarena/scripts_missing/Flourish.txt
+++ b/release/Magarena/scripts_missing/Flourish.txt
@@ -1,0 +1,11 @@
+name=Flourish
+image=https://img.scryfall.com/cards/normal/front/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={4}{G}{W}
+split=Flower
+effect=Creatures you control get +2/+2 until end of turn.
+timing=main
+oracle=Creatures you control get +2/+2 until end of turn.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Flower.txt
+++ b/release/Magarena/scripts_missing/Flower.txt
@@ -1,0 +1,11 @@
+name=Flower
+image=https://img.scryfall.com/cards/normal/front/f/e/feb4b39f-d309-49ba-b427-240b7fdc1099.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={G/W}
+split=Flourish
+effect=Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle your library.
+timing=main
+oracle=Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle your library.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Forge_of_Heroes.txt
+++ b/release/Magarena/scripts_missing/Forge_of_Heroes.txt
@@ -1,0 +1,9 @@
+name=Forge of Heroes
+image=https://img.scryfall.com/cards/normal/en/c18/58.jpg
+value=2.500
+rarity=C
+type=Land
+ability={T}: Add {C}.;\
+        {T}: Choose target commander that entered the battlefield this turn. Put a +1/+1 counter on it if it's a creature and a loyalty counter on it if it's a planeswalker.
+timing=land
+oracle={T}: Add {C}.\n{T}: Choose target commander that entered the battlefield this turn. Put a +1/+1 counter on it if it's a creature and a loyalty counter on it if it's a planeswalker.

--- a/release/Magarena/scripts_missing/Fresh_Faced_Recruit.txt
+++ b/release/Magarena/scripts_missing/Fresh_Faced_Recruit.txt
@@ -1,0 +1,11 @@
+name=Fresh-Faced Recruit
+image=https://img.scryfall.com/cards/large/front/a/8/a8b19518-7752-4673-a7d8-ae2e0070129c.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Soldier
+cost={1}{R/W}
+pt=2/1
+ability=As long as it's your turn, SN has first strike.
+timing=main
+oracle=As long as it's your turn, Fresh-Faced Recruit has first strike.

--- a/release/Magarena/scripts_missing/Fury_Storm.txt
+++ b/release/Magarena/scripts_missing/Fury_Storm.txt
@@ -1,0 +1,9 @@
+name=Fury Storm
+image=https://img.scryfall.com/cards/normal/en/c18/22.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={2}{R}{R}
+effect=When you cast this spell, copy it for each time you've cast your commander from the command zone this game. You may choose new targets for the copies.~Copy target instant or sorcery spell. You may choose new targets for the copy.
+timing=removal
+oracle=When you cast this spell, copy it for each time you've cast your commander from the command zone this game. You may choose new targets for the copies.\nCopy target instant or sorcery spell. You may choose new targets for the copy.

--- a/release/Magarena/scripts_missing/Garrison_Sergeant.txt
+++ b/release/Magarena/scripts_missing/Garrison_Sergeant.txt
@@ -1,0 +1,11 @@
+name=Garrison Sergeant
+image=https://img.scryfall.com/cards/normal/front/2/b/2bd957a1-a354-48e9-80ad-66e49aa845fc.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Viashino,Soldier
+cost={3}{R}{W}
+pt=3/3
+ability=SN has double strike as long as you control a Gate.
+timing=main
+oracle=Garrison Sergeant has double strike as long as you control a Gate.

--- a/release/Magarena/scripts_missing/Gatekeeper_Gargoyle.txt
+++ b/release/Magarena/scripts_missing/Gatekeeper_Gargoyle.txt
@@ -1,0 +1,12 @@
+name=Gatekeeper Gargoyle
+image=https://img.scryfall.com/cards/normal/front/4/b/4bbdd54e-5d7e-4e4b-8d59-4e3f46877d39.jpg
+value=2.500
+rarity=U
+type=Artifact,Creature
+subtype=Gargoyle
+cost={6}
+pt=3/3
+ability=Flying;\
+        SN enters the battlefield with a +1/+1 counter on it for each Gate you control.
+timing=main
+oracle=Flying\nGatekeeper Gargoyle enters the battlefield with a +1/+1 counter on it for each Gate you control.

--- a/release/Magarena/scripts_missing/Gateway_Plaza.txt
+++ b/release/Magarena/scripts_missing/Gateway_Plaza.txt
@@ -1,0 +1,11 @@
+name=Gateway Plaza
+image=https://img.scryfall.com/cards/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg
+value=2.500
+rarity=C
+type=Land
+subtype=Gate
+ability=SN enters the battlefield tapped.;\
+        When SN enters the battlefield, sacrifice it unless you pay {1}.;\
+        {T}: Add one mana of any color.
+timing=land
+oracle=Gateway Plaza enters the battlefield tapped.\nWhen Gateway Plaza enters the battlefield, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.

--- a/release/Magarena/scripts_missing/Generous_Stray.txt
+++ b/release/Magarena/scripts_missing/Generous_Stray.txt
@@ -1,0 +1,11 @@
+name=Generous Stray
+image=https://img.scryfall.com/cards/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Cat
+cost={2}{G}
+pt=1/2
+ability=When SN enters the battlefield, draw a card.
+timing=main
+oracle=When Generous Stray enters the battlefield, draw a card.

--- a/release/Magarena/scripts_missing/Genesis_Storm.txt
+++ b/release/Magarena/scripts_missing/Genesis_Storm.txt
@@ -1,0 +1,9 @@
+name=Genesis Storm
+image=https://img.scryfall.com/cards/normal/en/c18/30.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={4}{G}{G}
+effect=When you cast this spell, copy it for each time you've cast your commander from the command zone this game.~Reveal cards from the top of your library until you reveal a nonland permanent card. You may put that card onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield on the bottom of your library in a random order.
+timing=main
+oracle=When you cast this spell, copy it for each time you've cast your commander from the command zone this game.\nReveal cards from the top of your library until you reveal a nonland permanent card. You may put that card onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield on the bottom of your library in a random order.

--- a/release/Magarena/scripts_missing/Geode_Golem.txt
+++ b/release/Magarena/scripts_missing/Geode_Golem.txt
@@ -1,0 +1,12 @@
+name=Geode Golem
+image=https://img.scryfall.com/cards/normal/en/c18/56.jpg
+value=2.500
+rarity=U
+type=Artifact,Creature
+subtype=Golem
+cost={5}
+pt=5/3
+ability=Trample;\
+        Whenever SN deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost.
+timing=main
+oracle=Trample\nWhenever Geode Golem deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost.

--- a/release/Magarena/scripts_missing/Gird_for_Battle.txt
+++ b/release/Magarena/scripts_missing/Gird_for_Battle.txt
@@ -1,0 +1,9 @@
+name=Gird for Battle
+image=https://img.scryfall.com/cards/normal/front/f/9/f9f731df-eb40-44c8-a72d-f377c824584d.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={W}
+effect=Put a +1/+1 counter on each of up to two target creatures.
+timing=main
+oracle=Put a +1/+1 counter on each of up to two target creatures.

--- a/release/Magarena/scripts_missing/Glaive_of_the_Guildpact.txt
+++ b/release/Magarena/scripts_missing/Glaive_of_the_Guildpact.txt
@@ -1,0 +1,11 @@
+name=Glaive of the Guildpact
+image=https://img.scryfall.com/cards/normal/front/e/1/e19723ad-7bd2-49ee-a57a-ece99018f4e8.jpg
+value=2.500
+rarity=U
+type=Artifact
+subtype=Equipment
+cost={2}
+ability=Equipped creature gets +1/+0 for each Gate you control and has vigilance and menace.;\
+        Equip {3}
+timing=equipment
+oracle=Equipped creature gets +1/+0 for each Gate you control and has vigilance and menace.\nEquip {3}

--- a/release/Magarena/scripts_missing/Glowspore_Shaman.txt
+++ b/release/Magarena/scripts_missing/Glowspore_Shaman.txt
@@ -1,0 +1,11 @@
+name=Glowspore Shaman
+image=https://img.scryfall.com/cards/normal/front/0/8/08fe260a-d204-4e75-b3e5-0cd9b4ca7084.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Shaman
+cost={B}{G}
+pt=3/1
+ability=When SN enters the battlefield, put the top three cards of your library into your graveyard. You may put a land card from your graveyard on top of your library.
+timing=main
+oracle=When Glowspore Shaman enters the battlefield, put the top three cards of your library into your graveyard. You may put a land card from your graveyard on top of your library.

--- a/release/Magarena/scripts_missing/Goblin_Banneret.txt
+++ b/release/Magarena/scripts_missing/Goblin_Banneret.txt
@@ -1,0 +1,12 @@
+name=Goblin Banneret
+image=https://img.scryfall.com/cards/normal/front/9/0/90b3b56c-5236-4319-b17e-5f71143a7906.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Goblin,Soldier
+cost={R}
+pt=1/1
+ability=Mentor;\
+        {1}{R}: SN gets +2/+0 until end of turn.
+timing=main
+oracle=Mentor\n{1}{R}: Goblin Banneret gets +2/+0 until end of turn.

--- a/release/Magarena/scripts_missing/Goblin_Cratermaker.txt
+++ b/release/Magarena/scripts_missing/Goblin_Cratermaker.txt
@@ -1,0 +1,13 @@
+name=Goblin Cratermaker
+image=https://img.scryfall.com/cards/normal/front/8/6/86ecaedc-08f1-4de7-aae8-056df57940e0.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Goblin,Warrior
+cost={1}{R}
+pt=2/2
+ability={1}, Sacrifice SN: Choose one — \
+        (1) SN deals 2 damage to target creature. \
+        (2) Destroy target colorless nonland permanent.
+timing=main
+oracle={1}, Sacrifice Goblin Cratermaker: Choose one —\n• Goblin Cratermaker deals 2 damage to target creature.\n• Destroy target colorless nonland permanent.

--- a/release/Magarena/scripts_missing/Goblin_Locksmith.txt
+++ b/release/Magarena/scripts_missing/Goblin_Locksmith.txt
@@ -1,0 +1,11 @@
+name=Goblin Locksmith
+image=https://img.scryfall.com/cards/normal/front/c/f/cf2bed0a-990a-499a-af0a-52b77557d7cb.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Goblin,Rogue
+cost={1}{R}
+pt=2/1
+ability=Whenever SN attacks, creatures with defender can't block this turn.
+timing=main
+oracle=Whenever Goblin Locksmith attacks, creatures with defender can't block this turn.

--- a/release/Magarena/scripts_missing/Golgari_Findbroker.txt
+++ b/release/Magarena/scripts_missing/Golgari_Findbroker.txt
@@ -1,0 +1,11 @@
+name=Golgari Findbroker
+image=https://img.scryfall.com/cards/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Shaman
+cost={B}{B}{G}{G}
+pt=3/4
+ability=When SN enters the battlefield, return target permanent card from your graveyard to your hand.
+timing=main
+oracle=When Golgari Findbroker enters the battlefield, return target permanent card from your graveyard to your hand.

--- a/release/Magarena/scripts_missing/Golgari_Locket.txt
+++ b/release/Magarena/scripts_missing/Golgari_Locket.txt
@@ -1,0 +1,10 @@
+name=Golgari Locket
+image=https://img.scryfall.com/cards/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg
+value=2.500
+rarity=C
+type=Artifact
+cost={3}
+ability={T}: Add {B} or {G}.;\
+        {B/G}{B/G}{B/G}{B/G}, {T}, Sacrifice SN: Draw two cards.
+timing=artifact
+oracle={T}: Add {B} or {G}.\n{B/G}{B/G}{B/G}{B/G}, {T}, Sacrifice Golgari Locket: Draw two cards.

--- a/release/Magarena/scripts_missing/Golgari_Raiders.txt
+++ b/release/Magarena/scripts_missing/Golgari_Raiders.txt
@@ -1,0 +1,12 @@
+name=Golgari Raiders
+image=https://img.scryfall.com/cards/normal/front/3/7/37284ba8-441c-4cf6-95c6-6a0f52e6d36d.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Warrior
+cost={3}{G}
+pt=0/0
+ability=Haste;\
+        SN enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.
+timing=fmain
+oracle=Haste\nUndergrowth — Golgari Raiders enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.

--- a/release/Magarena/scripts_missing/Grappling_Sundew.txt
+++ b/release/Magarena/scripts_missing/Grappling_Sundew.txt
@@ -1,0 +1,12 @@
+name=Grappling Sundew
+image=https://img.scryfall.com/cards/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Plant
+cost={1}{G}
+pt=0/4
+ability=Defender, reach;\
+        {4}{G}: SN gains indestructible until end of turn.
+timing=smain
+oracle=Defender, reach\n{4}{G}: Grappling Sundew gains indestructible until end of turn.

--- a/release/Magarena/scripts_missing/Gravitic_Punch.txt
+++ b/release/Magarena/scripts_missing/Gravitic_Punch.txt
@@ -1,0 +1,9 @@
+name=Gravitic Punch
+image=https://img.scryfall.com/cards/normal/front/0/5/05fe0428-6e7d-49d4-9a29-80a3589f565a.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={3}{R}
+effect=Target creature you control deals damage equal to its power to target player.~Jump-start
+timing=main
+oracle=Target creature you control deals damage equal to its power to target player.\nJump-start

--- a/release/Magarena/scripts_missing/Gruesome_Menagerie.txt
+++ b/release/Magarena/scripts_missing/Gruesome_Menagerie.txt
@@ -1,0 +1,9 @@
+name=Gruesome Menagerie
+image=https://img.scryfall.com/cards/normal/front/7/3/73c0e4d9-bf0d-4e28-a647-9010701a915e.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={3}{B}{B}
+effect=Choose a creature card with converted mana cost 1 in your graveyard, then do the same for creature cards with converted mana costs 2 and 3. Return those cards to the battlefield.
+timing=main
+oracle=Choose a creature card with converted mana cost 1 in your graveyard, then do the same for creature cards with converted mana costs 2 and 3. Return those cards to the battlefield.

--- a/release/Magarena/scripts_missing/Guild_Summit.txt
+++ b/release/Magarena/scripts_missing/Guild_Summit.txt
@@ -1,0 +1,10 @@
+name=Guild Summit
+image=https://img.scryfall.com/cards/normal/front/d/9/d952259f-9e0a-49af-9dfb-3cad1a1bb3a8.jpg
+value=2.500
+rarity=U
+type=Enchantment
+cost={2}{U}
+ability=When SN enters the battlefield, you may tap any number of untapped Gates you control. Draw a card for each Gate tapped this way.;\
+        Whenever a Gate enters the battlefield under your control, draw a card.
+timing=enchantment
+oracle=When Guild Summit enters the battlefield, you may tap any number of untapped Gates you control. Draw a card for each Gate tapped this way.\nWhenever a Gate enters the battlefield under your control, draw a card.

--- a/release/Magarena/scripts_missing/Guildmages__Forum.txt
+++ b/release/Magarena/scripts_missing/Guildmages__Forum.txt
@@ -1,0 +1,9 @@
+name=Guildmages' Forum
+image=https://img.scryfall.com/cards/normal/front/c/b/cba12bda-d460-4206-8469-4357c967b9b8.jpg
+value=2.500
+rarity=R
+type=Land
+ability={T}: Add {C}.;\
+        {1}, {T}: Add one mana of any color. If that mana is spent on a multicolored creature spell, that creature enters the battlefield with an additional +1/+1 counter on it.
+timing=land
+oracle={T}: Add {C}.\n{1}, {T}: Add one mana of any color. If that mana is spent on a multicolored creature spell, that creature enters the battlefield with an additional +1/+1 counter on it.

--- a/release/Magarena/scripts_missing/Gyrus__Waker_of_Corpses.txt
+++ b/release/Magarena/scripts_missing/Gyrus__Waker_of_Corpses.txt
@@ -1,0 +1,12 @@
+name=Gyrus, Waker of Corpses
+image=https://img.scryfall.com/cards/normal/en/c18/41.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Hydra
+cost={X}{B}{R}{G}
+pt=0/0
+ability=SN enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.;\
+        Whenever Gyrus attacks, you may exile target creature card with lesser power from your graveyard. If you do, create a token that's a copy of that card and that's tapped and attacking. Exile the token at end of combat.
+timing=main
+oracle=Gyrus, Waker of Corpses enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.\nWhenever Gyrus attacks, you may exile target creature card with lesser power from your graveyard. If you do, create a token that's a copy of that card and that's tapped and attacking. Exile the token at end of combat.

--- a/release/Magarena/scripts_missing/Haazda_Marshal.txt
+++ b/release/Magarena/scripts_missing/Haazda_Marshal.txt
@@ -1,0 +1,11 @@
+name=Haazda Marshal
+image=https://img.scryfall.com/cards/normal/front/5/c/5c561d89-b02d-4f1a-b49a-cdf2def3404d.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Soldier
+cost={W}
+pt=1/1
+ability=Whenever SN and at least two other creatures attack, create a 1/1 white Soldier creature token with lifelink.
+timing=main
+oracle=Whenever Haazda Marshal and at least two other creatures attack, create a 1/1 white Soldier creature token with lifelink.

--- a/release/Magarena/scripts_missing/Hammer_Dropper.txt
+++ b/release/Magarena/scripts_missing/Hammer_Dropper.txt
@@ -1,0 +1,11 @@
+name=Hammer Dropper
+image=https://img.scryfall.com/cards/normal/front/9/e/9efac789-587b-45c1-b16e-616e9486b59b.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Giant,Soldier
+cost={2}{R}{W}
+pt=5/2
+ability=Mentor
+timing=main
+oracle=Mentor

--- a/release/Magarena/scripts_missing/Hatchery_Spider.txt
+++ b/release/Magarena/scripts_missing/Hatchery_Spider.txt
@@ -1,0 +1,12 @@
+name=Hatchery Spider
+image=https://img.scryfall.com/cards/normal/front/0/b/0b841904-202c-4b42-869a-e345112ab1c8.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Spider
+cost={5}{G}{G}
+pt=5/7
+ability=Reach;\
+        When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with converted mana cost X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.
+timing=main
+oracle=Reach\nUndergrowth — When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with converted mana cost X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.

--- a/release/Magarena/scripts_missing/Healer_s_Hawk.txt
+++ b/release/Magarena/scripts_missing/Healer_s_Hawk.txt
@@ -1,0 +1,11 @@
+name=Healer's Hawk
+image=https://img.scryfall.com/cards/normal/front/3/3/3313bd5c-b657-47a3-822a-dd0d9165492a.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Bird
+cost={W}
+pt=1/1
+ability=Flying, lifelink
+timing=main
+oracle=Flying, lifelink

--- a/release/Magarena/scripts_missing/Heavenly_Blademaster.txt
+++ b/release/Magarena/scripts_missing/Heavenly_Blademaster.txt
@@ -1,0 +1,13 @@
+name=Heavenly Blademaster
+image=https://img.scryfall.com/cards/normal/en/c18/3.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Angel
+cost={5}{W}
+pt=3/6
+ability=Flying, double strike;\
+        When SN enters the battlefield, you may attach any number of Auras and Equipment you control to it.;\
+        Other creatures you control get +1/+1 for each Aura and Equipment attached to SN.
+timing=main
+oracle=Flying, double strike\nWhen Heavenly Blademaster enters the battlefield, you may attach any number of Auras and Equipment you control to it.\nOther creatures you control get +1/+1 for each Aura and Equipment attached to Heavenly Blademaster.

--- a/release/Magarena/scripts_missing/Hellkite_Whelp.txt
+++ b/release/Magarena/scripts_missing/Hellkite_Whelp.txt
@@ -1,0 +1,12 @@
+name=Hellkite Whelp
+image=https://img.scryfall.com/cards/normal/front/6/5/65e902e8-bbd5-40fe-a655-45d3d3bc9fde.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Dragon
+cost={4}{R}
+pt=3/3
+ability=Flying;\
+        Whenever SN attacks, it deals 1 damage to target creature defending player controls.
+timing=main
+oracle=Flying\nWhenever Hellkite Whelp attacks, it deals 1 damage to target creature defending player controls.

--- a/release/Magarena/scripts_missing/Hired_Poisoner.txt
+++ b/release/Magarena/scripts_missing/Hired_Poisoner.txt
@@ -1,0 +1,11 @@
+name=Hired Poisoner
+image=https://img.scryfall.com/cards/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Assassin
+cost={B}
+pt=1/1
+ability=Deathtouch
+timing=main
+oracle=Deathtouch

--- a/release/Magarena/scripts_missing/House_Guildmage.txt
+++ b/release/Magarena/scripts_missing/House_Guildmage.txt
@@ -1,0 +1,12 @@
+name=House Guildmage
+image=https://img.scryfall.com/cards/normal/front/4/5/45ee7bc8-d5cf-47b1-93c2-7e1d5f536c85.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Wizard
+cost={U}{B}
+pt=2/2
+ability={1}{U}, {T}: Target creature doesn't untap during its controller's next untap step.;\
+        {2}{B}, {T}: Surveil 2.
+timing=main
+oracle={1}{U}, {T}: Target creature doesn't untap during its controller's next untap step.\n{2}{B}, {T}: Surveil 2.

--- a/release/Magarena/scripts_missing/Hunted_Witness.txt
+++ b/release/Magarena/scripts_missing/Hunted_Witness.txt
@@ -1,0 +1,11 @@
+name=Hunted Witness
+image=https://img.scryfall.com/cards/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human
+cost={W}
+pt=1/1
+ability=When SN dies, create a 1/1 white Soldier creature token with lifelink.
+timing=main
+oracle=When Hunted Witness dies, create a 1/1 white Soldier creature token with lifelink.

--- a/release/Magarena/scripts_missing/Hypothesizzle.txt
+++ b/release/Magarena/scripts_missing/Hypothesizzle.txt
@@ -1,0 +1,9 @@
+name=Hypothesizzle
+image=https://img.scryfall.com/cards/normal/front/d/5/d5690329-feb8-49c0-8f59-ee13782e8d3b.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={3}{U}{R}
+effect=Draw two cards. Then you may discard a nonland card. When you do, SN deals 4 damage to target creature.
+timing=removal
+oracle=Draw two cards. Then you may discard a nonland card. When you do, Hypothesizzle deals 4 damage to target creature.

--- a/release/Magarena/scripts_missing/Impervious_Greatwurm.txt
+++ b/release/Magarena/scripts_missing/Impervious_Greatwurm.txt
@@ -1,0 +1,12 @@
+name=Impervious Greatwurm
+image=https://img.scryfall.com/cards/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg
+value=2.500
+rarity=M
+type=Creature
+subtype=Wurm
+cost={7}{G}{G}{G}
+pt=16/16
+ability=Convoke;\
+        Indestructible
+timing=main
+oracle=Convoke\nIndestructible

--- a/release/Magarena/scripts_missing/Inescapable_Blaze.txt
+++ b/release/Magarena/scripts_missing/Inescapable_Blaze.txt
@@ -1,0 +1,10 @@
+name=Inescapable Blaze
+image=https://img.scryfall.com/cards/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={4}{R}{R}
+ability=This spell can't be countered.
+effect=SN deals 6 damage to any target.
+timing=removal
+oracle=This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.

--- a/release/Magarena/scripts_missing/Inspiring_Unicorn.txt
+++ b/release/Magarena/scripts_missing/Inspiring_Unicorn.txt
@@ -1,0 +1,11 @@
+name=Inspiring Unicorn
+image=https://img.scryfall.com/cards/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Unicorn
+cost={2}{W}{W}
+pt=2/2
+ability=Whenever SN attacks, creatures you control get +1/+1 until end of turn.
+timing=main
+oracle=Whenever Inspiring Unicorn attacks, creatures you control get +1/+1 until end of turn.

--- a/release/Magarena/scripts_missing/Integrity.txt
+++ b/release/Magarena/scripts_missing/Integrity.txt
@@ -1,0 +1,11 @@
+name=Integrity
+image=https://img.scryfall.com/cards/normal/front/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={R/W}
+split=Intervention
+effect=Target creature gets +2/+2 until end of turn.
+timing=removal
+oracle=Target creature gets +2/+2 until end of turn.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Intervention.txt
+++ b/release/Magarena/scripts_missing/Intervention.txt
@@ -1,0 +1,11 @@
+name=Intervention
+image=https://img.scryfall.com/cards/normal/front/4/a/4a82084e-b178-442b-8007-7b2a70f3fbba.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={2}{R}{W}
+split=Integrity
+effect=SN deals 3 damage to any target and you gain 3 life.
+timing=removal
+oracle=Intervention deals 3 damage to any target and you gain 3 life.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Intrusive_Packbeast.txt
+++ b/release/Magarena/scripts_missing/Intrusive_Packbeast.txt
@@ -1,0 +1,12 @@
+name=Intrusive Packbeast
+image=https://img.scryfall.com/cards/normal/front/4/9/49266f3c-4b43-4175-8bac-16789ba6f4b9.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Beast
+cost={4}{W}
+pt=3/3
+ability=Vigilance;\
+        When SN enters the battlefield, tap up to two target creatures your opponents control.
+timing=main
+oracle=Vigilance\nWhen Intrusive Packbeast enters the battlefield, tap up to two target creatures your opponents control.

--- a/release/Magarena/scripts_missing/Invent.txt
+++ b/release/Magarena/scripts_missing/Invent.txt
@@ -1,0 +1,11 @@
+name=Invent
+image=https://img.scryfall.com/cards/large/front/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={4}{U}{R}
+split=Invert
+effect=Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle your library.
+timing=removal
+oracle=Search your library for an instant card and/or a sorcery card, reveal them, put them into your hand, then shuffle your library.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Invert.txt
+++ b/release/Magarena/scripts_missing/Invert.txt
@@ -1,0 +1,11 @@
+name=Invert
+image=https://img.scryfall.com/cards/large/front/0/5/054a4e4f-8baa-41cf-b24c-d068e8b9a070.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={U/R}
+split=Invent
+effect=Switch the power and toughness of each of up to two target creatures until end of turn.
+timing=removal
+oracle=Switch the power and toughness of each of up to two target creatures until end of turn.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Ionize.txt
+++ b/release/Magarena/scripts_missing/Ionize.txt
@@ -1,0 +1,9 @@
+name=Ionize
+image=https://img.scryfall.com/cards/normal/front/f/1/f161f7d2-eaa1-4931-93f9-befa8b5df821.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={1}{U}{R}
+effect=Counter target spell. SN deals 2 damage to that spell's controller.
+timing=counter
+oracle=Counter target spell. Ionize deals 2 damage to that spell's controller.

--- a/release/Magarena/scripts_missing/Isolated_Watchtower.txt
+++ b/release/Magarena/scripts_missing/Isolated_Watchtower.txt
@@ -1,0 +1,9 @@
+name=Isolated Watchtower
+image=https://img.scryfall.com/cards/normal/en/c18/59.jpg
+value=2.500
+rarity=R
+type=Land
+ability={T}: Add {C}.;\
+        {2}, {T}: Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate this ability only if an opponent controls at least two more lands than you.
+timing=land
+oracle={T}: Add {C}.\n{2}, {T}: Scry 1, then you may reveal the top card of your library. If a basic land card is revealed this way, put it onto the battlefield tapped. Activate this ability only if an opponent controls at least two more lands than you.

--- a/release/Magarena/scripts_missing/Izoni__Thousand_Eyed.txt
+++ b/release/Magarena/scripts_missing/Izoni__Thousand_Eyed.txt
@@ -1,0 +1,12 @@
+name=Izoni, Thousand-Eyed
+image=https://img.scryfall.com/cards/large/front/7/5/75955b0e-12d6-40ba-aab5-b7b7e2bde121.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Elf,Shaman
+cost={2}{B}{B}{G}{G}
+pt=2/3
+ability=Undergrowth — When SN enters the battlefield, create a 1/1 black and green Insect creature token for each creature card in your graveyard.;\
+        {B}{G}, Sacrifice another creature: You gain 1 life and draw a card.
+timing=main
+oracle=Undergrowth — When Izoni, Thousand-Eyed enters the battlefield, create a 1/1 black and green Insect creature token for each creature card in your graveyard.\n{B}{G}, Sacrifice another creature: You gain 1 life and draw a card.

--- a/release/Magarena/scripts_missing/Izzet_Locket.txt
+++ b/release/Magarena/scripts_missing/Izzet_Locket.txt
@@ -1,0 +1,10 @@
+name=Izzet Locket
+image=https://img.scryfall.com/cards/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg
+value=2.500
+rarity=C
+type=Artifact
+cost={3}
+ability={T}: Add {U} or {R}.;\
+        {U/R}{U/R}{U/R}{U/R}, {T}, Sacrifice SN: Draw two cards.
+timing=artifact
+oracle={T}: Add {U} or {R}.\n{U/R}{U/R}{U/R}{U/R}, {T}, Sacrifice Izzet Locket: Draw two cards.

--- a/release/Magarena/scripts_missing/Jeweled_Bird.txt
+++ b/release/Magarena/scripts_missing/Jeweled_Bird.txt
@@ -1,0 +1,10 @@
+name=Jeweled Bird
+image=https://img.scryfall.com/cards/normal/en/arn/66.jpg
+value=2.500
+rarity=U
+type=Artifact
+cost={1}
+ability=Remove SN from your deck before playing if you're not playing for ante.;\
+        {T}: Ante SN. If you do, put all other cards you own from the ante into your graveyard, then draw a card.
+timing=artifact
+oracle=Remove Jeweled Bird from your deck before playing if you're not playing for ante.\n{T}: Ante Jeweled Bird. If you do, put all other cards you own from the ante into your graveyard, then draw a card.

--- a/release/Magarena/scripts_missing/Jeweled_Bird.txt
+++ b/release/Magarena/scripts_missing/Jeweled_Bird.txt
@@ -8,3 +8,4 @@ ability=Remove SN from your deck before playing if you're not playing for ante.;
         {T}: Ante SN. If you do, put all other cards you own from the ante into your graveyard, then draw a card.
 timing=artifact
 oracle=Remove Jeweled Bird from your deck before playing if you're not playing for ante.\n{T}: Ante Jeweled Bird. If you do, put all other cards you own from the ante into your graveyard, then draw a card.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Join_Shields.txt
+++ b/release/Magarena/scripts_missing/Join_Shields.txt
@@ -1,0 +1,9 @@
+name=Join Shields
+image=https://img.scryfall.com/cards/normal/front/9/1/91898d8a-589d-43db-8dc4-0ec6a3bd6d49.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={3}{G}{W}
+effect=Untap all creatures you control. They gain hexproof and indestructible until end of turn.
+timing=removal
+oracle=Untap all creatures you control. They gain hexproof and indestructible until end of turn.

--- a/release/Magarena/scripts_missing/Justice_Strike.txt
+++ b/release/Magarena/scripts_missing/Justice_Strike.txt
@@ -1,0 +1,9 @@
+name=Justice Strike
+image=https://img.scryfall.com/cards/normal/front/2/7/27619ce9-59df-4f0e-a5db-2d32a530e547.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={R}{W}
+effect=Target creature deals damage to itself equal to its power.
+timing=removal
+oracle=Target creature deals damage to itself equal to its power.

--- a/release/Magarena/scripts_missing/Kestia__the_Cultivator.txt
+++ b/release/Magarena/scripts_missing/Kestia__the_Cultivator.txt
@@ -1,0 +1,13 @@
+name=Kestia, the Cultivator
+image=https://img.scryfall.com/cards/normal/en/c18/42.jpg
+value=2.500
+rarity=M
+type=Legendary,Enchantment,Creature
+subtype=Nymph
+cost={1}{G}{W}{U}
+pt=4/4
+ability=Bestow {3}{G}{W}{U};\
+        Enchanted creature gets +4/+4.;\
+        Whenever an enchanted creature or enchantment creature you control attacks, draw a card.
+timing=main
+oracle=Bestow {3}{G}{W}{U}\nEnchanted creature gets +4/+4.\nWhenever an enchanted creature or enchantment creature you control attacks, draw a card.

--- a/release/Magarena/scripts_missing/Knight_of_Autumn.txt
+++ b/release/Magarena/scripts_missing/Knight_of_Autumn.txt
@@ -1,0 +1,14 @@
+name=Knight of Autumn
+image=https://img.scryfall.com/cards/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Dryad,Knight
+cost={1}{G}{W}
+pt=2/1
+ability=When SN enters the battlefield, choose one — \
+        (1) Put two +1/+1 counters on SN. \
+        (2) Destroy target artifact or enchantment. \
+        (3) You gain 4 life.
+timing=main
+oracle=When Knight of Autumn enters the battlefield, choose one —\n• Put two +1/+1 counters on Knight of Autumn.\n• Destroy target artifact or enchantment.\n• You gain 4 life.

--- a/release/Magarena/scripts_missing/Kraul_Foragers.txt
+++ b/release/Magarena/scripts_missing/Kraul_Foragers.txt
@@ -1,0 +1,11 @@
+name=Kraul Foragers
+image=https://img.scryfall.com/cards/normal/front/b/5/b5ed4b08-8583-4ad4-b0ba-0463d367efc8.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Insect,Scout
+cost={4}{G}
+pt=4/4
+ability=Undergrowth — When SN enters the battlefield, you gain 1 life for each creature card in your graveyard.
+timing=main
+oracle=Undergrowth — When Kraul Foragers enters the battlefield, you gain 1 life for each creature card in your graveyard.

--- a/release/Magarena/scripts_missing/Kraul_Harpooner.txt
+++ b/release/Magarena/scripts_missing/Kraul_Harpooner.txt
@@ -1,0 +1,12 @@
+name=Kraul Harpooner
+image=https://img.scryfall.com/cards/normal/front/f/6/f6d3c086-9ce4-41c3-8402-2818f1b27192.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Insect,Warrior
+cost={1}{G}
+pt=3/2
+ability=Reach;\
+        When SN enters the battlefield, choose up to one target creature with flying you don't control. SN gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have SN fight that creature.
+timing=main
+oracle=Reach\nUndergrowth — When Kraul Harpooner enters the battlefield, choose up to one target creature with flying you don't control. Kraul Harpooner gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard, then you may have Kraul Harpooner fight that creature.

--- a/release/Magarena/scripts_missing/Kraul_Raider.txt
+++ b/release/Magarena/scripts_missing/Kraul_Raider.txt
@@ -1,0 +1,11 @@
+name=Kraul Raider
+image=https://img.scryfall.com/cards/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Insect,Warrior
+cost={2}{B}
+pt=2/3
+ability=Menace
+timing=main
+oracle=Menace

--- a/release/Magarena/scripts_missing/Kraul_Swarm.txt
+++ b/release/Magarena/scripts_missing/Kraul_Swarm.txt
@@ -1,0 +1,12 @@
+name=Kraul Swarm
+image=https://img.scryfall.com/cards/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Insect,Warrior
+cost={4}{B}
+pt=4/1
+ability=Flying;\
+        {2}{B}, Discard a creature card: Return SN from your graveyard to your hand.
+timing=main
+oracle=Flying\n{2}{B}, Discard a creature card: Return Kraul Swarm from your graveyard to your hand.

--- a/release/Magarena/scripts_missing/Lava_Coil.txt
+++ b/release/Magarena/scripts_missing/Lava_Coil.txt
@@ -1,0 +1,9 @@
+name=Lava Coil
+image=https://img.scryfall.com/cards/normal/front/f/6/f6135cf4-50c2-4e44-b9b0-96e1187a2200.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={1}{R}
+effect=SN deals 4 damage to target creature. If that creature would die this turn, exile it instead.
+timing=main
+oracle=Lava Coil deals 4 damage to target creature. If that creature would die this turn, exile it instead.

--- a/release/Magarena/scripts_missing/Lazav__the_Multifarious.txt
+++ b/release/Magarena/scripts_missing/Lazav__the_Multifarious.txt
@@ -1,0 +1,12 @@
+name=Lazav, the Multifarious
+image=https://img.scryfall.com/cards/normal/front/2/4/24c1e710-f61c-4dd6-b620-6d2e1ecab689.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Shapeshifter
+cost={U}{B}
+pt=1/3
+ability=When SN enters the battlefield, surveil 1.;\
+        {X}: SN becomes a copy of target creature card in your graveyard with converted mana cost X, except its name is SN, it's legendary in addition to its other types, and it has this ability.
+timing=main
+oracle=When Lazav, the Multifarious enters the battlefield, surveil 1.\n{X}: Lazav, the Multifarious becomes a copy of target creature card in your graveyard with converted mana cost X, except its name is Lazav, the Multifarious, it's legendary in addition to its other types, and it has this ability.

--- a/release/Magarena/scripts_missing/League_Guildmage.txt
+++ b/release/Magarena/scripts_missing/League_Guildmage.txt
@@ -1,0 +1,12 @@
+name=League Guildmage
+image=https://img.scryfall.com/cards/normal/front/7/4/7439118d-4869-486e-8930-6e00db2634b2.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Wizard
+cost={U}{R}
+pt=2/2
+ability={3}{U}, {T}: Draw a card.;\
+        {X}{R}, {T}: Copy target instant or sorcery spell you control with converted mana cost X. You may choose new targets for the copy.
+timing=main
+oracle={3}{U}, {T}: Draw a card.\n{X}{R}, {T}: Copy target instant or sorcery spell you control with converted mana cost X. You may choose new targets for the copy.

--- a/release/Magarena/scripts_missing/Leapfrog.txt
+++ b/release/Magarena/scripts_missing/Leapfrog.txt
@@ -1,0 +1,11 @@
+name=Leapfrog
+image=https://img.scryfall.com/cards/normal/front/2/e/2e415a03-f7f8-4fca-954a-ef21b4a2c60f.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Frog
+cost={2}{U}
+pt=3/1
+ability=SN has flying as long as you've cast an instant or sorcery spell this turn.
+timing=main
+oracle=Leapfrog has flying as long as you've cast an instant or sorcery spell this turn.

--- a/release/Magarena/scripts_missing/Ledev_Champion.txt
+++ b/release/Magarena/scripts_missing/Ledev_Champion.txt
@@ -1,0 +1,12 @@
+name=Ledev Champion
+image=https://img.scryfall.com/cards/normal/front/b/c/bc4f508b-a48d-4462-9d89-ee2ead3a0847.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Knight
+cost={1}{G}{W}
+pt=2/2
+ability=Whenever SN attacks, you may tap any number of untapped creatures you control. SN gets +1/+1 until end of turn for each creature tapped this way.;\
+        {3}{G}{W}: Create a 1/1 white Soldier creature token with lifelink.
+timing=main
+oracle=Whenever Ledev Champion attacks, you may tap any number of untapped creatures you control. Ledev Champion gets +1/+1 until end of turn for each creature tapped this way.\n{3}{G}{W}: Create a 1/1 white Soldier creature token with lifelink.

--- a/release/Magarena/scripts_missing/Ledev_Guardian.txt
+++ b/release/Magarena/scripts_missing/Ledev_Guardian.txt
@@ -1,0 +1,11 @@
+name=Ledev Guardian
+image=https://img.scryfall.com/cards/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Knight
+cost={3}{W}
+pt=2/4
+ability=Convoke
+timing=main
+oracle=Convoke

--- a/release/Magarena/scripts_missing/Legion_Guildmage.txt
+++ b/release/Magarena/scripts_missing/Legion_Guildmage.txt
@@ -1,0 +1,12 @@
+name=Legion Guildmage
+image=https://img.scryfall.com/cards/normal/front/b/0/b03423b2-faca-4b2e-8328-8b9b7fdb7ce3.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Wizard
+cost={R}{W}
+pt=2/2
+ability={5}{R}, {T}: SN deals 3 damage to each opponent.;\
+        {2}{W}, {T}: Tap another target creature.
+timing=main
+oracle={5}{R}, {T}: Legion Guildmage deals 3 damage to each opponent.\n{2}{W}, {T}: Tap another target creature.

--- a/release/Magarena/scripts_missing/Legion_Warboss.txt
+++ b/release/Magarena/scripts_missing/Legion_Warboss.txt
@@ -1,0 +1,12 @@
+name=Legion Warboss
+image=https://img.scryfall.com/cards/normal/front/5/e/5e84cb9c-9876-47a4-aea4-78574321bc36.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Goblin,Soldier
+cost={2}{R}
+pt=2/2
+ability=Mentor;\
+        At the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token gains haste until end of turn and attacks this combat if able.
+timing=main
+oracle=Mentor\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token gains haste until end of turn and attacks this combat if able.

--- a/release/Magarena/scripts_missing/Light_of_the_Legion.txt
+++ b/release/Magarena/scripts_missing/Light_of_the_Legion.txt
@@ -1,0 +1,13 @@
+name=Light of the Legion
+image=https://img.scryfall.com/cards/normal/front/a/2/a2f1b831-ca55-4575-9dfa-c3163e3d789d.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Angel
+cost={4}{W}{W}
+pt=5/5
+ability=Flying;\
+        Mentor;\
+        When SN dies, put a +1/+1 counter on each white creature you control.
+timing=main
+oracle=Flying\nMentor\nWhen Light of the Legion dies, put a +1/+1 counter on each white creature you control.

--- a/release/Magarena/scripts_missing/Lord_Windgrace.txt
+++ b/release/Magarena/scripts_missing/Lord_Windgrace.txt
@@ -1,0 +1,14 @@
+name=Lord Windgrace
+image=https://img.scryfall.com/cards/normal/en/c18/43.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Windgrace
+cost={2}{B}{R}{G}
+loyalty=5
+ability=+2: Discard a card, then draw a card. If a land card is discarded this way, draw an additional card.;\
+        −3: Return up to two target land cards from your graveyard to the battlefield.;\
+        −11: Destroy up to six target nonland permanents, then create six 2/2 green Cat Warrior creature tokens with forestwalk.;\
+        SN can be your commander.
+timing=main
+oracle=+2: Discard a card, then draw a card. If a land card is discarded this way, draw an additional card.\n−3: Return up to two target land cards from your graveyard to the battlefield.\n−11: Destroy up to six target nonland permanents, then create six 2/2 green Cat Warrior creature tokens with forestwalk.\nLord Windgrace can be your commander.

--- a/release/Magarena/scripts_missing/Lotleth_Giant.txt
+++ b/release/Magarena/scripts_missing/Lotleth_Giant.txt
@@ -1,0 +1,11 @@
+name=Lotleth Giant
+image=https://img.scryfall.com/cards/normal/front/b/1/b1dc38b7-52f7-4394-b095-5442429ab291.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Zombie,Giant
+cost={6}{B}
+pt=6/5
+ability=Undergrowth — When SN enters the battlefield, it deals 1 damage to target opponent for each creature card in your graveyard.
+timing=main
+oracle=Undergrowth — When Lotleth Giant enters the battlefield, it deals 1 damage to target opponent for each creature card in your graveyard.

--- a/release/Magarena/scripts_missing/Loxodon_Restorer.txt
+++ b/release/Magarena/scripts_missing/Loxodon_Restorer.txt
@@ -1,0 +1,12 @@
+name=Loxodon Restorer
+image=https://img.scryfall.com/cards/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Elephant,Cleric
+cost={4}{W}{W}
+pt=3/4
+ability=Convoke;\
+        When SN enters the battlefield, you gain 4 life.
+timing=main
+oracle=Convoke\nWhen Loxodon Restorer enters the battlefield, you gain 4 life.

--- a/release/Magarena/scripts_missing/Loyal_Apprentice.txt
+++ b/release/Magarena/scripts_missing/Loyal_Apprentice.txt
@@ -1,0 +1,12 @@
+name=Loyal Apprentice
+image=https://img.scryfall.com/cards/normal/en/c18/23.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Artificer
+cost={1}{R}
+pt=2/1
+ability=Haste;\
+        At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.
+timing=fmain
+oracle=Haste\nLieutenant — At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.

--- a/release/Magarena/scripts_missing/Loyal_Drake.txt
+++ b/release/Magarena/scripts_missing/Loyal_Drake.txt
@@ -1,0 +1,12 @@
+name=Loyal Drake
+image=https://img.scryfall.com/cards/normal/en/c18/10.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Drake
+cost={2}{U}
+pt=2/2
+ability=Flying;\
+        At the beginning of combat on your turn, if you control your commander, draw a card.
+timing=main
+oracle=Flying\nLieutenant — At the beginning of combat on your turn, if you control your commander, draw a card.

--- a/release/Magarena/scripts_missing/Loyal_Guardian.txt
+++ b/release/Magarena/scripts_missing/Loyal_Guardian.txt
@@ -1,0 +1,12 @@
+name=Loyal Guardian
+image=https://img.scryfall.com/cards/normal/en/c18/31.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Rhino
+cost={4}{G}
+pt=4/4
+ability=Trample;\
+        At the beginning of combat on your turn, if you control your commander, put a +1/+1 counter on each creature you control.
+timing=main
+oracle=Trample\nLieutenant — At the beginning of combat on your turn, if you control your commander, put a +1/+1 counter on each creature you control.

--- a/release/Magarena/scripts_missing/Loyal_Subordinate.txt
+++ b/release/Magarena/scripts_missing/Loyal_Subordinate.txt
@@ -1,0 +1,12 @@
+name=Loyal Subordinate
+image=https://img.scryfall.com/cards/normal/en/c18/16.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Zombie
+cost={2}{B}
+pt=3/1
+ability=Menace;\
+        At the beginning of combat on your turn, if you control your commander, each opponent loses 3 life.
+timing=main
+oracle=Menace\nLieutenant — At the beginning of combat on your turn, if you control your commander, each opponent loses 3 life.

--- a/release/Magarena/scripts_missing/Loyal_Unicorn.txt
+++ b/release/Magarena/scripts_missing/Loyal_Unicorn.txt
@@ -1,0 +1,12 @@
+name=Loyal Unicorn
+image=https://img.scryfall.com/cards/normal/en/c18/4.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Unicorn
+cost={3}{W}
+pt=3/4
+ability=Vigilance;\
+        At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn. Other creatures you control gain vigilance until end of turn.
+timing=main
+oracle=Vigilance\nLieutenant — At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn. Other creatures you control gain vigilance until end of turn.

--- a/release/Magarena/scripts_missing/Magus_of_the_Balance.txt
+++ b/release/Magarena/scripts_missing/Magus_of_the_Balance.txt
@@ -1,0 +1,11 @@
+name=Magus of the Balance
+image=https://img.scryfall.com/cards/normal/en/c18/5.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Human,Wizard
+cost={1}{W}
+pt=2/2
+ability={4}{W}, {T}, Sacrifice SN: Each player chooses a number of lands they control equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.
+timing=main
+oracle={4}{W}, {T}, Sacrifice Magus of the Balance: Each player chooses a number of lands they control equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.

--- a/release/Magarena/scripts_missing/March_of_the_Multitudes.txt
+++ b/release/Magarena/scripts_missing/March_of_the_Multitudes.txt
@@ -1,0 +1,10 @@
+name=March of the Multitudes
+image=https://img.scryfall.com/cards/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg
+value=2.500
+rarity=M
+type=Instant
+cost={X}{G}{W}{W}
+ability=Convoke
+effect=Create X 1/1 white Soldier creature tokens with lifelink.
+timing=removal
+oracle=Convoke\nCreate X 1/1 white Soldier creature tokens with lifelink.

--- a/release/Magarena/scripts_missing/Mausoleum_Secrets.txt
+++ b/release/Magarena/scripts_missing/Mausoleum_Secrets.txt
@@ -1,0 +1,9 @@
+name=Mausoleum Secrets
+image=https://img.scryfall.com/cards/normal/front/2/6/26f7cf38-78cc-4139-9f2a-4dd0be7d9da8.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={1}{B}
+effect=Search your library for a black card with converted mana cost less than or equal to the number of creature cards in your graveyard, reveal it, put it into your hand, then shuffle your library.
+timing=removal
+oracle=Undergrowth — Search your library for a black card with converted mana cost less than or equal to the number of creature cards in your graveyard, reveal it, put it into your hand, then shuffle your library.

--- a/release/Magarena/scripts_missing/Maximize_Altitude.txt
+++ b/release/Magarena/scripts_missing/Maximize_Altitude.txt
@@ -1,0 +1,9 @@
+name=Maximize Altitude
+image=https://img.scryfall.com/cards/normal/front/3/b/3b5a08a0-b002-4bfe-9cac-d2bf96175f8e.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={U}
+effect=Target creature gets +1/+1 and gains flying until end of turn.~Jump-start
+timing=main
+oracle=Target creature gets +1/+1 and gains flying until end of turn.\nJump-start

--- a/release/Magarena/scripts_missing/Maximize_Velocity.txt
+++ b/release/Magarena/scripts_missing/Maximize_Velocity.txt
@@ -1,0 +1,9 @@
+name=Maximize Velocity
+image=https://img.scryfall.com/cards/normal/front/e/b/ebb7a2aa-f002-4f05-b9ec-8adee4c65e46.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={R}
+effect=Target creature gets +1/+1 and gains haste until end of turn.~Jump-start
+timing=main
+oracle=Target creature gets +1/+1 and gains haste until end of turn.\nJump-start

--- a/release/Magarena/scripts_missing/Mephitic_Vapors.txt
+++ b/release/Magarena/scripts_missing/Mephitic_Vapors.txt
@@ -1,0 +1,9 @@
+name=Mephitic Vapors
+image=https://img.scryfall.com/cards/normal/front/6/7/675640ba-37e7-4231-8524-87e8b87ea46f.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={2}{B}
+effect=All creatures get -1/-1 until end of turn.~Surveil 2.
+timing=main
+oracle=All creatures get -1/-1 until end of turn.\nSurveil 2.

--- a/release/Magarena/scripts_missing/Midnight_Reaper.txt
+++ b/release/Magarena/scripts_missing/Midnight_Reaper.txt
@@ -1,0 +1,11 @@
+name=Midnight Reaper
+image=https://img.scryfall.com/cards/normal/front/5/e/5e122fe0-51c5-404d-a7b9-3d161a426c35.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Zombie,Knight
+cost={2}{B}
+pt=3/2
+ability=Whenever a nontoken creature you control dies, SN deals 1 damage to you and you draw a card.
+timing=main
+oracle=Whenever a nontoken creature you control dies, Midnight Reaper deals 1 damage to you and you draw a card.

--- a/release/Magarena/scripts_missing/Mission_Briefing.txt
+++ b/release/Magarena/scripts_missing/Mission_Briefing.txt
@@ -1,0 +1,9 @@
+name=Mission Briefing
+image=https://img.scryfall.com/cards/normal/front/0/2/02bed34d-67d9-4ae9-b351-dc9a89daeabf.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={U}{U}
+effect=Surveil 2, then choose an instant or sorcery card in your graveyard. You may cast that card this turn. If that card would be put into your graveyard this turn, exile it instead.(To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+timing=removal
+oracle=Surveil 2, then choose an instant or sorcery card in your graveyard. You may cast that card this turn. If that card would be put into your graveyard this turn, exile it instead.(To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)

--- a/release/Magarena/scripts_missing/Mnemonic_Betrayal.txt
+++ b/release/Magarena/scripts_missing/Mnemonic_Betrayal.txt
@@ -1,0 +1,9 @@
+name=Mnemonic Betrayal
+image=https://img.scryfall.com/cards/normal/front/a/5/a5cf45aa-ed34-4add-a2ec-fc11f8c15ffa.jpg
+value=2.500
+rarity=M
+type=Sorcery
+cost={1}{U}{B}
+effect=Exile all cards from all opponents' graveyards. You may cast those cards this turn, and you may spend mana as though it were mana of any type to cast those spells. At the beginning of the next end step, if any of those cards remain exiled, return them to their owners' graveyards.~Exile SN.
+timing=main
+oracle=Exile all cards from all opponents' graveyards. You may cast those cards this turn, and you may spend mana as though it were mana of any type to cast those spells. At the beginning of the next end step, if any of those cards remain exiled, return them to their owners' graveyards.\nExile Mnemonic Betrayal.

--- a/release/Magarena/scripts_missing/Molderhulk.txt
+++ b/release/Magarena/scripts_missing/Molderhulk.txt
@@ -1,0 +1,12 @@
+name=Molderhulk
+image=https://img.scryfall.com/cards/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Fungus,Zombie
+cost={7}{B}{G}
+pt=6/6
+ability=Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.;\
+        When SN enters the battlefield, return target land card from your graveyard to the battlefield.
+timing=main
+oracle=Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.\nWhen Molderhulk enters the battlefield, return target land card from your graveyard to the battlefield.

--- a/release/Magarena/scripts_missing/Moodmark_Painter.txt
+++ b/release/Magarena/scripts_missing/Moodmark_Painter.txt
@@ -1,0 +1,11 @@
+name=Moodmark Painter
+image=https://img.scryfall.com/cards/normal/front/8/2/82903e5f-c10f-4767-a2c0-6f8cc7280fa0.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Shaman
+cost={2}{B}{B}
+pt=2/3
+ability=Undergrowth — When SN enters the battlefield, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
+timing=main
+oracle=Undergrowth — When Moodmark Painter enters the battlefield, target creature gains menace and gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.

--- a/release/Magarena/scripts_missing/Murmuring_Mystic.txt
+++ b/release/Magarena/scripts_missing/Murmuring_Mystic.txt
@@ -1,0 +1,11 @@
+name=Murmuring Mystic
+image=https://img.scryfall.com/cards/normal/front/5/f/5fc6adff-dcb3-456d-a8c2-0e77b784ff89.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Wizard
+cost={3}{U}
+pt=1/5
+ability=Whenever you cast an instant or sorcery spell, create a 1/1 blue Bird Illusion creature token with flying.
+timing=main
+oracle=Whenever you cast an instant or sorcery spell, create a 1/1 blue Bird Illusion creature token with flying.

--- a/release/Magarena/scripts_missing/Muse_Drake.txt
+++ b/release/Magarena/scripts_missing/Muse_Drake.txt
@@ -1,0 +1,12 @@
+name=Muse Drake
+image=https://img.scryfall.com/cards/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Drake
+cost={3}{U}
+pt=1/3
+ability=Flying;\
+        When SN enters the battlefield, draw a card.
+timing=main
+oracle=Flying\nWhen Muse Drake enters the battlefield, draw a card.

--- a/release/Magarena/scripts_missing/Myth_Unbound.txt
+++ b/release/Magarena/scripts_missing/Myth_Unbound.txt
@@ -1,0 +1,10 @@
+name=Myth Unbound
+image=https://img.scryfall.com/cards/normal/en/c18/32.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={2}{G}
+ability=Your commander costs {1} less to cast for each time it's been cast from the command zone this game.;\
+        Whenever your commander is put into the command zone from anywhere, draw a card.
+timing=enchantment
+oracle=Your commander costs {1} less to cast for each time it's been cast from the command zone this game.\nWhenever your commander is put into the command zone from anywhere, draw a card.

--- a/release/Magarena/scripts_missing/Necrotic_Wound.txt
+++ b/release/Magarena/scripts_missing/Necrotic_Wound.txt
@@ -1,0 +1,9 @@
+name=Necrotic Wound
+image=https://img.scryfall.com/cards/normal/front/9/a/9ab636af-5b30-4138-8e68-81f567f10417.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={B}
+effect=Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.
+timing=removal
+oracle=Undergrowth — Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.

--- a/release/Magarena/scripts_missing/Nesting_Dragon.txt
+++ b/release/Magarena/scripts_missing/Nesting_Dragon.txt
@@ -1,0 +1,12 @@
+name=Nesting Dragon
+image=https://img.scryfall.com/cards/normal/en/c18/24.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Dragon
+cost={3}{R}{R}
+pt=5/4
+ability=Flying;\
+        Whenever a land enters the battlefield under your control, create a 0/2 red Dragon Egg creature token with defender and "When this creature dies, create a 2/2 red Dragon creature token with flying and '{R}: This creature gets +1/+0 until end of turn.'"
+timing=main
+oracle=Flying\nLandfall — Whenever a land enters the battlefield under your control, create a 0/2 red Dragon Egg creature token with defender and "When this creature dies, create a 2/2 red Dragon creature token with flying and '{R}: This creature gets +1/+0 until end of turn.'"

--- a/release/Magarena/scripts_missing/Never_Happened.txt
+++ b/release/Magarena/scripts_missing/Never_Happened.txt
@@ -1,0 +1,9 @@
+name=Never Happened
+image=https://img.scryfall.com/cards/normal/front/2/8/289d3746-9e54-4983-9daa-f1a7afbdedad.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={2}{B}
+effect=Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it.
+timing=main
+oracle=Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it.

--- a/release/Magarena/scripts_missing/Night_Incarnate.txt
+++ b/release/Magarena/scripts_missing/Night_Incarnate.txt
@@ -1,0 +1,13 @@
+name=Night Incarnate
+image=https://img.scryfall.com/cards/normal/en/c18/17.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Elemental
+cost={4}{B}
+pt=3/4
+ability=Deathtouch;\
+        When SN leaves the battlefield, all creatures get -3/-3 until end of turn.;\
+        Evoke {3}{B}
+timing=main
+oracle=Deathtouch\nWhen Night Incarnate leaves the battlefield, all creatures get -3/-3 until end of turn.\nEvoke {3}{B}

--- a/release/Magarena/scripts_missing/Nightveil_Predator.txt
+++ b/release/Magarena/scripts_missing/Nightveil_Predator.txt
@@ -1,0 +1,12 @@
+name=Nightveil Predator
+image=https://img.scryfall.com/cards/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Vampire
+cost={U}{U}{B}{B}
+pt=3/3
+ability=Flying, deathtouch;\
+        Hexproof
+timing=main
+oracle=Flying, deathtouch\nHexproof

--- a/release/Magarena/scripts_missing/Nightveil_Sprite.txt
+++ b/release/Magarena/scripts_missing/Nightveil_Sprite.txt
@@ -1,0 +1,12 @@
+name=Nightveil Sprite
+image=https://img.scryfall.com/cards/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Faerie,Rogue
+cost={1}{U}
+pt=1/2
+ability=Flying;\
+        Whenever SN attacks, surveil 1.
+timing=main
+oracle=Flying\nWhenever Nightveil Sprite attacks, surveil 1.

--- a/release/Magarena/scripts_missing/Niv_Mizzet__Parun.txt
+++ b/release/Magarena/scripts_missing/Niv_Mizzet__Parun.txt
@@ -1,0 +1,14 @@
+name=Niv-Mizzet, Parun
+image=https://img.scryfall.com/cards/normal/front/8/f/8f1801f2-ea6e-4196-858e-2afc456cf6a0.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Dragon,Wizard
+cost={U}{U}{U}{R}{R}{R}
+pt=5/5
+ability=This spell can't be countered.;\
+        Flying;\
+        Whenever you draw a card, SN deals 1 damage to any target.;\
+        Whenever a player casts an instant or sorcery spell, you draw a card.
+timing=main
+oracle=This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.

--- a/release/Magarena/scripts_missing/Notion_Rain.txt
+++ b/release/Magarena/scripts_missing/Notion_Rain.txt
@@ -1,0 +1,9 @@
+name=Notion Rain
+image=https://img.scryfall.com/cards/normal/front/f/4/f4db287e-34c1-459b-882d-3db58f13eade.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={1}{U}{B}
+effect=Surveil 2, then draw two cards. SN deals 2 damage to you.
+timing=main
+oracle=Surveil 2, then draw two cards. Notion Rain deals 2 damage to you.

--- a/release/Magarena/scripts_missing/Nullhide_Ferox.txt
+++ b/release/Magarena/scripts_missing/Nullhide_Ferox.txt
@@ -1,0 +1,14 @@
+name=Nullhide Ferox
+image=https://img.scryfall.com/cards/normal/front/2/4/24c30bb0-06ba-432b-a20c-6fa79b0dc68a.jpg
+value=2.500
+rarity=M
+type=Creature
+subtype=Beast
+cost={2}{G}{G}
+pt=6/6
+ability=Hexproof;\
+        You can't cast noncreature spells.;\
+        {2}: SN loses all abilities until end of turn. Any player may activate this ability.;\
+        If a spell or ability an opponent controls causes you to discard SN, put it onto the battlefield instead of putting it into your graveyard.
+timing=main
+oracle=Hexproof\nYou can't cast noncreature spells.\n{2}: Nullhide Ferox loses all abilities until end of turn. Any player may activate this ability.\nIf a spell or ability an opponent controls causes you to discard Nullhide Ferox, put it onto the battlefield instead of putting it into your graveyard.

--- a/release/Magarena/scripts_missing/Nylea_s_Colossus.txt
+++ b/release/Magarena/scripts_missing/Nylea_s_Colossus.txt
@@ -1,0 +1,11 @@
+name=Nylea's Colossus
+image=https://img.scryfall.com/cards/normal/en/c18/33.jpg
+value=2.500
+rarity=R
+type=Enchantment,Creature
+subtype=Giant
+cost={6}{G}
+pt=6/6
+ability=Constellation — Whenever SN or another enchantment enters the battlefield under your control, double target creature's power and toughness until end of turn.
+timing=main
+oracle=Constellation — Whenever Nylea's Colossus or another enchantment enters the battlefield under your control, double target creature's power and toughness until end of turn.

--- a/release/Magarena/scripts_missing/Ochran_Assassin.txt
+++ b/release/Magarena/scripts_missing/Ochran_Assassin.txt
@@ -1,0 +1,12 @@
+name=Ochran Assassin
+image=https://img.scryfall.com/cards/normal/front/5/4/541ef933-64f8-4075-9bd3-97149ac84b2b.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Assassin
+cost={1}{B}{G}
+pt=1/1
+ability=Deathtouch;\
+        All creatures able to block SN do so.
+timing=main
+oracle=Deathtouch\nAll creatures able to block Ochran Assassin do so.

--- a/release/Magarena/scripts_missing/Octopus_Umbra.txt
+++ b/release/Magarena/scripts_missing/Octopus_Umbra.txt
@@ -1,0 +1,13 @@
+name=Octopus Umbra
+image=https://img.scryfall.com/cards/normal/en/c18/11.jpg
+value=2.500
+rarity=R
+type=Enchantment
+subtype=Aura
+cost={3}{U}{U}
+ability=Enchant creature;\
+        Enchanted creature has base power and toughness 8/8 and has "Whenever this creature attacks, you may tap target creature with power 8 or less.";\
+        Totem armor
+timing=aura
+enchant=default,creature
+oracle=Enchant creature\nEnchanted creature has base power and toughness 8/8 and has "Whenever this creature attacks, you may tap target creature with power 8 or less."\nTotem armor

--- a/release/Magarena/scripts_missing/Omnispell_Adept.txt
+++ b/release/Magarena/scripts_missing/Omnispell_Adept.txt
@@ -1,0 +1,11 @@
+name=Omnispell Adept
+image=https://img.scryfall.com/cards/normal/front/e/1/e17664df-e8ba-464d-b338-3e671d2d7f0e.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Human,Wizard
+cost={4}{U}
+pt=3/4
+ability={2}{U}, {T}: You may cast an instant or sorcery card from your hand without paying its mana cost.
+timing=main
+oracle={2}{U}, {T}: You may cast an instant or sorcery card from your hand without paying its mana cost.

--- a/release/Magarena/scripts_missing/Ornery_Goblin.txt
+++ b/release/Magarena/scripts_missing/Ornery_Goblin.txt
@@ -1,0 +1,11 @@
+name=Ornery Goblin
+image=https://img.scryfall.com/cards/normal/front/b/e/be1c1353-b315-4a0e-80b5-0d9a2962e35f.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Goblin,Warrior
+cost={1}{R}
+pt=2/1
+ability=Whenever SN blocks or becomes blocked by a creature, SN deals 1 damage to that creature.
+timing=main
+oracle=Whenever Ornery Goblin blocks or becomes blocked by a creature, Ornery Goblin deals 1 damage to that creature.

--- a/release/Magarena/scripts_missing/Pack_s_Favor.txt
+++ b/release/Magarena/scripts_missing/Pack_s_Favor.txt
@@ -1,0 +1,10 @@
+name=Pack's Favor
+image=https://img.scryfall.com/cards/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={2}{G}
+ability=Convoke
+effect=Target creature gets +3/+3 until end of turn.
+timing=removal
+oracle=Convoke\nTarget creature gets +3/+3 until end of turn.

--- a/release/Magarena/scripts_missing/Parhelion_Patrol.txt
+++ b/release/Magarena/scripts_missing/Parhelion_Patrol.txt
@@ -1,0 +1,12 @@
+name=Parhelion Patrol
+image=https://img.scryfall.com/cards/normal/front/e/e/eef126f2-7e72-4338-8021-3ad95e4ab982.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Knight
+cost={3}{W}
+pt=2/3
+ability=Flying, vigilance;\
+        Mentor
+timing=main
+oracle=Flying, vigilance\nMentor

--- a/release/Magarena/scripts_missing/Passwall_Adept.txt
+++ b/release/Magarena/scripts_missing/Passwall_Adept.txt
@@ -1,0 +1,11 @@
+name=Passwall Adept
+image=https://img.scryfall.com/cards/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Wizard
+cost={1}{U}
+pt=1/3
+ability={2}{U}: Target creature can't be blocked this turn.
+timing=main
+oracle={2}{U}: Target creature can't be blocked this turn.

--- a/release/Magarena/scripts_missing/Pause_for_Reflection.txt
+++ b/release/Magarena/scripts_missing/Pause_for_Reflection.txt
@@ -1,0 +1,10 @@
+name=Pause for Reflection
+image=https://img.scryfall.com/cards/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={2}{G}
+ability=Convoke
+effect=Prevent all combat damage that would be dealt this turn.
+timing=removal
+oracle=Convoke\nPrevent all combat damage that would be dealt this turn.

--- a/release/Magarena/scripts_missing/Pelt_Collector.txt
+++ b/release/Magarena/scripts_missing/Pelt_Collector.txt
@@ -1,0 +1,12 @@
+name=Pelt Collector
+image=https://img.scryfall.com/cards/normal/front/b/e/bee125cb-12b9-4f78-8e1d-6018d9c52275.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Elf,Warrior
+cost={G}
+pt=1/1
+ability=Whenever another creature you control enters the battlefield or dies, if that creature's power is greater than SN's, put a +1/+1 counter on SN.;\
+        As long as SN has three or more +1/+1 counters on it, it has trample.
+timing=main
+oracle=Whenever another creature you control enters the battlefield or dies, if that creature's power is greater than Pelt Collector's, put a +1/+1 counter on Pelt Collector.\nAs long as Pelt Collector has three or more +1/+1 counters on it, it has trample.

--- a/release/Magarena/scripts_missing/Pilfering_Imp.txt
+++ b/release/Magarena/scripts_missing/Pilfering_Imp.txt
@@ -1,0 +1,12 @@
+name=Pilfering Imp
+image=https://img.scryfall.com/cards/normal/front/6/4/646dedff-150c-4ed2-8f2e-3b2e6ba5521a.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Imp
+cost={B}
+pt=1/1
+ability=Flying;\
+        {1}{B}, {T}, Sacrifice SN: Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.
+timing=main
+oracle=Flying\n{1}{B}, {T}, Sacrifice Pilfering Imp: Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.

--- a/release/Magarena/scripts_missing/Piston_Fist_Cyclops.txt
+++ b/release/Magarena/scripts_missing/Piston_Fist_Cyclops.txt
@@ -1,0 +1,12 @@
+name=Piston-Fist Cyclops
+image=https://img.scryfall.com/cards/large/front/2/e/2ec7523a-a9c4-4b76-8f9e-b591a88e2e37.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Cyclops
+cost={1}{U/R}{U/R}
+pt=4/3
+ability=Defender;\
+        As long as you've cast an instant or sorcery spell this turn, SN can attack as though it didn't have defender.
+timing=smain
+oracle=Defender\nAs long as you've cast an instant or sorcery spell this turn, Piston-Fist Cyclops can attack as though it didn't have defender.

--- a/release/Magarena/scripts_missing/Pitiless_Gorgon.txt
+++ b/release/Magarena/scripts_missing/Pitiless_Gorgon.txt
@@ -1,0 +1,11 @@
+name=Pitiless Gorgon
+image=https://img.scryfall.com/cards/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Gorgon
+cost={1}{B/G}{B/G}
+pt=2/2
+ability=Deathtouch
+timing=main
+oracle=Deathtouch

--- a/release/Magarena/scripts_missing/Plaguecrafter.txt
+++ b/release/Magarena/scripts_missing/Plaguecrafter.txt
@@ -1,0 +1,11 @@
+name=Plaguecrafter
+image=https://img.scryfall.com/cards/normal/front/8/6/8682fb87-df14-4277-aaa0-0d53d766c406.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Shaman
+cost={2}{B}
+pt=3/2
+ability=When SN enters the battlefield, each player sacrifices a creature or planeswalker. Each player who can't discards a card.
+timing=main
+oracle=When Plaguecrafter enters the battlefield, each player sacrifices a creature or planeswalker. Each player who can't discards a card.

--- a/release/Magarena/scripts_missing/Portcullis_Vine.txt
+++ b/release/Magarena/scripts_missing/Portcullis_Vine.txt
@@ -1,0 +1,12 @@
+name=Portcullis Vine
+image=https://img.scryfall.com/cards/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Plant,Wall
+cost={G}
+pt=0/3
+ability=Defender;\
+        {2}, {T}, Sacrifice a creature with defender: Draw a card.
+timing=smain
+oracle=Defender\n{2}, {T}, Sacrifice a creature with defender: Draw a card.

--- a/release/Magarena/scripts_missing/Precision_Bolt.txt
+++ b/release/Magarena/scripts_missing/Precision_Bolt.txt
@@ -1,0 +1,9 @@
+name=Precision Bolt
+image=https://img.scryfall.com/cards/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={2}{R}
+effect=SN deals 3 damage to any target.
+timing=main
+oracle=Precision Bolt deals 3 damage to any target.

--- a/release/Magarena/scripts_missing/Price_of_Fame.txt
+++ b/release/Magarena/scripts_missing/Price_of_Fame.txt
@@ -1,0 +1,10 @@
+name=Price of Fame
+image=https://img.scryfall.com/cards/normal/front/6/1/61b52152-0f7c-4466-9e49-033477028f67.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={3}{B}
+ability=This spell costs {2} less to cast if it targets a legendary creature.
+effect=Destroy target creature.~Surveil 2.
+timing=removal
+oracle=This spell costs {2} less to cast if it targets a legendary creature.\nDestroy target creature.\nSurveil 2.

--- a/release/Magarena/scripts_missing/Primordial_Mist.txt
+++ b/release/Magarena/scripts_missing/Primordial_Mist.txt
@@ -1,0 +1,10 @@
+name=Primordial Mist
+image=https://img.scryfall.com/cards/normal/en/c18/12.jpg
+value=2.500
+rarity=R
+type=Enchantment
+cost={4}{U}
+ability=At the beginning of your end step, you may manifest the top card of your library.;\
+        Exile a face-down permanent you control face up: You may play that card this turn.
+timing=enchantment
+oracle=At the beginning of your end step, you may manifest the top card of your library.\nExile a face-down permanent you control face up: You may play that card this turn.

--- a/release/Magarena/scripts_missing/Quasiduplicate.txt
+++ b/release/Magarena/scripts_missing/Quasiduplicate.txt
@@ -1,0 +1,9 @@
+name=Quasiduplicate
+image=https://img.scryfall.com/cards/normal/front/f/0/f069646c-fae2-40bd-92bc-35459a84d847.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={1}{U}{U}
+effect=Create a token that's a copy of target creature you control.~Jump-start
+timing=main
+oracle=Create a token that's a copy of target creature you control.\nJump-start

--- a/release/Magarena/scripts_missing/Radical_Idea.txt
+++ b/release/Magarena/scripts_missing/Radical_Idea.txt
@@ -1,0 +1,9 @@
+name=Radical Idea
+image=https://img.scryfall.com/cards/normal/front/c/9/c9570734-5e9b-46ff-b606-9759b5195756.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={1}{U}
+effect=Draw a card.~Jump-start
+timing=removal
+oracle=Draw a card.\nJump-start

--- a/release/Magarena/scripts_missing/Ral__Caller_of_Storms.txt
+++ b/release/Magarena/scripts_missing/Ral__Caller_of_Storms.txt
@@ -1,0 +1,13 @@
+name=Ral, Caller of Storms
+image=https://img.scryfall.com/cards/normal/front/c/4/c44f0c60-5732-4c25-9ba9-4829f1891762.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Ral
+cost={4}{U}{R}
+loyalty=4
+ability=+1: Draw a card.;\
+        −2: SN deals 3 damage divided as you choose among one, two, or three targets.;\
+        −7: Draw seven cards. SN deals 7 damage to each creature your opponents control.
+timing=main
+oracle=+1: Draw a card.\n−2: Ral, Caller of Storms deals 3 damage divided as you choose among one, two, or three targets.\n−7: Draw seven cards. Ral, Caller of Storms deals 7 damage to each creature your opponents control.

--- a/release/Magarena/scripts_missing/Ral__Izzet_Viceroy.txt
+++ b/release/Magarena/scripts_missing/Ral__Izzet_Viceroy.txt
@@ -1,0 +1,13 @@
+name=Ral, Izzet Viceroy
+image=https://img.scryfall.com/cards/normal/en/med/GR5.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Ral
+cost={3}{U}{R}
+loyalty=5
+ability=+1: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.;\
+        −3: SN deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.;\
+        −8: You get an emblem with "Whenever you cast an instant or sorcery spell, this emblem deals 4 damage to any target and you draw two cards."
+timing=main
+oracle=+1: Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\n−3: Ral, Izzet Viceroy deals damage to target creature equal to the total number of instant and sorcery cards you own in exile and in your graveyard.\n−8: You get an emblem with "Whenever you cast an instant or sorcery spell, this emblem deals 4 damage to any target and you draw two cards."

--- a/release/Magarena/scripts_missing/Ral_s_Dispersal.txt
+++ b/release/Magarena/scripts_missing/Ral_s_Dispersal.txt
@@ -1,0 +1,9 @@
+name=Ral's Dispersal
+image=https://img.scryfall.com/cards/normal/front/a/2/a2660fae-6459-446d-85dc-3c9126c81cb3.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={3}{U}{U}
+effect=Return target creature to its owner's hand. You may search your library and/or graveyard for a card named Ral, Caller of Storms, reveal it, and put it into your hand. If you search your library this way, shuffle it.
+timing=removal
+oracle=Return target creature to its owner's hand. You may search your library and/or graveyard for a card named Ral, Caller of Storms, reveal it, and put it into your hand. If you search your library this way, shuffle it.

--- a/release/Magarena/scripts_missing/Ral_s_Staticaster.txt
+++ b/release/Magarena/scripts_missing/Ral_s_Staticaster.txt
@@ -1,0 +1,12 @@
+name=Ral's Staticaster
+image=https://img.scryfall.com/cards/normal/front/a/d/adfa16dc-03b3-4533-884c-a23b992b8d86.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Viashino,Wizard
+cost={2}{U}{R}
+pt=3/3
+ability=Trample;\
+        Whenever SN attacks, if you control a Ral planeswalker, SN gets +1/+0 for each card in your hand until end of turn.
+timing=main
+oracle=Trample\nWhenever Ral's Staticaster attacks, if you control a Ral planeswalker, Ral's Staticaster gets +1/+0 for each card in your hand until end of turn.

--- a/release/Magarena/scripts_missing/Rampaging_Monument.txt
+++ b/release/Magarena/scripts_missing/Rampaging_Monument.txt
@@ -1,0 +1,13 @@
+name=Rampaging Monument
+image=https://img.scryfall.com/cards/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg
+value=2.500
+rarity=U
+type=Artifact,Creature
+subtype=Cleric
+cost={4}
+pt=0/0
+ability=Trample;\
+        SN enters the battlefield with three +1/+1 counters on it.;\
+        Whenever you cast a multicolored spell, put a +1/+1 counter on SN.
+timing=main
+oracle=Trample\nRampaging Monument enters the battlefield with three +1/+1 counters on it.\nWhenever you cast a multicolored spell, put a +1/+1 counter on Rampaging Monument.

--- a/release/Magarena/scripts_missing/Ravenous_Slime.txt
+++ b/release/Magarena/scripts_missing/Ravenous_Slime.txt
@@ -1,0 +1,12 @@
+name=Ravenous Slime
+image=https://img.scryfall.com/cards/normal/en/c18/34.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Ooze
+cost={2}{G}
+pt=1/1
+ability=SN can't be blocked by creatures with power 2 or less.;\
+        If a creature an opponent controls would die, instead exile it and put a number of +1/+1 counters equal to that creature's power on SN.
+timing=main
+oracle=Ravenous Slime can't be blocked by creatures with power 2 or less.\nIf a creature an opponent controls would die, instead exile it and put a number of +1/+1 counters equal to that creature's power on Ravenous Slime.

--- a/release/Magarena/scripts_missing/Reality_Scramble.txt
+++ b/release/Magarena/scripts_missing/Reality_Scramble.txt
@@ -1,0 +1,10 @@
+name=Reality Scramble
+image=https://img.scryfall.com/cards/normal/en/c18/25.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={2}{R}{R}
+ability=Retrace
+effect=Put target permanent you own on the bottom of your library. Reveal cards from the top of your library until you reveal a card that shares a card type with that permanent. Put that card onto the battlefield and the rest on the bottom of your library in a random order.
+timing=main
+oracle=Put target permanent you own on the bottom of your library. Reveal cards from the top of your library until you reveal a card that shares a card type with that permanent. Put that card onto the battlefield and the rest on the bottom of your library in a random order.\nRetrace

--- a/release/Magarena/scripts_missing/Rebirth.txt
+++ b/release/Magarena/scripts_missing/Rebirth.txt
@@ -1,0 +1,9 @@
+name=Rebirth
+image=https://img.scryfall.com/cards/normal/en/leg/200.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={3}{G}{G}{G}
+effect=Remove SN from your deck before playing if you're not playing for ante.~Each player may ante the top card of their library. If a player does, that player's life total becomes 20.
+timing=main
+oracle=Remove Rebirth from your deck before playing if you're not playing for ante.\nEach player may ante the top card of their library. If a player does, that player's life total becomes 20.

--- a/release/Magarena/scripts_missing/Rebirth.txt
+++ b/release/Magarena/scripts_missing/Rebirth.txt
@@ -7,3 +7,4 @@ cost={3}{G}{G}{G}
 effect=Remove SN from your deck before playing if you're not playing for ante.~Each player may ante the top card of their library. If a player does, that player's life total becomes 20.
 timing=main
 oracle=Remove Rebirth from your deck before playing if you're not playing for ante.\nEach player may ante the top card of their library. If a player does, that player's life total becomes 20.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Response.txt
+++ b/release/Magarena/scripts_missing/Response.txt
@@ -1,0 +1,11 @@
+name=Response
+image=https://img.scryfall.com/cards/normal/front/4/3/437d7378-fad5-496e-a264-d4ea3819ade1.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={R/W}{R/W}
+split=Resurgence
+effect=SN deals 5 damage to target attacking or blocking creature.
+timing=removal
+oracle=Response deals 5 damage to target attacking or blocking creature.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Resurgence.txt
+++ b/release/Magarena/scripts_missing/Resurgence.txt
@@ -1,0 +1,11 @@
+name=Resurgence
+image=https://img.scryfall.com/cards/normal/front/4/3/437d7378-fad5-496e-a264-d4ea3819ade1.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={3}{R}{W}
+split=Response
+effect=Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.
+timing=main
+oracle=Creatures you control gain first strike and vigilance until end of turn. After this main phase, there is an additional combat phase followed by an additional main phase.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Retrofitter_Foundry.txt
+++ b/release/Magarena/scripts_missing/Retrofitter_Foundry.txt
@@ -1,0 +1,12 @@
+name=Retrofitter Foundry
+image=https://img.scryfall.com/cards/normal/en/c18/57.jpg
+value=2.500
+rarity=R
+type=Artifact
+cost={1}
+ability={3}: Untap SN.;\
+        {2}, {T}: Create a 1/1 colorless Servo artifact creature token.;\
+        {1}, {T}, Sacrifice a Servo: Create a 1/1 colorless Thopter artifact creature token with flying.;\
+        {T}, Sacrifice a Thopter: Create a 4/4 colorless Construct artifact creature token.
+timing=artifact
+oracle={3}: Untap Retrofitter Foundry.\n{2}, {T}: Create a 1/1 colorless Servo artifact creature token.\n{1}, {T}, Sacrifice a Servo: Create a 1/1 colorless Thopter artifact creature token with flying.\n{T}, Sacrifice a Thopter: Create a 4/4 colorless Construct artifact creature token.

--- a/release/Magarena/scripts_missing/Rhizome_Lurcher.txt
+++ b/release/Magarena/scripts_missing/Rhizome_Lurcher.txt
@@ -1,0 +1,11 @@
+name=Rhizome Lurcher
+image=https://img.scryfall.com/cards/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Fungus,Zombie
+cost={2}{B}{G}
+pt=2/2
+ability=Undergrowth — SN enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.
+timing=main
+oracle=Undergrowth — Rhizome Lurcher enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.

--- a/release/Magarena/scripts_missing/Risk_Factor.txt
+++ b/release/Magarena/scripts_missing/Risk_Factor.txt
@@ -1,0 +1,9 @@
+name=Risk Factor
+image=https://img.scryfall.com/cards/normal/front/4/e/4eda89d9-9bd1-4a55-ac02-f9a0625d8e5b.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={2}{R}
+effect=Target opponent may have SN deal 4 damage to them. If that player doesn't, you draw three cards.~Jump-start
+timing=removal
+oracle=Target opponent may have Risk Factor deal 4 damage to them. If that player doesn't, you draw three cards.\nJump-start

--- a/release/Magarena/scripts_missing/Ritual_of_Soot.txt
+++ b/release/Magarena/scripts_missing/Ritual_of_Soot.txt
@@ -1,0 +1,9 @@
+name=Ritual of Soot
+image=https://img.scryfall.com/cards/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={2}{B}{B}
+effect=Destroy all creatures with converted mana cost 3 or less.
+timing=main
+oracle=Destroy all creatures with converted mana cost 3 or less.

--- a/release/Magarena/scripts_missing/Roc_Charger.txt
+++ b/release/Magarena/scripts_missing/Roc_Charger.txt
@@ -1,0 +1,12 @@
+name=Roc Charger
+image=https://img.scryfall.com/cards/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Bird
+cost={2}{W}
+pt=1/3
+ability=Flying;\
+        Whenever SN attacks, target attacking creature without flying gains flying until end of turn.
+timing=main
+oracle=Flying\nWhenever Roc Charger attacks, target attacking creature without flying gains flying until end of turn.

--- a/release/Magarena/scripts_missing/Rosemane_Centaur.txt
+++ b/release/Magarena/scripts_missing/Rosemane_Centaur.txt
@@ -1,0 +1,12 @@
+name=Rosemane Centaur
+image=https://img.scryfall.com/cards/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Centaur,Soldier
+cost={3}{G}{W}
+pt=4/4
+ability=Convoke;\
+        Vigilance
+timing=main
+oracle=Convoke\nVigilance

--- a/release/Magarena/scripts_missing/Rubblebelt_Boar.txt
+++ b/release/Magarena/scripts_missing/Rubblebelt_Boar.txt
@@ -1,0 +1,11 @@
+name=Rubblebelt Boar
+image=https://img.scryfall.com/cards/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Boar
+cost={3}{R}
+pt=3/3
+ability=When SN enters the battlefield, target creature gets +2/+0 until end of turn.
+timing=main
+oracle=When Rubblebelt Boar enters the battlefield, target creature gets +2/+0 until end of turn.

--- a/release/Magarena/scripts_missing/Runaway_Steam_Kin.txt
+++ b/release/Magarena/scripts_missing/Runaway_Steam_Kin.txt
@@ -1,0 +1,12 @@
+name=Runaway Steam-Kin
+image=https://img.scryfall.com/cards/large/front/d/8/d8c9c111-fbc7-44e1-94bd-1ca164370623.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Elemental
+cost={1}{R}
+pt=1/1
+ability=Whenever you cast a red spell, if SN has fewer than three +1/+1 counters on it, put a +1/+1 counter on SN.;\
+        Remove three +1/+1 counters from SN: Add {R}{R}{R}.
+timing=main
+oracle=Whenever you cast a red spell, if Runaway Steam-Kin has fewer than three +1/+1 counters on it, put a +1/+1 counter on Runaway Steam-Kin.\nRemove three +1/+1 counters from Runaway Steam-Kin: Add {R}{R}{R}.

--- a/release/Magarena/scripts_missing/Saheeli__the_Gifted.txt
+++ b/release/Magarena/scripts_missing/Saheeli__the_Gifted.txt
@@ -1,0 +1,14 @@
+name=Saheeli, the Gifted
+image=https://img.scryfall.com/cards/normal/en/c18/44.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Saheeli
+cost={2}{U}{R}
+loyalty=4
+ability=+1: Create a 1/1 colorless Servo artifact creature token.;\
+        +1: The next spell you cast this turn costs {1} less to cast for each artifact you control as you cast it.;\
+        −7: For each artifact you control, create a token that's a copy of it. Those tokens gain haste. Exile those tokens at the beginning of the next end step.;\
+        SN can be your commander.
+timing=main
+oracle=+1: Create a 1/1 colorless Servo artifact creature token.\n+1: The next spell you cast this turn costs {1} less to cast for each artifact you control as you cast it.\n−7: For each artifact you control, create a token that's a copy of it. Those tokens gain haste. Exile those tokens at the beginning of the next end step.\nSaheeli, the Gifted can be your commander.

--- a/release/Magarena/scripts_missing/Saheeli_s_Directive.txt
+++ b/release/Magarena/scripts_missing/Saheeli_s_Directive.txt
@@ -1,0 +1,9 @@
+name=Saheeli's Directive
+image=https://img.scryfall.com/cards/normal/en/c18/26.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={X}{R}{R}{R}
+effect=Improvise~Reveal the top X cards of your library. You may put any number of artifact cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.
+timing=main
+oracle=Improvise\nReveal the top X cards of your library. You may put any number of artifact cards with converted mana cost X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.

--- a/release/Magarena/scripts_missing/Selective_Snare.txt
+++ b/release/Magarena/scripts_missing/Selective_Snare.txt
@@ -1,0 +1,9 @@
+name=Selective Snare
+image=https://img.scryfall.com/cards/normal/front/2/a/2adfc0ac-08a9-487a-b01c-5de52fae0312.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={X}{U}
+effect=Return X target creatures of the creature type of your choice to their owner's hand.
+timing=main
+oracle=Return X target creatures of the creature type of your choice to their owner's hand.

--- a/release/Magarena/scripts_missing/Selesnya_Locket.txt
+++ b/release/Magarena/scripts_missing/Selesnya_Locket.txt
@@ -1,0 +1,10 @@
+name=Selesnya Locket
+image=https://img.scryfall.com/cards/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg
+value=2.500
+rarity=C
+type=Artifact
+cost={3}
+ability={T}: Add {G} or {W}.;\
+        {G/W}{G/W}{G/W}{G/W}, {T}, Sacrifice SN: Draw two cards.
+timing=artifact
+oracle={T}: Add {G} or {W}.\n{G/W}{G/W}{G/W}{G/W}, {T}, Sacrifice Selesnya Locket: Draw two cards.

--- a/release/Magarena/scripts_missing/Severed_Strands.txt
+++ b/release/Magarena/scripts_missing/Severed_Strands.txt
@@ -1,0 +1,10 @@
+name=Severed Strands
+image=https://img.scryfall.com/cards/normal/front/b/c/bce654d6-fcf1-40a8-8bdb-5c37e561f7dc.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={1}{B}
+ability=As an additional cost to cast this spell, sacrifice a creature.
+effect=You gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.
+timing=main
+oracle=As an additional cost to cast this spell, sacrifice a creature.\nYou gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.

--- a/release/Magarena/scripts_missing/Shahrazad.txt
+++ b/release/Magarena/scripts_missing/Shahrazad.txt
@@ -1,0 +1,9 @@
+name=Shahrazad
+image=https://img.scryfall.com/cards/normal/en/arn/10.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={W}{W}
+effect=Players play a Magic subgame, using their libraries as their decks. Each player who doesn't win the subgame loses half their life, rounded up.
+timing=main
+oracle=Players play a Magic subgame, using their libraries as their decks. Each player who doesn't win the subgame loses half their life, rounded up.

--- a/release/Magarena/scripts_missing/Silent_Dart.txt
+++ b/release/Magarena/scripts_missing/Silent_Dart.txt
@@ -1,0 +1,9 @@
+name=Silent Dart
+image=https://img.scryfall.com/cards/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg
+value=2.500
+rarity=U
+type=Artifact
+cost={1}
+ability={4}, {T}, Sacrifice SN: It deals 3 damage to target creature.
+timing=artifact
+oracle={4}, {T}, Sacrifice Silent Dart: It deals 3 damage to target creature.

--- a/release/Magarena/scripts_missing/Sinister_Sabotage.txt
+++ b/release/Magarena/scripts_missing/Sinister_Sabotage.txt
@@ -1,0 +1,9 @@
+name=Sinister Sabotage
+image=https://img.scryfall.com/cards/normal/front/6/c/6cbef36d-7170-424f-8fb1-8e7e112b7f0b.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={1}{U}{U}
+effect=Counter target spell.~Surveil 1.
+timing=counter
+oracle=Counter target spell.\nSurveil 1.

--- a/release/Magarena/scripts_missing/Skull_Storm.txt
+++ b/release/Magarena/scripts_missing/Skull_Storm.txt
@@ -1,0 +1,9 @@
+name=Skull Storm
+image=https://img.scryfall.com/cards/normal/en/c18/18.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={7}{B}{B}
+effect=When you cast this spell, copy it for each time you've cast your commander from the command zone this game.~Each opponent sacrifices a creature. Each opponent who can't loses half their life, rounded up.
+timing=main
+oracle=When you cast this spell, copy it for each time you've cast your commander from the command zone this game.\nEach opponent sacrifices a creature. Each opponent who can't loses half their life, rounded up.

--- a/release/Magarena/scripts_missing/Skyline_Scout.txt
+++ b/release/Magarena/scripts_missing/Skyline_Scout.txt
@@ -1,0 +1,11 @@
+name=Skyline Scout
+image=https://img.scryfall.com/cards/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Scout
+cost={1}{W}
+pt=2/1
+ability=Whenever SN attacks, you may pay {1}{W}. If you do, it gains flying until end of turn.
+timing=main
+oracle=Whenever Skyline Scout attacks, you may pay {1}{W}. If you do, it gains flying until end of turn.

--- a/release/Magarena/scripts_missing/Smelt_Ward_Minotaur.txt
+++ b/release/Magarena/scripts_missing/Smelt_Ward_Minotaur.txt
@@ -1,0 +1,11 @@
+name=Smelt-Ward Minotaur
+image=https://img.scryfall.com/cards/large/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Minotaur,Warrior
+cost={2}{R}
+pt=2/3
+ability=Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn.
+timing=main
+oracle=Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn.

--- a/release/Magarena/scripts_missing/Sonic_Assault.txt
+++ b/release/Magarena/scripts_missing/Sonic_Assault.txt
@@ -1,0 +1,9 @@
+name=Sonic Assault
+image=https://img.scryfall.com/cards/normal/front/c/c/cc61a398-cf16-415b-b3cf-897217dc7cc9.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={1}{U}{R}
+effect=Tap target creature. SN deals 2 damage to that creature's controller.~Jump-start
+timing=removal
+oracle=Tap target creature. Sonic Assault deals 2 damage to that creature's controller.\nJump-start

--- a/release/Magarena/scripts_missing/Sower_of_Discord.txt
+++ b/release/Magarena/scripts_missing/Sower_of_Discord.txt
@@ -1,0 +1,13 @@
+name=Sower of Discord
+image=https://img.scryfall.com/cards/normal/en/c18/19.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Demon
+cost={4}{B}{B}
+pt=6/6
+ability=Flying;\
+        As SN enters the battlefield, choose two players.;\
+        Whenever damage is dealt to one of the chosen players, the other chosen player also loses that much life.
+timing=main
+oracle=Flying\nAs Sower of Discord enters the battlefield, choose two players.\nWhenever damage is dealt to one of the chosen players, the other chosen player also loses that much life.

--- a/release/Magarena/scripts_missing/Spinal_Centipede.txt
+++ b/release/Magarena/scripts_missing/Spinal_Centipede.txt
@@ -1,0 +1,11 @@
+name=Spinal Centipede
+image=https://img.scryfall.com/cards/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Insect
+cost={2}{B}
+pt=3/2
+ability=When SN dies, put a +1/+1 counter on target creature you control.
+timing=main
+oracle=When Spinal Centipede dies, put a +1/+1 counter on target creature you control.

--- a/release/Magarena/scripts_missing/Sprouting_Renewal.txt
+++ b/release/Magarena/scripts_missing/Sprouting_Renewal.txt
@@ -1,0 +1,10 @@
+name=Sprouting Renewal
+image=https://img.scryfall.com/cards/normal/front/6/6/668232ab-5e58-49f3-804a-c938252ff177.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={2}{G}
+ability=Convoke
+effect=Choose one — (1) Create a 2/2 green and white Elf Knight creature token with vigilance. (2) Destroy target artifact or enchantment.
+timing=main
+oracle=Convoke\nChoose one —\n• Create a 2/2 green and white Elf Knight creature token with vigilance.\n• Destroy target artifact or enchantment.

--- a/release/Magarena/scripts_missing/Statue.txt
+++ b/release/Magarena/scripts_missing/Statue.txt
@@ -1,0 +1,11 @@
+name=Statue
+image=https://img.scryfall.com/cards/large/front/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={2}{B}{G}
+split=Status
+effect=Destroy target artifact, creature, or enchantment.
+timing=removal
+oracle=Destroy target artifact, creature, or enchantment.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Status.txt
+++ b/release/Magarena/scripts_missing/Status.txt
@@ -1,0 +1,11 @@
+name=Status
+image=https://img.scryfall.com/cards/large/front/4/4/44614c6d-5508-4077-b825-66d5d684086c.jpg
+value=2.500
+rarity=U
+type=Instant
+cost={B/G}
+split=Statue
+effect=Target creature gets +1/+1 and gains deathtouch until end of turn.
+timing=removal
+oracle=Target creature gets +1/+1 and gains deathtouch until end of turn.
+status=not supported: split-card

--- a/release/Magarena/scripts_missing/Street_Riot.txt
+++ b/release/Magarena/scripts_missing/Street_Riot.txt
@@ -1,0 +1,9 @@
+name=Street Riot
+image=https://img.scryfall.com/cards/normal/front/8/0/80b352d5-4a57-41bc-b4c4-8b81255a9db8.jpg
+value=2.500
+rarity=U
+type=Enchantment
+cost={4}{R}
+ability=As long as it's your turn, creatures you control get +1/+0 and have trample.
+timing=enchantment
+oracle=As long as it's your turn, creatures you control get +1/+0 and have trample.

--- a/release/Magarena/scripts_missing/Sumala_Woodshaper.txt
+++ b/release/Magarena/scripts_missing/Sumala_Woodshaper.txt
@@ -1,0 +1,11 @@
+name=Sumala Woodshaper
+image=https://img.scryfall.com/cards/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Elf,Druid
+cost={2}{G}{W}
+pt=2/1
+ability=When SN enters the battlefield, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+timing=main
+oracle=When Sumala Woodshaper enters the battlefield, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.

--- a/release/Magarena/scripts_missing/Sunhome_Stalwart.txt
+++ b/release/Magarena/scripts_missing/Sunhome_Stalwart.txt
@@ -1,0 +1,12 @@
+name=Sunhome Stalwart
+image=https://img.scryfall.com/cards/normal/front/a/4/a431f183-17eb-4a6c-a137-d106bdc8c997.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Soldier
+cost={1}{W}
+pt=2/2
+ability=First strike;\
+        Mentor
+timing=main
+oracle=First strike\nMentor

--- a/release/Magarena/scripts_missing/Swarm_Guildmage.txt
+++ b/release/Magarena/scripts_missing/Swarm_Guildmage.txt
@@ -1,0 +1,12 @@
+name=Swarm Guildmage
+image=https://img.scryfall.com/cards/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elf,Shaman
+cost={B}{G}
+pt=2/2
+ability={4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn.;\
+        {1}{G}, {T}: You gain 2 life.
+timing=main
+oracle={4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn.\n{1}{G}, {T}: You gain 2 life.

--- a/release/Magarena/scripts_missing/Swathcutter_Giant.txt
+++ b/release/Magarena/scripts_missing/Swathcutter_Giant.txt
@@ -1,0 +1,12 @@
+name=Swathcutter Giant
+image=https://img.scryfall.com/cards/normal/front/7/0/700b38c5-3fd2-4566-8d27-9a09d5ab02b2.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Giant,Soldier
+cost={4}{R}{W}
+pt=5/5
+ability=Vigilance;\
+        Whenever SN attacks, it deals 1 damage to each creature defending player controls.
+timing=main
+oracle=Vigilance\nWhenever Swathcutter Giant attacks, it deals 1 damage to each creature defending player controls.

--- a/release/Magarena/scripts_missing/Swiftblade_Vindicator.txt
+++ b/release/Magarena/scripts_missing/Swiftblade_Vindicator.txt
@@ -1,0 +1,11 @@
+name=Swiftblade Vindicator
+image=https://img.scryfall.com/cards/normal/front/2/8/285c4d9e-0f22-49a8-b68c-150fd0d4b617.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Human,Soldier
+cost={R}{W}
+pt=1/1
+ability=Double strike, vigilance, trample
+timing=main
+oracle=Double strike, vigilance, trample

--- a/release/Magarena/scripts_missing/Sworn_Companions.txt
+++ b/release/Magarena/scripts_missing/Sworn_Companions.txt
@@ -1,0 +1,9 @@
+name=Sworn Companions
+image=https://img.scryfall.com/cards/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={2}{W}
+effect=Create two 1/1 white Soldier creature tokens with lifelink.
+timing=main
+oracle=Create two 1/1 white Soldier creature tokens with lifelink.

--- a/release/Magarena/scripts_missing/Tajic__Legion_s_Edge.txt
+++ b/release/Magarena/scripts_missing/Tajic__Legion_s_Edge.txt
@@ -1,0 +1,14 @@
+name=Tajic, Legion's Edge
+image=https://img.scryfall.com/cards/normal/front/5/e/5e669a01-84d3-4fcc-8396-9e987bd89b4f.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Human,Soldier
+cost={1}{R}{W}
+pt=3/2
+ability=Haste;\
+        Mentor;\
+        Prevent all noncombat damage that would be dealt to other creatures you control.;\
+        {R}{W}: SN gains first strike until end of turn.
+timing=fmain
+oracle=Haste\nMentor\nPrevent all noncombat damage that would be dealt to other creatures you control.\n{R}{W}: Tajic, Legion's Edge gains first strike until end of turn.

--- a/release/Magarena/scripts_missing/Take_Heart.txt
+++ b/release/Magarena/scripts_missing/Take_Heart.txt
@@ -1,0 +1,9 @@
+name=Take Heart
+image=https://img.scryfall.com/cards/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={W}
+effect=Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.
+timing=removal
+oracle=Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.

--- a/release/Magarena/scripts_missing/Tawnos__Urza_s_Apprentice.txt
+++ b/release/Magarena/scripts_missing/Tawnos__Urza_s_Apprentice.txt
@@ -1,0 +1,12 @@
+name=Tawnos, Urza's Apprentice
+image=https://img.scryfall.com/cards/normal/en/c18/45.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Human,Artificer
+cost={U}{R}
+pt=1/3
+ability=Haste;\
+        {U}{R}, {T}: Copy target activated or triggered ability you control from an artifact source. You may choose new targets for the copy.
+timing=fmain
+oracle=Haste\n{U}{R}, {T}: Copy target activated or triggered ability you control from an artifact source. You may choose new targets for the copy.

--- a/release/Magarena/scripts_missing/Tempest_Efreet.txt
+++ b/release/Magarena/scripts_missing/Tempest_Efreet.txt
@@ -1,0 +1,12 @@
+name=Tempest Efreet
+image=https://img.scryfall.com/cards/normal/en/leg/166.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Efreet
+cost={1}{R}{R}{R}
+pt=3/3
+ability=Remove SN from your deck before playing if you're not playing for ante.;\
+        {T}, Sacrifice SN: Target opponent may pay 10 life. If that player doesn't, they reveal a card at random from their hand. Exchange ownership of the revealed card and SN. Put the revealed card into your hand and SN from anywhere into that player's graveyard. This change in ownership is permanent.
+timing=main
+oracle=Remove Tempest Efreet from your deck before playing if you're not playing for ante.\n{T}, Sacrifice Tempest Efreet: Target opponent may pay 10 life. If that player doesn't, they reveal a card at random from their hand. Exchange ownership of the revealed card and Tempest Efreet. Put the revealed card into your hand and Tempest Efreet from anywhere into that player's graveyard. This change in ownership is permanent.

--- a/release/Magarena/scripts_missing/Tempest_Efreet.txt
+++ b/release/Magarena/scripts_missing/Tempest_Efreet.txt
@@ -10,3 +10,4 @@ ability=Remove SN from your deck before playing if you're not playing for ante.;
         {T}, Sacrifice SN: Target opponent may pay 10 life. If that player doesn't, they reveal a card at random from their hand. Exchange ownership of the revealed card and SN. Put the revealed card into your hand and SN from anywhere into that player's graveyard. This change in ownership is permanent.
 timing=main
 oracle=Remove Tempest Efreet from your deck before playing if you're not playing for ante.\n{T}, Sacrifice Tempest Efreet: Target opponent may pay 10 life. If that player doesn't, they reveal a card at random from their hand. Exchange ownership of the revealed card and Tempest Efreet. Put the revealed card into your hand and Tempest Efreet from anywhere into that player's graveyard. This change in ownership is permanent.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Tenth_District_Guard.txt
+++ b/release/Magarena/scripts_missing/Tenth_District_Guard.txt
@@ -1,0 +1,11 @@
+name=Tenth District Guard
+image=https://img.scryfall.com/cards/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Soldier
+cost={1}{W}
+pt=2/2
+ability=When SN enters the battlefield, target creature gets +0/+1 until end of turn.
+timing=main
+oracle=When Tenth District Guard enters the battlefield, target creature gets +0/+1 until end of turn.

--- a/release/Magarena/scripts_missing/Thantis__the_Warweaver.txt
+++ b/release/Magarena/scripts_missing/Thantis__the_Warweaver.txt
@@ -1,0 +1,13 @@
+name=Thantis, the Warweaver
+image=https://img.scryfall.com/cards/normal/en/c18/46.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Spider
+cost={3}{B}{R}{G}
+pt=5/5
+ability=Vigilance, reach;\
+        All creatures attack each combat if able.;\
+        Whenever a creature attacks you or a planeswalker you control, put a +1/+1 counter on SN.
+timing=main
+oracle=Vigilance, reach\nAll creatures attack each combat if able.\nWhenever a creature attacks you or a planeswalker you control, put a +1/+1 counter on Thantis, the Warweaver.

--- a/release/Magarena/scripts_missing/Thief_of_Sanity.txt
+++ b/release/Magarena/scripts_missing/Thief_of_Sanity.txt
@@ -1,0 +1,12 @@
+name=Thief of Sanity
+image=https://img.scryfall.com/cards/normal/front/3/0/307543ca-8e17-433f-9758-4c77da6c0870.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Specter
+cost={1}{U}{B}
+pt=2/2
+ability=Flying;\
+        Whenever SN deals combat damage to a player, look at the top three cards of that player's library, exile one of them face down, then put the rest into their graveyard. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.
+timing=main
+oracle=Flying\nWhenever Thief of Sanity deals combat damage to a player, look at the top three cards of that player's library, exile one of them face down, then put the rest into their graveyard. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.

--- a/release/Magarena/scripts_missing/Thought_Erasure.txt
+++ b/release/Magarena/scripts_missing/Thought_Erasure.txt
@@ -1,0 +1,9 @@
+name=Thought Erasure
+image=https://img.scryfall.com/cards/normal/front/7/c/7ce226ad-cb1d-47f5-90fc-27704e181884.jpg
+value=2.500
+rarity=U
+type=Sorcery
+cost={U}{B}
+effect=Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.~Surveil 1.
+timing=main
+oracle=Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nSurveil 1.

--- a/release/Magarena/scripts_missing/Thoughtbound_Phantasm.txt
+++ b/release/Magarena/scripts_missing/Thoughtbound_Phantasm.txt
@@ -1,0 +1,13 @@
+name=Thoughtbound Phantasm
+image=https://img.scryfall.com/cards/normal/front/3/6/36478e73-162a-412c-bf5b-9ca0d92f51e2.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Spirit
+cost={U}
+pt=2/2
+ability=Defender;\
+        Whenever you surveil, put a +1/+1 counter on SN.;\
+        As long as SN has three or more +1/+1 counters on it, it can attack as though it didn't have defender.
+timing=smain
+oracle=Defender\nWhenever you surveil, put a +1/+1 counter on Thoughtbound Phantasm.\nAs long as Thoughtbound Phantasm has three or more +1/+1 counters on it, it can attack as though it didn't have defender.

--- a/release/Magarena/scripts_missing/Thousand_Year_Storm.txt
+++ b/release/Magarena/scripts_missing/Thousand_Year_Storm.txt
@@ -1,0 +1,9 @@
+name=Thousand-Year Storm
+image=https://img.scryfall.com/cards/large/front/2/7/270a0863-7d07-43f0-925d-a8ce0383a1cb.jpg
+value=2.500
+rarity=M
+type=Enchantment
+cost={4}{U}{R}
+ability=Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.
+timing=enchantment
+oracle=Whenever you cast an instant or sorcery spell, copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies.

--- a/release/Magarena/scripts_missing/Timmerian_Fiends.txt
+++ b/release/Magarena/scripts_missing/Timmerian_Fiends.txt
@@ -10,3 +10,4 @@ ability=Remove SN from your deck before playing if you're not playing for ante.;
         {B}{B}{B}, Sacrifice SN: The owner of target artifact may ante the top card of their library. If that player doesn't, exchange ownership of that artifact and SN. Put the artifact card into your graveyard and SN from anywhere into that player's graveyard. This change in ownership is permanent.
 timing=main
 oracle=Remove Timmerian Fiends from your deck before playing if you're not playing for ante.\n{B}{B}{B}, Sacrifice Timmerian Fiends: The owner of target artifact may ante the top card of their library. If that player doesn't, exchange ownership of that artifact and Timmerian Fiends. Put the artifact card into your graveyard and Timmerian Fiends from anywhere into that player's graveyard. This change in ownership is permanent.
+status=ante-not-supported

--- a/release/Magarena/scripts_missing/Timmerian_Fiends.txt
+++ b/release/Magarena/scripts_missing/Timmerian_Fiends.txt
@@ -1,0 +1,12 @@
+name=Timmerian Fiends
+image=https://img.scryfall.com/cards/normal/en/hml/58.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Horror
+cost={1}{B}{B}
+pt=1/1
+ability=Remove SN from your deck before playing if you're not playing for ante.;\
+        {B}{B}{B}, Sacrifice SN: The owner of target artifact may ante the top card of their library. If that player doesn't, exchange ownership of that artifact and SN. Put the artifact card into your graveyard and SN from anywhere into that player's graveyard. This change in ownership is permanent.
+timing=main
+oracle=Remove Timmerian Fiends from your deck before playing if you're not playing for ante.\n{B}{B}{B}, Sacrifice Timmerian Fiends: The owner of target artifact may ante the top card of their library. If that player doesn't, exchange ownership of that artifact and Timmerian Fiends. Put the artifact card into your graveyard and Timmerian Fiends from anywhere into that player's graveyard. This change in ownership is permanent.

--- a/release/Magarena/scripts_missing/Torch_Courier.txt
+++ b/release/Magarena/scripts_missing/Torch_Courier.txt
@@ -1,0 +1,12 @@
+name=Torch Courier
+image=https://img.scryfall.com/cards/normal/front/d/4/d4c9fc8c-e68f-4636-84b8-877f6ec04b09.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Goblin
+cost={R}
+pt=1/1
+ability=Haste;\
+        Sacrifice SN: Another target creature gains haste until end of turn.
+timing=fmain
+oracle=Haste\nSacrifice Torch Courier: Another target creature gains haste until end of turn.

--- a/release/Magarena/scripts_missing/Treasure_Nabber.txt
+++ b/release/Magarena/scripts_missing/Treasure_Nabber.txt
@@ -1,0 +1,11 @@
+name=Treasure Nabber
+image=https://img.scryfall.com/cards/normal/en/c18/27.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Goblin,Rogue
+cost={2}{R}
+pt=3/2
+ability=Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.
+timing=main
+oracle=Whenever an opponent taps an artifact for mana, gain control of that artifact until the end of your next turn.

--- a/release/Magarena/scripts_missing/Trostani_Discordant.txt
+++ b/release/Magarena/scripts_missing/Trostani_Discordant.txt
@@ -1,0 +1,13 @@
+name=Trostani Discordant
+image=https://img.scryfall.com/cards/normal/front/f/a/fa1190a4-3d7e-4500-991f-e36ec3d1d9dc.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Dryad
+cost={3}{G}{W}
+pt=1/4
+ability=Other creatures you control get +1/+1.;\
+        When SN enters the battlefield, create two 1/1 white Soldier creature tokens with lifelink.;\
+        At the beginning of your end step, each player gains control of all creatures they own.
+timing=main
+oracle=Other creatures you control get +1/+1.\nWhen Trostani Discordant enters the battlefield, create two 1/1 white Soldier creature tokens with lifelink.\nAt the beginning of your end step, each player gains control of all creatures they own.

--- a/release/Magarena/scripts_missing/Truefire_Captain.txt
+++ b/release/Magarena/scripts_missing/Truefire_Captain.txt
@@ -1,0 +1,12 @@
+name=Truefire Captain
+image=https://img.scryfall.com/cards/normal/front/6/0/6099a230-9298-4649-b257-243af40d0625.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Human,Knight
+cost={R}{R}{W}{W}
+pt=4/3
+ability=Mentor;\
+        Whenever SN is dealt damage, it deals that much damage to target player.
+timing=main
+oracle=Mentor\nWhenever Truefire Captain is dealt damage, it deals that much damage to target player.

--- a/release/Magarena/scripts_missing/Turntimber_Sower.txt
+++ b/release/Magarena/scripts_missing/Turntimber_Sower.txt
@@ -1,0 +1,12 @@
+name=Turntimber Sower
+image=https://img.scryfall.com/cards/normal/en/c18/35.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Elf,Druid
+cost={2}{G}
+pt=3/3
+ability=Whenever one or more land cards are put into your graveyard from anywhere, create a 0/1 green Plant creature token.;\
+        {G}, Sacrifice three creatures: Return target land card from your graveyard to your hand.
+timing=main
+oracle=Whenever one or more land cards are put into your graveyard from anywhere, create a 0/1 green Plant creature token.\n{G}, Sacrifice three creatures: Return target land card from your graveyard to your hand.

--- a/release/Magarena/scripts_missing/Tuvasa_the_Sunlit.txt
+++ b/release/Magarena/scripts_missing/Tuvasa_the_Sunlit.txt
@@ -1,0 +1,12 @@
+name=Tuvasa the Sunlit
+image=https://img.scryfall.com/cards/normal/en/c18/47.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Merfolk,Shaman
+cost={G}{W}{U}
+pt=1/1
+ability=SN gets +1/+1 for each enchantment you control.;\
+        Whenever you cast your first enchantment spell each turn, draw a card.
+timing=main
+oracle=Tuvasa the Sunlit gets +1/+1 for each enchantment you control.\nWhenever you cast your first enchantment spell each turn, draw a card.

--- a/release/Magarena/scripts_missing/Undercity_Necrolisk.txt
+++ b/release/Magarena/scripts_missing/Undercity_Necrolisk.txt
@@ -1,0 +1,11 @@
+name=Undercity Necrolisk
+image=https://img.scryfall.com/cards/normal/front/2/5/2571d168-38d4-46d7-afae-ffbd12bd2313.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Zombie,Lizard
+cost={3}{B}
+pt=3/3
+ability={1}, Sacrifice another creature: Put a +1/+1 counter on SN. It gains menace until end of turn. Activate this ability only any time you could cast a sorcery.
+timing=main
+oracle={1}, Sacrifice another creature: Put a +1/+1 counter on Undercity Necrolisk. It gains menace until end of turn. Activate this ability only any time you could cast a sorcery.

--- a/release/Magarena/scripts_missing/Undercity_Uprising.txt
+++ b/release/Magarena/scripts_missing/Undercity_Uprising.txt
@@ -1,0 +1,9 @@
+name=Undercity Uprising
+image=https://img.scryfall.com/cards/normal/front/7/e/7e1e08bf-a5d6-48bb-9f7f-4711f9ec88d7.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={2}{B}{G}
+effect=Creatures you control gain deathtouch until end of turn. Then target creature you control fights target creature you don't control.
+timing=main
+oracle=Creatures you control gain deathtouch until end of turn. Then target creature you control fights target creature you don't control.

--- a/release/Magarena/scripts_missing/Underrealm_Lich.txt
+++ b/release/Magarena/scripts_missing/Underrealm_Lich.txt
@@ -1,0 +1,12 @@
+name=Underrealm Lich
+image=https://img.scryfall.com/cards/normal/front/0/7/0782e090-209c-428f-966a-17f3ceab2903.jpg
+value=2.500
+rarity=M
+type=Creature
+subtype=Zombie,Elf,Shaman
+cost={3}{B}{G}
+pt=4/3
+ability=If you would draw a card, instead look at the top three cards of your library, then put one into your hand and the rest into your graveyard.;\
+        Pay 4 life: SN gains indestructible until end of turn. Tap it.
+timing=main
+oracle=If you would draw a card, instead look at the top three cards of your library, then put one into your hand and the rest into your graveyard.\nPay 4 life: Underrealm Lich gains indestructible until end of turn. Tap it.

--- a/release/Magarena/scripts_missing/Unexplained_Disappearance.txt
+++ b/release/Magarena/scripts_missing/Unexplained_Disappearance.txt
@@ -1,0 +1,9 @@
+name=Unexplained Disappearance
+image=https://img.scryfall.com/cards/normal/front/9/c/9c99b239-50d2-4393-80ec-94dbfaa6ae70.jpg
+value=2.500
+rarity=C
+type=Instant
+cost={1}{U}
+effect=Return target creature to its owner's hand.~Surveil 1.
+timing=removal
+oracle=Return target creature to its owner's hand.\nSurveil 1.

--- a/release/Magarena/scripts_missing/Unmoored_Ego.txt
+++ b/release/Magarena/scripts_missing/Unmoored_Ego.txt
@@ -1,0 +1,9 @@
+name=Unmoored Ego
+image=https://img.scryfall.com/cards/normal/front/9/5/95aecc12-3363-41f7-9b58-277c81859670.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={1}{U}{B}
+effect=Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles their library, then draws a card for each card exiled from their hand this way.
+timing=main
+oracle=Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles their library, then draws a card for each card exiled from their hand this way.

--- a/release/Magarena/scripts_missing/Urban_Utopia.txt
+++ b/release/Magarena/scripts_missing/Urban_Utopia.txt
@@ -1,0 +1,13 @@
+name=Urban Utopia
+image=https://img.scryfall.com/cards/normal/front/4/5/45d7ab0e-db37-4051-86dd-3ab09c047a2b.jpg
+value=2.500
+rarity=C
+type=Enchantment
+subtype=Aura
+cost={1}{G}
+ability=Enchant land;\
+        When SN enters the battlefield, draw a card.;\
+        Enchanted land has "{T}: Add one mana of any color."
+timing=aura
+enchant=default,creature
+oracle=Enchant land\nWhen Urban Utopia enters the battlefield, draw a card.\nEnchanted land has "{T}: Add one mana of any color."

--- a/release/Magarena/scripts_missing/Varchild__Betrayer_of_Kjeldor.txt
+++ b/release/Magarena/scripts_missing/Varchild__Betrayer_of_Kjeldor.txt
@@ -1,0 +1,13 @@
+name=Varchild, Betrayer of Kjeldor
+image=https://img.scryfall.com/cards/normal/en/c18/28.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Human,Knight
+cost={2}{R}
+pt=3/3
+ability=Whenever SN deals combat damage to a player, that player creates that many 1/1 red Survivor creature tokens.;\
+        Survivors your opponents control can't block, and they can't attack you or a planeswalker you control.;\
+        When Varchild leaves the battlefield, gain control of all Survivors.
+timing=main
+oracle=Whenever Varchild, Betrayer of Kjeldor deals combat damage to a player, that player creates that many 1/1 red Survivor creature tokens.\nSurvivors your opponents control can't block, and they can't attack you or a planeswalker you control.\nWhen Varchild leaves the battlefield, gain control of all Survivors.

--- a/release/Magarena/scripts_missing/Varina__Lich_Queen.txt
+++ b/release/Magarena/scripts_missing/Varina__Lich_Queen.txt
@@ -1,0 +1,12 @@
+name=Varina, Lich Queen
+image=https://img.scryfall.com/cards/normal/en/c18/48.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Zombie,Wizard
+cost={1}{W}{U}{B}
+pt=4/4
+ability=Whenever you attack with one or more Zombies, draw that many cards, then discard that many cards. You gain that much life.;\
+        {2}, Exile two cards from your graveyard: Create a tapped 2/2 black Zombie creature token.
+timing=main
+oracle=Whenever you attack with one or more Zombies, draw that many cards, then discard that many cards. You gain that much life.\n{2}, Exile two cards from your graveyard: Create a tapped 2/2 black Zombie creature token.

--- a/release/Magarena/scripts_missing/Vedalken_Humiliator.txt
+++ b/release/Magarena/scripts_missing/Vedalken_Humiliator.txt
@@ -1,0 +1,11 @@
+name=Vedalken Humiliator
+image=https://img.scryfall.com/cards/normal/en/c18/13.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Vedalken,Wizard
+cost={3}{U}
+pt=3/4
+ability=Metalcraft — Whenever SN attacks, if you control three or more artifacts, creatures your opponents control lose all abilities and have base power and toughness 1/1 until end of turn.
+timing=main
+oracle=Metalcraft — Whenever Vedalken Humiliator attacks, if you control three or more artifacts, creatures your opponents control lose all abilities and have base power and toughness 1/1 until end of turn.

--- a/release/Magarena/scripts_missing/Vedalken_Mesmerist.txt
+++ b/release/Magarena/scripts_missing/Vedalken_Mesmerist.txt
@@ -1,0 +1,11 @@
+name=Vedalken Mesmerist
+image=https://img.scryfall.com/cards/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Vedalken,Wizard
+cost={1}{U}
+pt=2/1
+ability=Whenever SN attacks, target creature an opponent controls gets -2/-0 until end of turn.
+timing=main
+oracle=Whenever Vedalken Mesmerist attacks, target creature an opponent controls gets -2/-0 until end of turn.

--- a/release/Magarena/scripts_missing/Veiled_Shade.txt
+++ b/release/Magarena/scripts_missing/Veiled_Shade.txt
@@ -1,0 +1,11 @@
+name=Veiled Shade
+image=https://img.scryfall.com/cards/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Shade
+cost={2}{B}
+pt=2/2
+ability={1}{B}: SN gets +1/+1 until end of turn.
+timing=main
+oracle={1}{B}: Veiled Shade gets +1/+1 until end of turn.

--- a/release/Magarena/scripts_missing/Venerated_Loxodon.txt
+++ b/release/Magarena/scripts_missing/Venerated_Loxodon.txt
@@ -1,0 +1,12 @@
+name=Venerated Loxodon
+image=https://img.scryfall.com/cards/normal/front/9/3/93599fba-7c53-4621-85b5-6434be077bf6.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Elephant,Cleric
+cost={4}{W}
+pt=4/4
+ability=Convoke;\
+        When SN enters the battlefield, put a +1/+1 counter on each creature that convoked it.
+timing=main
+oracle=Convoke\nWhen Venerated Loxodon enters the battlefield, put a +1/+1 counter on each creature that convoked it.

--- a/release/Magarena/scripts_missing/Vernadi_Shieldmate.txt
+++ b/release/Magarena/scripts_missing/Vernadi_Shieldmate.txt
@@ -1,0 +1,11 @@
+name=Vernadi Shieldmate
+image=https://img.scryfall.com/cards/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Soldier
+cost={1}{G/W}
+pt=2/2
+ability=Vigilance
+timing=main
+oracle=Vigilance

--- a/release/Magarena/scripts_missing/Vicious_Rumors.txt
+++ b/release/Magarena/scripts_missing/Vicious_Rumors.txt
@@ -1,0 +1,9 @@
+name=Vicious Rumors
+image=https://img.scryfall.com/cards/normal/front/b/1/b1939952-608e-4786-beeb-a6ff0fa36624.jpg
+value=2.500
+rarity=C
+type=Sorcery
+cost={B}
+effect=SN deals 1 damage to each opponent. Each opponent discards a card, then puts the top card of their library into their graveyard. You gain 1 life.
+timing=main
+oracle=Vicious Rumors deals 1 damage to each opponent. Each opponent discards a card, then puts the top card of their library into their graveyard. You gain 1 life.

--- a/release/Magarena/scripts_missing/Vigorspore_Wurm.txt
+++ b/release/Magarena/scripts_missing/Vigorspore_Wurm.txt
@@ -1,0 +1,12 @@
+name=Vigorspore Wurm
+image=https://img.scryfall.com/cards/normal/front/b/6/b62625de-3a2f-43d6-8cf7-ea38f038f3b6.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Wurm
+cost={5}{G}
+pt=6/4
+ability=Undergrowth — When SN enters the battlefield, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.;\
+        SN can't be blocked by more than one creature.
+timing=main
+oracle=Undergrowth — When Vigorspore Wurm enters the battlefield, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.\nVigorspore Wurm can't be blocked by more than one creature.

--- a/release/Magarena/scripts_missing/Vivid_Revival.txt
+++ b/release/Magarena/scripts_missing/Vivid_Revival.txt
@@ -1,0 +1,9 @@
+name=Vivid Revival
+image=https://img.scryfall.com/cards/normal/front/9/e/9e67fcfd-0e9e-4b88-8c65-2125fac10a3d.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={4}{G}
+effect=Return up to three target multicolored cards from your graveyard to your hand. Exile SN.
+timing=main
+oracle=Return up to three target multicolored cards from your graveyard to your hand. Exile Vivid Revival.

--- a/release/Magarena/scripts_missing/Vraska__Golgari_Queen.txt
+++ b/release/Magarena/scripts_missing/Vraska__Golgari_Queen.txt
@@ -1,0 +1,13 @@
+name=Vraska, Golgari Queen
+image=https://img.scryfall.com/cards/normal/front/9/6/963f641d-aabe-4432-87c5-d8cddf95d8d5.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Vraska
+cost={2}{B}{G}
+loyalty=4
+ability=+2: You may sacrifice another permanent. If you do, you gain 1 life and draw a card.;\
+        −3: Destroy target nonland permanent with converted mana cost 3 or less.;\
+        −9: You get an emblem with "Whenever a creature you control deals combat damage to a player, that player loses the game."
+timing=main
+oracle=+2: You may sacrifice another permanent. If you do, you gain 1 life and draw a card.\n−3: Destroy target nonland permanent with converted mana cost 3 or less.\n−9: You get an emblem with "Whenever a creature you control deals combat damage to a player, that player loses the game."

--- a/release/Magarena/scripts_missing/Vraska__Regal_Gorgon.txt
+++ b/release/Magarena/scripts_missing/Vraska__Regal_Gorgon.txt
@@ -1,0 +1,13 @@
+name=Vraska, Regal Gorgon
+image=https://img.scryfall.com/cards/normal/front/4/2/4299dbe6-c94d-4ecc-8bfd-741d2649cba1.jpg
+value=2.500
+rarity=M
+type=Legendary,Planeswalker
+subtype=Vraska
+cost={5}{B}{G}
+loyalty=5
+ability=+2: Put a +1/+1 counter on up to one target creature. That creature gains menace until end of turn.;\
+        −3: Destroy target creature.;\
+        −10: For each creature card in your graveyard, put a +1/+1 counter on each creature you control.
+timing=main
+oracle=+2: Put a +1/+1 counter on up to one target creature. That creature gains menace until end of turn.\n−3: Destroy target creature.\n−10: For each creature card in your graveyard, put a +1/+1 counter on each creature you control.

--- a/release/Magarena/scripts_missing/Vraska_s_Stoneglare.txt
+++ b/release/Magarena/scripts_missing/Vraska_s_Stoneglare.txt
@@ -1,0 +1,9 @@
+name=Vraska's Stoneglare
+image=https://img.scryfall.com/cards/normal/front/2/7/27fc4db6-a5f5-4254-ae64-c8eaf2c98030.jpg
+value=2.500
+rarity=R
+type=Sorcery
+cost={4}{B}{G}
+effect=Destroy target creature. You gain life equal to its toughness. You may search your library and/or graveyard for a card named Vraska, Regal Gorgon, reveal it, and put it into your hand. If you search your library this way, shuffle it.
+timing=main
+oracle=Destroy target creature. You gain life equal to its toughness. You may search your library and/or graveyard for a card named Vraska, Regal Gorgon, reveal it, and put it into your hand. If you search your library this way, shuffle it.

--- a/release/Magarena/scripts_missing/Wand_of_Vertebrae.txt
+++ b/release/Magarena/scripts_missing/Wand_of_Vertebrae.txt
@@ -1,0 +1,10 @@
+name=Wand of Vertebrae
+image=https://img.scryfall.com/cards/normal/front/8/7/87f208bc-e4dc-4d3a-8906-dccde3cc251b.jpg
+value=2.500
+rarity=U
+type=Artifact
+cost={1}
+ability={T}: Put the top card of your library into your graveyard.;\
+        {2}, {T}, Exile SN: Shuffle up to five target cards from your graveyard into your library.
+timing=artifact
+oracle={T}: Put the top card of your library into your graveyard.\n{2}, {T}, Exile Wand of Vertebrae: Shuffle up to five target cards from your graveyard into your library.

--- a/release/Magarena/scripts_missing/Wary_Okapi.txt
+++ b/release/Magarena/scripts_missing/Wary_Okapi.txt
@@ -1,0 +1,11 @@
+name=Wary Okapi
+image=https://img.scryfall.com/cards/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Antelope
+cost={2}{G}
+pt=3/2
+ability=Vigilance
+timing=main
+oracle=Vigilance

--- a/release/Magarena/scripts_missing/Watcher_in_the_Mist.txt
+++ b/release/Magarena/scripts_missing/Watcher_in_the_Mist.txt
@@ -1,0 +1,12 @@
+name=Watcher in the Mist
+image=https://img.scryfall.com/cards/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Spirit
+cost={3}{U}{U}
+pt=3/4
+ability=Flying;\
+        When SN enters the battlefield, surveil 2.
+timing=main
+oracle=Flying\nWhen Watcher in the Mist enters the battlefield, surveil 2.

--- a/release/Magarena/scripts_missing/Whiptongue_Hydra.txt
+++ b/release/Magarena/scripts_missing/Whiptongue_Hydra.txt
@@ -1,0 +1,12 @@
+name=Whiptongue Hydra
+image=https://img.scryfall.com/cards/normal/en/c18/36.jpg
+value=2.500
+rarity=R
+type=Creature
+subtype=Lizard,Hydra
+cost={5}{G}
+pt=4/4
+ability=Reach;\
+        When SN enters the battlefield, destroy all creatures with flying. Put a +1/+1 counter on SN for each creature destroyed this way.
+timing=main
+oracle=Reach\nWhen Whiptongue Hydra enters the battlefield, destroy all creatures with flying. Put a +1/+1 counter on Whiptongue Hydra for each creature destroyed this way.

--- a/release/Magarena/scripts_missing/Whisper_Agent.txt
+++ b/release/Magarena/scripts_missing/Whisper_Agent.txt
@@ -1,0 +1,12 @@
+name=Whisper Agent
+image=https://img.scryfall.com/cards/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Rogue
+cost={1}{U/B}{U/B}
+pt=3/2
+ability=Flash;\
+        When SN enters the battlefield, surveil 1.
+timing=flash
+oracle=Flash\nWhen Whisper Agent enters the battlefield, surveil 1.

--- a/release/Magarena/scripts_missing/Whispering_Snitch.txt
+++ b/release/Magarena/scripts_missing/Whispering_Snitch.txt
@@ -1,0 +1,11 @@
+name=Whispering Snitch
+image=https://img.scryfall.com/cards/normal/front/f/a/fa4ca97e-b402-4a73-9c70-79ec4565a39c.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Vampire,Rogue
+cost={1}{B}
+pt=1/3
+ability=Whenever you surveil for the first time each turn, SN deals 1 damage to each opponent and you gain 1 life.
+timing=main
+oracle=Whenever you surveil for the first time each turn, Whispering Snitch deals 1 damage to each opponent and you gain 1 life.

--- a/release/Magarena/scripts_missing/Wild_Ceratok.txt
+++ b/release/Magarena/scripts_missing/Wild_Ceratok.txt
@@ -1,0 +1,10 @@
+name=Wild Ceratok
+image=https://img.scryfall.com/cards/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Rhino
+cost={3}{G}
+pt=4/3
+timing=main
+oracle=NONE

--- a/release/Magarena/scripts_missing/Windgrace_s_Judgment.txt
+++ b/release/Magarena/scripts_missing/Windgrace_s_Judgment.txt
@@ -1,0 +1,9 @@
+name=Windgrace's Judgment
+image=https://img.scryfall.com/cards/normal/en/c18/49.jpg
+value=2.500
+rarity=R
+type=Instant
+cost={3}{B}{G}
+effect=For any number of opponents, destroy target nonland permanent that player controls.
+timing=removal
+oracle=For any number of opponents, destroy target nonland permanent that player controls.

--- a/release/Magarena/scripts_missing/Wishcoin_Crab.txt
+++ b/release/Magarena/scripts_missing/Wishcoin_Crab.txt
@@ -1,0 +1,10 @@
+name=Wishcoin Crab
+image=https://img.scryfall.com/cards/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Crab
+cost={3}{U}
+pt=2/5
+timing=main
+oracle=NONE

--- a/release/Magarena/scripts_missing/Wojek_Bodyguard.txt
+++ b/release/Magarena/scripts_missing/Wojek_Bodyguard.txt
@@ -1,0 +1,12 @@
+name=Wojek Bodyguard
+image=https://img.scryfall.com/cards/normal/front/e/b/ebff5313-e325-47c3-814b-38fdb4c6c8d2.jpg
+value=2.500
+rarity=C
+type=Creature
+subtype=Human,Soldier
+cost={2}{R}
+pt=3/3
+ability=Mentor;\
+        SN can't attack or block alone.
+timing=main
+oracle=Mentor\nWojek Bodyguard can't attack or block alone.

--- a/release/Magarena/scripts_missing/Woodland_Stream.txt
+++ b/release/Magarena/scripts_missing/Woodland_Stream.txt
@@ -1,0 +1,9 @@
+name=Woodland Stream
+image=https://img.scryfall.com/cards/normal/en/soi/282.jpg
+value=2.500
+rarity=C
+type=Land
+ability=SN enters the battlefield tapped.;\
+        {T}: Add {G} or {U}.
+timing=land
+oracle=Woodland Stream enters the battlefield tapped.\n{T}: Add {G} or {U}.

--- a/release/Magarena/scripts_missing/Worldsoul_Colossus.txt
+++ b/release/Magarena/scripts_missing/Worldsoul_Colossus.txt
@@ -1,0 +1,12 @@
+name=Worldsoul Colossus
+image=https://img.scryfall.com/cards/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg
+value=2.500
+rarity=U
+type=Creature
+subtype=Elemental
+cost={X}{G}{W}
+pt=0/0
+ability=Convoke;\
+        SN enters the battlefield with X +1/+1 counters on it.
+timing=main
+oracle=Convoke\nWorldsoul Colossus enters the battlefield with X +1/+1 counters on it.

--- a/release/Magarena/scripts_missing/Xantcha__Sleeper_Agent.txt
+++ b/release/Magarena/scripts_missing/Xantcha__Sleeper_Agent.txt
@@ -1,0 +1,13 @@
+name=Xantcha, Sleeper Agent
+image=https://img.scryfall.com/cards/normal/en/c18/50.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Minion
+cost={1}{B}{R}
+pt=5/5
+ability=As SN enters the battlefield, an opponent of your choice gains control of it.;\
+        Xantcha attacks each combat if able and can't attack its owner or planeswalkers its owner controls.;\
+        {3}: Xantcha's controller loses 2 life and you draw a card. Any player may activate this ability.
+timing=main
+oracle=As Xantcha, Sleeper Agent enters the battlefield, an opponent of your choice gains control of it.\nXantcha attacks each combat if able and can't attack its owner or planeswalkers its owner controls.\n{3}: Xantcha's controller loses 2 life and you draw a card. Any player may activate this ability.

--- a/release/Magarena/scripts_missing/Yennett__Cryptic_Sovereign.txt
+++ b/release/Magarena/scripts_missing/Yennett__Cryptic_Sovereign.txt
@@ -1,0 +1,12 @@
+name=Yennett, Cryptic Sovereign
+image=https://img.scryfall.com/cards/normal/en/c18/51.jpg
+value=2.500
+rarity=M
+type=Legendary,Creature
+subtype=Sphinx
+cost={2}{W}{U}{B}
+pt=3/5
+ability=Flying, vigilance, menace;\
+        Whenever SN attacks, reveal the top card of your library. If that card's converted mana cost is odd, you may cast it without paying its mana cost. Otherwise, draw a card.
+timing=main
+oracle=Flying, vigilance, menace\nWhenever Yennett, Cryptic Sovereign attacks, reveal the top card of your library. If that card's converted mana cost is odd, you may cast it without paying its mana cost. Otherwise, draw a card.

--- a/release/Magarena/scripts_missing/Yuriko__the_Tiger_s_Shadow.txt
+++ b/release/Magarena/scripts_missing/Yuriko__the_Tiger_s_Shadow.txt
@@ -1,0 +1,12 @@
+name=Yuriko, the Tiger's Shadow
+image=https://img.scryfall.com/cards/normal/en/c18/52.jpg
+value=2.500
+rarity=R
+type=Legendary,Creature
+subtype=Human,Ninja
+cost={1}{U}{B}
+pt=1/3
+ability=Commander ninjutsu {U}{B};\
+        Whenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's converted mana cost.
+timing=main
+oracle=Commander ninjutsu {U}{B}\nWhenever a Ninja you control deals combat damage to a player, reveal the top card of your library and put that card into your hand. Each opponent loses life equal to that card's converted mana cost.

--- a/resources/magic/data/sets/GRN.txt
+++ b/resources/magic/data/sets/GRN.txt
@@ -1,0 +1,278 @@
+Affectionate Indrik
+Arboretum Elemental
+Arclight Phoenix
+Artful Takedown
+Assassin's Trophy
+Assemble
+Assure
+Attendant of Vraska
+Aurelia, Exemplar of Justice
+Barging Sergeant
+Barrier of Bones
+Bartizan Bats
+Beacon Bolt
+Beamsplitter Mage
+Beast Whisperer
+Blade Instructor
+Blood Operative
+Book Devourer
+Boros Challenger
+Boros Guildgate
+Boros Locket
+Bounty Agent
+Bounty of Might
+Burglar Rat
+Camaraderie
+Candlelight Vigil
+Capture Sphere
+Centaur Peacemaker
+Chamber Sentry
+Chance for Glory
+Charnel Troll
+Chemister's Insight
+Child of Night
+Chromatic Lantern
+Circuitous Route
+Citywatch Sphinx
+Citywide Bust
+Collar the Culprit
+Command the Storm
+Conclave Cavalier
+Conclave Guildmage
+Conclave Tribunal
+Concoct
+Connive
+Cosmotronic Wave
+Crackling Drake
+Creeping Chill
+Crush Contraband
+Crushing Canopy
+Darkblade Agent
+Dawn of Hope
+Dazzling Lights
+Dead Weight
+Deadly Visit
+Deafening Clarion
+Demotion
+Devious Cover-Up
+Devkarin Dissident
+Dimir Guildgate
+Dimir Informant
+Dimir Locket
+Dimir Spybug
+Direct Current
+Discovery
+Disdainful Stroke
+Disinformation Campaign
+Dispersal
+District Guide
+Divine Visitation
+Doom Whisperer
+Douser of Lights
+Dream Eater
+Drowned Secrets
+Electrostatic Field
+Emmara, Soul of the Accord
+Enhanced Surveillance
+Erratic Cyclops
+Erstwhile Trooper
+Etrata, the Silencer
+Expansion
+Experimental Frenzy
+Explosion
+Fearless Halberdier
+Finality
+Find
+Fire Urchin
+Firemind's Research
+Flight of Equenauts
+Flourish
+Flower
+Forest
+Fresh-Faced Recruit
+Garrison Sergeant
+Gatekeeper Gargoyle
+Gateway Plaza
+Generous Stray
+Gird for Battle
+Glaive of the Guildpact
+Glowspore Shaman
+Goblin Banneret
+Goblin Cratermaker
+Goblin Electromancer
+Goblin Locksmith
+Golgari Findbroker
+Golgari Guildgate
+Golgari Locket
+Golgari Raiders
+Grappling Sundew
+Gravitic Punch
+Gruesome Menagerie
+Guild Summit
+Guildmages' Forum
+Haazda Marshal
+Hammer Dropper
+Hatchery Spider
+Healer's Hawk
+Hellkite Whelp
+Hired Poisoner
+Hitchclaw Recluse
+House Guildmage
+Hunted Witness
+Hypothesizzle
+Impervious Greatwurm
+Inescapable Blaze
+Inspiring Unicorn
+Integrity
+Intervention
+Intrusive Packbeast
+Invent
+Invert
+Ionize
+Ironshell Beetle
+Island
+Izoni, Thousand-Eyed
+Izzet Guildgate
+Izzet Locket
+Join Shields
+Justice Strike
+Knight of Autumn
+Kraul Foragers
+Kraul Harpooner
+Kraul Raider
+Kraul Swarm
+Lava Coil
+Lazav, the Multifarious
+League Guildmage
+Leapfrog
+Ledev Champion
+Ledev Guardian
+Legion Guildmage
+Legion Warboss
+Light of the Legion
+Lotleth Giant
+Loxodon Restorer
+Luminous Bonds
+Maniacal Rage
+March of the Multitudes
+Mausoleum Secrets
+Maximize Altitude
+Maximize Velocity
+Mephitic Vapors
+Midnight Reaper
+Might of the Masses
+Mission Briefing
+Mnemonic Betrayal
+Molderhulk
+Moodmark Painter
+Mountain
+Murmuring Mystic
+Muse Drake
+Narcomoeba
+Necrotic Wound
+Never Happened
+Nightveil Predator
+Nightveil Sprite
+Niv-Mizzet, Parun
+Notion Rain
+Nullhide Ferox
+Ochran Assassin
+Omnispell Adept
+Ornery Goblin
+Overgrown Tomb
+Pack's Favor
+Parhelion Patrol
+Passwall Adept
+Pause for Reflection
+Pelt Collector
+Pilfering Imp
+Piston-Fist Cyclops
+Pitiless Gorgon
+Plaguecrafter
+Plains
+Portcullis Vine
+Precision Bolt
+Prey Upon
+Price of Fame
+Quasiduplicate
+Radical Idea
+Ral's Dispersal
+Ral's Staticaster
+Ral, Caller of Storms
+Ral, Izzet Viceroy
+Rampaging Monument
+Response
+Resurgence
+Rhizome Lurcher
+Righteous Blow
+Risk Factor
+Ritual of Soot
+Roc Charger
+Rosemane Centaur
+Rubblebelt Boar
+Runaway Steam-Kin
+Sacred Foundry
+Selective Snare
+Selesnya Guildgate
+Selesnya Locket
+Severed Strands
+Siege Wurm
+Silent Dart
+Sinister Sabotage
+Skyknight Legionnaire
+Skyline Scout
+Smelt-Ward Minotaur
+Sonic Assault
+Spinal Centipede
+Sprouting Renewal
+Statue
+Status
+Steam Vents
+Street Riot
+Sumala Woodshaper
+Sunhome Stalwart
+Sure Strike
+Swamp
+Swarm Guildmage
+Swathcutter Giant
+Swiftblade Vindicator
+Sworn Companions
+Tajic, Legion's Edge
+Take Heart
+Temple Garden
+Tenth District Guard
+Thief of Sanity
+Thought Erasure
+Thoughtbound Phantasm
+Thousand-Year Storm
+Torch Courier
+Trostani Discordant
+Truefire Captain
+Undercity Necrolisk
+Undercity Uprising
+Underrealm Lich
+Unexplained Disappearance
+Unmoored Ego
+Urban Utopia
+Vedalken Mesmerist
+Veiled Shade
+Venerated Loxodon
+Vernadi Shieldmate
+Vicious Rumors
+Vigorspore Wurm
+Vivid Revival
+Vraska's Stoneglare
+Vraska, Golgari Queen
+Vraska, Regal Gorgon
+Wall of Mist
+Wand of Vertebrae
+Wary Okapi
+Watcher in the Mist
+Watery Grave
+Wee Dragonauts
+Whisper Agent
+Whispering Snitch
+Wild Ceratok
+Wishcoin Crab
+Wojek Bodyguard
+Worldsoul Colossus


### PR DESCRIPTION
This adds new cards mostly from GRN and C18 sets, plus few forgotten ones (Accorder Paladin, ...) that did not make it for same reason in the past (I tried to put in all existing cards that were missing either in scripts or scripts_missing).

Note that this also puts in those few never-to-be-implemented ante cards. Those are marked by appropriate status.

I had to do some modifications to magarena-script-builder in order to do this - these will be in separate pull request in that repo.

The cards are put all into script_missing. I think there probably is some automated process to find those that are implemented and move them to "script", but I do not know how to run it.