### PR TITLE
Fix weird crash with bogus reason if deckfile does not exists

### DIFF
--- a/src/magic/utility/DeckUtils.java
+++ b/src/magic/utility/DeckUtils.java
@@ -197,7 +197,7 @@ public class DeckUtils {
      */
     public static MagicDeck loadDeckFromFile(final Path deckFilePath) {
         if (deckFilePath == null || !deckFilePath.toFile().exists()) {
-            return new MagicDeck();
+            throw new InvalidDeckException("File " + deckFilePath + " does not exist");
         }
         final List<String> lines = getDeckFileContent(deckFilePath.toString());
         final MagicDeck deck = DeckParser.parseLines(lines);


### PR DESCRIPTION
If deckfile set in GUI is invalid (i.e. if the file got removed between magarena runs), without the fix it fails with very cryptic exception like "unknown magiccolor "N" and magarena crashes. With this fix you get messagebox "deck in invalid".