### PR TITLE
Reduced colored costs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /build/
+/buildtest/
+/test/lib
 /.project
 /nbproject/
 /manifest.mf

--- a/src/magic/model/MagicCostManaType.java
+++ b/src/magic/model/MagicCostManaType.java
@@ -1,6 +1,7 @@
 package magic.model;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -8,34 +9,34 @@ public enum MagicCostManaType {
 
     // Ordered from least restrictive to most restrictive.
     // Same order as in mana cost
-    Generic("generic","{1}",Arrays.asList(MagicManaType.Colorless,MagicManaType.White,MagicManaType.Blue,MagicManaType.Black,MagicManaType.Red,MagicManaType.Green)),
-    WhiteBlue("white/blue","{W/U}",Arrays.asList(MagicManaType.White,MagicManaType.Blue)),
-    WhiteBlack("white/black","{W/B}",Arrays.asList(MagicManaType.White,MagicManaType.Black)),
-    BlueBlack("blue/black","{U/B}",Arrays.asList(MagicManaType.Blue,MagicManaType.Black)),
-    BlueRed("blue/red","{U/R}",Arrays.asList(MagicManaType.Blue,MagicManaType.Red)),
-    BlackRed("black/red","{B/R}",Arrays.asList(MagicManaType.Black,MagicManaType.Red)),
-    BlackGreen("black/green","{B/G}",Arrays.asList(MagicManaType.Black,MagicManaType.Green)),
-    RedGreen("red/green","{R/G}",Arrays.asList(MagicManaType.Red,MagicManaType.Green)),
-    RedWhite("red/white","{R/W}",Arrays.asList(MagicManaType.Red,MagicManaType.White)),
-    GreenWhite("green/white","{G/W}",Arrays.asList(MagicManaType.Green,MagicManaType.White)),
-    GreenBlue("green/blue","{G/U}",Arrays.asList(MagicManaType.Green,MagicManaType.Blue)),
-    PhyrexianWhite("phyrexian white","{W/P}",Arrays.asList(MagicManaType.White)),
-    PhyrexianBlue("phyrexian blue","{U/P}",Arrays.asList(MagicManaType.Blue)),
-    PhyrexianBlack("phyrexian black","{B/P}",Arrays.asList(MagicManaType.Black)),
-    PhyrexianRed("phyrexian red","{R/P}",Arrays.asList(MagicManaType.Red)),
-    PhyrexianGreen("phyrexian green","{G/P}",Arrays.asList(MagicManaType.Green)),
-    HybridWhite("hybrid white","{2/W}",Arrays.asList(MagicManaType.White)),
-    HybridBlue("hybrid blue","{2/U}",Arrays.asList(MagicManaType.Blue)),
-    HybridBlack("hybrid black","{2/B}",Arrays.asList(MagicManaType.Black)),
-    HybridRed("hybrid red","{2/R}",Arrays.asList(MagicManaType.Red)),
-    HybridGreen("hybrid green","{2/G}",Arrays.asList(MagicManaType.Green)),
-    White("white","{W}",Arrays.asList(MagicManaType.White)),
-    Blue("blue","{U}",Arrays.asList(MagicManaType.Blue)),
-    Black("black","{B}",Arrays.asList(MagicManaType.Black)),
-    Red("red","{R}",Arrays.asList(MagicManaType.Red)),
-    Green("green","{G}",Arrays.asList(MagicManaType.Green)),
-    Snow("snow","{S}",Arrays.asList(MagicManaType.Snow)),
-    Colorless("colorless","{C}",Arrays.asList(MagicManaType.Colorless))
+    Generic("generic", "{1}", Arrays.asList(MagicManaType.Colorless, MagicManaType.White, MagicManaType.Blue, MagicManaType.Black, MagicManaType.Red, MagicManaType.Green)),
+    WhiteBlue("white/blue", "{W/U}", Arrays.asList(MagicManaType.White, MagicManaType.Blue)),
+    WhiteBlack("white/black", "{W/B}", Arrays.asList(MagicManaType.White, MagicManaType.Black)),
+    BlueBlack("blue/black", "{U/B}", Arrays.asList(MagicManaType.Blue, MagicManaType.Black)),
+    BlueRed("blue/red", "{U/R}", Arrays.asList(MagicManaType.Blue, MagicManaType.Red)),
+    BlackRed("black/red", "{B/R}", Arrays.asList(MagicManaType.Black, MagicManaType.Red)),
+    BlackGreen("black/green", "{B/G}", Arrays.asList(MagicManaType.Black, MagicManaType.Green)),
+    RedGreen("red/green", "{R/G}", Arrays.asList(MagicManaType.Red, MagicManaType.Green)),
+    RedWhite("red/white", "{R/W}", Arrays.asList(MagicManaType.Red, MagicManaType.White)),
+    GreenWhite("green/white", "{G/W}", Arrays.asList(MagicManaType.Green, MagicManaType.White)),
+    GreenBlue("green/blue", "{G/U}", Arrays.asList(MagicManaType.Green, MagicManaType.Blue)),
+    PhyrexianWhite("phyrexian white", "{W/P}", Collections.singletonList(MagicManaType.White)),
+    PhyrexianBlue("phyrexian blue", "{U/P}", Collections.singletonList(MagicManaType.Blue)),
+    PhyrexianBlack("phyrexian black", "{B/P}", Collections.singletonList(MagicManaType.Black)),
+    PhyrexianRed("phyrexian red", "{R/P}", Collections.singletonList(MagicManaType.Red)),
+    PhyrexianGreen("phyrexian green", "{G/P}", Collections.singletonList(MagicManaType.Green)),
+    HybridWhite("hybrid white", "{2/W}", Collections.singletonList(MagicManaType.White)),
+    HybridBlue("hybrid blue", "{2/U}", Collections.singletonList(MagicManaType.Blue)),
+    HybridBlack("hybrid black", "{2/B}", Collections.singletonList(MagicManaType.Black)),
+    HybridRed("hybrid red", "{2/R}", Collections.singletonList(MagicManaType.Red)),
+    HybridGreen("hybrid green", "{2/G}", Collections.singletonList(MagicManaType.Green)),
+    White("white", "{W}", Collections.singletonList(MagicManaType.White)),
+    Blue("blue", "{U}", Collections.singletonList(MagicManaType.Blue)),
+    Black("black", "{B}", Collections.singletonList(MagicManaType.Black)),
+    Red("red", "{R}", Collections.singletonList(MagicManaType.Red)),
+    Green("green", "{G}", Collections.singletonList(MagicManaType.Green)),
+    Snow("snow", "{S}", Collections.singletonList(MagicManaType.Snow)),
+    Colorless("colorless", "{C}", Collections.singletonList(MagicManaType.Colorless))
     ;
 
     public static final int NR_OF_TYPES=values().length;

--- a/src/magic/model/MagicCostManaType.java
+++ b/src/magic/model/MagicCostManaType.java
@@ -41,6 +41,7 @@ public enum MagicCostManaType {
     public static final int NR_OF_TYPES=values().length;
     public static final EnumSet<MagicCostManaType> MONO = EnumSet.range(White, Green);
     public static final EnumSet<MagicCostManaType> HYBRID = EnumSet.range(WhiteBlue, GreenBlue);
+    public static final EnumSet<MagicCostManaType> CHOICE = EnumSet.range(WhiteBlue, HybridGreen);
     public static final EnumSet<MagicCostManaType> NON_MONO = EnumSet.complementOf(MONO);
 
     private final String name;

--- a/src/magic/model/event/MagicBestowActivation.java
+++ b/src/magic/model/event/MagicBestowActivation.java
@@ -1,6 +1,6 @@
 package magic.model.event;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import magic.model.MagicCard;
 import magic.model.MagicGame;
@@ -53,7 +53,7 @@ public class MagicBestowActivation extends MagicHandCastActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicCard source) {
-        return Arrays.asList(MagicPayManaCostEvent.Cast(source, cost));
+        return Collections.singletonList(MagicPayManaCostEvent.Cast(source, cost));
     }
 
     @Override

--- a/src/magic/model/event/MagicCrewActivation.java
+++ b/src/magic/model/event/MagicCrewActivation.java
@@ -8,7 +8,7 @@ import magic.model.mstatic.MagicStatic;
 import magic.model.mstatic.MagicLayer;
 import magic.model.action.AddStaticAction;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 public class MagicCrewActivation extends MagicPermanentActivation {
 
@@ -34,7 +34,7 @@ public class MagicCrewActivation extends MagicPermanentActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
-        return Arrays.asList(new MagicCrewCostEvent(source,crew));
+        return Collections.singletonList(new MagicCrewCostEvent(source, crew));
     }
 
     @Override

--- a/src/magic/model/event/MagicDashActivation.java
+++ b/src/magic/model/event/MagicDashActivation.java
@@ -1,6 +1,7 @@
 package magic.model.event;
 
-import java.util.Arrays;
+import java.util.Collections;
+
 import magic.model.MagicCard;
 import magic.model.MagicGame;
 import magic.model.MagicManaCost;
@@ -27,7 +28,7 @@ public class MagicDashActivation extends MagicHandCastActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicCard source) {
-        return Arrays.asList(
+        return Collections.singletonList(
             new MagicPayManaCostEvent(
                 source,
                 source.getGameCost(cost)

--- a/src/magic/model/event/MagicLevelUpActivation.java
+++ b/src/magic/model/event/MagicLevelUpActivation.java
@@ -10,7 +10,7 @@ import magic.model.action.ChangeCountersAction;
 import magic.model.condition.MagicArtificialCondition;
 import magic.model.condition.MagicCondition;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 public class MagicLevelUpActivation extends MagicPermanentActivation {
 
@@ -35,7 +35,7 @@ public class MagicLevelUpActivation extends MagicPermanentActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
-        return Arrays.asList(new MagicPayManaCostEvent(source,cost));
+        return Collections.singletonList(new MagicPayManaCostEvent(source, cost));
     }
 
     @Override

--- a/src/magic/model/event/MagicMorphActivation.java
+++ b/src/magic/model/event/MagicMorphActivation.java
@@ -1,7 +1,6 @@
 package magic.model.event;
 
 import java.util.Collections;
-import java.util.Arrays;
 import java.util.List;
 import java.util.LinkedList;
 
@@ -23,7 +22,7 @@ public class MagicMorphActivation extends MagicPermanentActivation {
     public static final MagicMorphActivation Manifest = new MagicMorphActivation(Collections.emptyList()) {
         @Override
         public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
-            return Arrays.asList(
+            return Collections.singletonList(
                 new MagicPayManaCostEvent(
                     source,
                     source.getRealCardDefinition().getCost()

--- a/src/magic/model/event/MagicMorphCastActivation.java
+++ b/src/magic/model/event/MagicMorphCastActivation.java
@@ -20,7 +20,7 @@ import magic.model.action.PutItemOnStackAction;
 import magic.model.action.RemoveCardAction;
 import magic.model.action.PlayCardFromStackAction;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 public class MagicMorphCastActivation extends MagicHandCastActivation {
 
@@ -44,7 +44,7 @@ public class MagicMorphCastActivation extends MagicHandCastActivation {
             MagicCard.createTokenCard(morphSpell, morphSpell.getController()),
             MagicManaCost.create("{3}")
         );
-        return Arrays.asList(
+        return Collections.singletonList(
             new MagicPayManaCostEvent(
                 morphSpell,
                 modCost

--- a/src/magic/model/event/MagicPermanentActivation.java
+++ b/src/magic/model/event/MagicPermanentActivation.java
@@ -16,7 +16,7 @@ import magic.model.condition.MagicCondition;
 import magic.model.mstatic.MagicStatic;
 import magic.model.stack.MagicAbilityOnStack;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class MagicPermanentActivation extends MagicActivation<MagicPermanent> implements MagicChangeCardDefinition {
@@ -157,7 +157,7 @@ public abstract class MagicPermanentActivation extends MagicActivation<MagicPerm
         ) {
             @Override
             public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent source) {
-                return Arrays.asList(new MagicPayManaCostEvent(source,cost));
+                return Collections.singletonList(new MagicPayManaCostEvent(source, cost));
             }
             @Override
             public MagicEvent getPermanentEvent(final MagicPermanent source,final MagicPayedCost payedCost) {

--- a/src/magic/model/event/MagicSacrificeManaActivation.java
+++ b/src/magic/model/event/MagicSacrificeManaActivation.java
@@ -2,7 +2,7 @@ package magic.model.event;
 
 import magic.model.MagicManaType;
 import magic.model.MagicPermanent;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class MagicSacrificeManaActivation extends MagicManaActivation {
@@ -13,6 +13,6 @@ public class MagicSacrificeManaActivation extends MagicManaActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent perm) {
-        return Arrays.asList(new MagicSacrificeEvent(perm));
+        return Collections.singletonList(new MagicSacrificeEvent(perm));
     }
 }

--- a/src/magic/model/event/MagicSuspendActivation.java
+++ b/src/magic/model/event/MagicSuspendActivation.java
@@ -1,6 +1,7 @@
 package magic.model.event;
 
-import java.util.Arrays;
+import java.util.Collections;
+
 import magic.model.MagicCard;
 import magic.model.MagicCounterType;
 import magic.model.MagicGame;
@@ -33,7 +34,7 @@ public class MagicSuspendActivation extends MagicCardAbilityActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicCard source) {
-        return Arrays.asList(
+        return Collections.singletonList(
             new MagicPayManaCostEvent(source, cost)
         );
     }

--- a/src/magic/model/event/MagicTapManaActivation.java
+++ b/src/magic/model/event/MagicTapManaActivation.java
@@ -1,6 +1,6 @@
 package magic.model.event;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import magic.model.MagicManaType;
@@ -14,7 +14,7 @@ public class MagicTapManaActivation extends MagicManaActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicPermanent perm) {
-        return Arrays.asList(new MagicTapEvent(perm));
+        return Collections.singletonList(new MagicTapEvent(perm));
     }
 
     public static final MagicManaActivation White = new MagicTapManaActivation(MagicManaType.getList("{W}"));

--- a/src/magic/model/event/MagicUnearthActivation.java
+++ b/src/magic/model/event/MagicUnearthActivation.java
@@ -1,6 +1,7 @@
 package magic.model.event;
 
-import java.util.Arrays;
+import java.util.Collections;
+
 import magic.model.MagicCard;
 import magic.model.MagicCardDefinition;
 import magic.model.MagicGame;
@@ -32,7 +33,7 @@ public class MagicUnearthActivation extends MagicCardAbilityActivation {
 
     @Override
     public Iterable<? extends MagicEvent> getCostEvent(final MagicCard source) {
-        return Arrays.asList(
+        return Collections.singletonList(
             new MagicPayManaCostEvent(source, cost)
         );
     }

--- a/src/magic/ui/screen/duel/setup/DuelPlayerDeckPanel.java
+++ b/src/magic/ui/screen/duel/setup/DuelPlayerDeckPanel.java
@@ -118,11 +118,12 @@ class DuelPlayerDeckPanel extends TexturedPanel implements IThemeStyle {
     }
 
     private String getVerboseColors(final String colorCodes) {
-        String colors = "";
-        for (char ch: colorCodes.toCharArray()) {
-            colors += MagicColor.getColor(ch).getDisplayName() + ", ";
+        StringBuilder colors = new StringBuilder();
+        for (char ch : colorCodes.toCharArray()) {
+            colors.append(MagicColor.getColor(ch).getDisplayName()).append(", ");
         }
-        return colors.trim().substring(0, colors.trim().length() - 1);
+        String trimmed = colors.toString().trim();
+        return trimmed.substring(0, trimmed.length() - 1);
     }
 
     private MouseAdapter getMouseAdapter() {

--- a/test/magic/model/mstatic/MagicManaCostTest.java
+++ b/test/magic/model/mstatic/MagicManaCostTest.java
@@ -23,9 +23,36 @@ public class MagicManaCostTest {
 
         assertEquals("{X}{2}{R}", rx.increasedBy(MagicManaCost.create("{2}")).toString());
         assertEquals("{X}{X}{2}{U}", uxx.increasedBy(MagicManaCost.create("{2}")).toString());
+
+        // Following two are not 100% correct, but as close to the wanted result as possible
+        // (as the X should be replaced by something like "X-2", or rather the discount should be fully resolved at cast time)
+        // Note that -2 is stored internally in the amount, but not used for discount when casting.
         assertEquals("{X}{R}", rx.reducedBy(MagicManaCost.create("{2}")).toString());
         assertEquals("{X}{X}{U}", uxx.reducedBy(MagicManaCost.create("{2}")).toString());
 
-        assertEquals("{X}{R}", rx.increasedBy(MagicManaCost.create("{2}")).reducedBy(MagicManaCost.create("{2}")).toString());
+        assertEquals("{X}{R}", rx.increasedBy(MagicManaCost.create("{2}")).reducedBy(
+                MagicManaCost.create("{2}")).toString());
+    }
+
+    @Test
+    public void testSplitCostModification() {
+        MagicManaCost rw3 = MagicManaCost.create("{R/W}{R/W}{R/W}");
+        assertEquals("{R/W}{R/W}", rw3.reducedBy(MagicManaCost.create("{R}{G}")).toString());
+        assertEquals("{R/W}", rw3.reducedBy(MagicManaCost.create("{R}{G}{R/W}")).toString());
+        MagicManaCost rw2gw = MagicManaCost.create("{R/W}{R/W}{G/W}");
+
+        assertEquals("{0}", rw2gw.reducedBy(MagicManaCost.create("{R}{G}{R/W}")).toString());
+        assertEquals("{0}", rw2gw.reducedBy(MagicManaCost.create("{R}{G}{W}")).toString());
+
+        MagicManaCost hybrid = MagicManaCost.create("{2/R}{2/G}{2/W}");
+        assertEquals("{2/W}", hybrid.reducedBy(MagicManaCost.create("{R}{G}{U}")).toString());
+
+        MagicManaCost phyR = MagicManaCost.create("{R}{R/P}{G/P}{W/P}");
+        assertEquals("{W/P}", phyR.reducedBy(MagicManaCost.create("{R}{R}{G}{U}")).toString());
+
+        MagicManaCost phy = MagicManaCost.create("{R/P}{G/P}{W/P}");
+        assertEquals("{W/P}", phy.reducedBy(MagicManaCost.create("{R}{G}{U}")).toString());
+
+
     }
 }


### PR DESCRIPTION
As mentioned in #1628 - the colored discount was not applied to spit/hybrid/phyrexian costs.

With this change it is! If the cost includes only one type of split cost (for example {R/W}{R/W}{R/W}), it works flawlessly.

If the card contains multiple types of split costs, the algorithm reduces first found matching cost, even if some other combination may be better for the player. So far the only card  (that might trigger the inefficiency issue) that exist with multiple types of split cost in its cost is Reaper King: {2/W}{2/U}{2/B}{2/R}{2/G} - and that one is not implemented in magarena at the moment anyway.

Tested both with extended unit test and in game (Ragemonger is now able to reduce cost of Boros Reckoner from {R/W}{R/W}{R/W} to {R/W}{R/W}).