### PR TITLE
Add "card test" mode that tests all cards in a predefined scenario.

### DIFF
--- a/src/magic/CardTest.java
+++ b/src/magic/CardTest.java
@@ -1,0 +1,219 @@
+package magic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import magic.ai.MagicAI;
+import magic.ai.MagicAIImpl;
+import magic.data.CardDefinitions;
+import magic.data.DuelConfig;
+import magic.exception.handler.ConsoleExceptionHandler;
+import magic.headless.HeadlessGameController;
+import magic.model.DuelPlayerConfig;
+import magic.model.MagicCardDefinition;
+import magic.model.MagicDeckProfile;
+import magic.model.MagicDuel;
+import magic.model.MagicGame;
+import magic.model.MagicPlayer;
+import magic.model.phase.MagicMainPhase;
+import magic.model.player.AiProfile;
+import magic.test.TestGameBuilder;
+import magic.utility.MagicSystem;
+import magic.utility.ProgressReporter;
+
+/**
+ * Special kind of headless game, where every implemented
+ * card and token is used for a very short game in a predefined scenario.
+ */
+public class CardTest {
+    private static void parseCommandLine(CommandLineArgs cmdline) {
+        MagicAI.setMaxThreads(cmdline.getMaxThreads());
+        MagicSystem.setIsDevMode(cmdline.isDevMode());
+    }
+
+    public static void main(final CommandLineArgs cmdline) {
+        Thread.setDefaultUncaughtExceptionHandler(new ConsoleExceptionHandler());
+
+        parseCommandLine(cmdline);
+
+        MagicSystem.initialize(new ProgressReporter());
+
+        System.out.println("=================== Card test ====================");
+
+        Collection<MagicCardDefinition> allC = CardDefinitions.getAllPlayableCardDefs();
+
+        List<String> cards = new ArrayList<>();
+        List<MagicCardDefinition> tokens = new ArrayList<>();
+
+        for (MagicCardDefinition def : allC) {
+            String name = def.getName();
+            if (name.isEmpty()) {
+                // Manifest, morph, or alike ...
+                System.out.println("Def without name: " + def.getDistinctName());
+                continue;
+            }
+            if (def.isToken()) tokens.add(def);
+            else cards.add(name);
+        }
+        System.out.println("Cards: " + cards.size());
+        System.out.println("Tokens: " + tokens.size());
+
+        int t = 1;
+        for (MagicCardDefinition token : tokens) {
+            System.out.println("Testing token #" + t + ": " + token.getName());
+            t++;
+            MagicGame game = new TokenScenario(token).getGame();
+            game.setArtificial(true);
+
+            //5 seconds max for a quick match
+            final HeadlessGameController controller = new HeadlessGameController(
+                game, 5 * 1000
+            );
+
+            final long start_time = System.currentTimeMillis();
+            controller.runGame();
+            final double duration = (double) (System.currentTimeMillis() - start_time) / 1000;
+
+            System.out.printf("Token time: %.2fs : %s\n", duration, token);
+        }
+
+
+        int n = 1;
+        for (String name : cards) {
+            System.out.println("Testing card #" + n + ": " + name);
+            n++;
+            MagicGame game = new CardScenario(name).getGame();
+            game.setArtificial(true);
+
+            //5 seconds max for a quick match
+            final HeadlessGameController controller = new HeadlessGameController(
+                game, 5 * 1000
+            );
+
+            final long start_time = System.currentTimeMillis();
+            controller.runGame();
+            final double duration = (double) (System.currentTimeMillis() - start_time) / 1000;
+
+            System.out.printf("Time: %.2fs : %s\n", duration, name);
+        }
+
+    }
+
+    /**
+     * Base scenario, where player starts with two tested cares in hand.
+     */
+    private static class CardScenario extends BaseScenario {
+        private String testCard;
+
+        public CardScenario(String testCard) {
+            this.testCard = testCard;
+        }
+
+        @Override
+        public void prepareScenario(MagicPlayer player, MagicPlayer opponent) {
+            addToHand(player, testCard, 2);
+
+        }
+    }
+
+    /**
+     * Base scenario, where player starts one tested token in play.
+     */
+    private static class TokenScenario extends BaseScenario {
+        private MagicCardDefinition testToken;
+
+        public TokenScenario(MagicCardDefinition testToken) {
+            this.testToken = testToken;
+        }
+
+        @Override
+        public void prepareScenario(MagicPlayer player, MagicPlayer opponent) {
+            createPermanent(player, testToken, false, 1);
+        }
+    }
+
+    /**
+     * Base scenario - player has most likely enough mana to cast anything,
+     * opponent has at least one permanent of every type, so there would likely be some targets
+     * for variety of possible spells and effects.
+     *
+     * Libraries have only two cards (basic lands) in them, so the game is likely to end quickly.
+     */
+    private static abstract class BaseScenario extends TestGameBuilder {
+        public abstract void prepareScenario(MagicPlayer player, MagicPlayer opponent);
+
+        public static MagicDuel createAiDuel(final MagicAIImpl aAiType, final int aAiLevel) {
+            // Set number of games.
+            final DuelConfig config = new DuelConfig();
+            config.setNrOfGames(1);
+            config.setStartLife(20);
+
+            AiProfile ai = AiProfile.create(aAiType, aAiLevel);
+
+            // Create players
+            config.setPlayerProfile(0, ai);
+            config.setPlayerProfile(1, ai);
+
+            final MagicDuel duel = new MagicDuel(config);
+
+            final MagicDeckProfile profile = new MagicDeckProfile("bgruw");
+            final DuelPlayerConfig player1 = new DuelPlayerConfig(ai, profile);
+            final DuelPlayerConfig player2 = new DuelPlayerConfig(ai, profile);
+
+            duel.setPlayers(new DuelPlayerConfig[]{player1, player2});
+            duel.setStartPlayer(0);
+            return duel;
+        }
+
+        public static MagicDuel createAiDuel() {
+            return createAiDuel(MagicAIImpl.MMABFast, 2);
+        }
+
+        @Override
+        public MagicGame getGame() {
+            final MagicDuel duel = createAiDuel();
+            final MagicGame game = duel.nextGame();
+            game.setPhase(MagicMainPhase.getFirstInstance());
+            final MagicPlayer player = game.getPlayer(0);
+            final MagicPlayer opponent = game.getPlayer(1);
+
+            MagicPlayer P = player;
+
+            P.setLife(10);
+            addToLibrary(P, "Plains", 2);
+            // 5 mana of every color
+            createPermanent(P, "Plains", false, 5);
+            createPermanent(P, "Forest", false, 5);
+            createPermanent(P, "Island", false, 5);
+            createPermanent(P, "Swamp", false, 5);
+            createPermanent(P, "Mountain", false, 5);
+            // Own artifact creature
+            createPermanent(P, "Ornithopter", false, 1);
+
+            P = opponent;
+
+            P.setLife(10);
+            addToLibrary(P, "Plains", 2);
+            createPermanent(P, "Plains", false, 1);
+            createPermanent(P, "Forest", false, 1);
+            createPermanent(P, "Island", false, 1);
+            createPermanent(P, "Swamp", false, 1);
+            createPermanent(P, "Mountain", false, 1);
+            // Creature
+            createPermanent(P, "Wall of Ice", false, 1);
+            // Enchantment
+            createPermanent(P, "Orcish Oriflamme", false, 1);
+            // Artifact Creature
+            createPermanent(P, "Omega Myr", false, 1);
+            // Planeswalker
+            createPermanent(P, "Ajani Goldmane", false, 1);
+            // Sorcery
+            addToHand(P, "Angelic Edict", 1);
+            // Instant
+            addToHand(P, "Giant Growth", 1);
+            prepareScenario(player, opponent);
+
+            return game;
+        }
+    }
+}

--- a/src/magic/CardTest.java
+++ b/src/magic/CardTest.java
@@ -50,6 +50,9 @@ public class CardTest {
 
         Collection<MagicCardDefinition> allC = CardDefinitions.getAllPlayableCardDefs();
 
+        double totalTime = 0;
+        int totalCards = 0;
+
         Set<String> skip = new HashSet<>();
         String skipList = cmdline.getSkipList();
         if (skipList != null) {
@@ -83,8 +86,10 @@ public class CardTest {
         for (MagicCardDefinition token : tokens) {
             System.out.println("Testing token #" + t + ": " + token.getName());
             t++;
+            totalCards++;
             MagicGame game = new TokenScenario(token).getGame();
             final double duration = runGame(game);
+            totalTime += duration;
 
             System.out.printf("Token time: %.2fs : %s\n", duration, token);
         }
@@ -94,12 +99,16 @@ public class CardTest {
         for (String name : cards) {
             System.out.println("Testing card #" + n + ": " + name);
             n++;
+            totalCards++;
             MagicGame game = new CardScenario(name).getGame();
             final double duration = runGame(game);
+            totalTime += duration;
 
             System.out.printf("Time: %.2fs : %s\n", duration, name);
         }
-        System.out.println("All cards/tokens tested.");
+        System.out.println("Tested " + totalCards + " cards/tokens.");
+        System.out.println("Total time: " + totalTime);
+        System.out.println("Time per card: " + totalTime / totalCards);
     }
 
     private static double runGame(MagicGame game) {

--- a/src/magic/CommandLineArgs.java
+++ b/src/magic/CommandLineArgs.java
@@ -22,6 +22,7 @@ class CommandLineArgs {
     private String deck2 = "";
     private boolean showFps = false;
     private boolean headless = false;
+    private boolean cardTest = false;
     private int fps;
     private int duels = 1;
 
@@ -73,6 +74,9 @@ class CommandLineArgs {
             //
             case "--headless":
                 headless = true;
+                break;
+            case "--cardtest":
+                cardTest = true;
                 break;
             case "--duels": // the number of duels to play [--duels 1].
                 duels = Integer.parseInt(args[i + 1].trim());
@@ -207,6 +211,10 @@ class CommandLineArgs {
 
     boolean isHeadless() {
         return headless;
+    }
+
+    boolean isCardTest() {
+        return cardTest;
     }
 
     int getFPS() {

--- a/src/magic/CommandLineArgs.java
+++ b/src/magic/CommandLineArgs.java
@@ -89,6 +89,9 @@ class CommandLineArgs {
     // the number of duels to play [--duels 1].
     private Arg<Integer> duels = new Arg<>("--duels", 1, x -> Integer.parseInt(x));
 
+    // Skiplist for card test
+    private Arg<String> skipList = new Arg<>("--skip", null, x -> x);
+
     /**
      * Commandline argument requiring a value
      *
@@ -220,4 +223,7 @@ class CommandLineArgs {
         return duels.value;
     }
 
+    String getSkipList() {
+        return skipList.value;
+    }
 }

--- a/src/magic/MagicMain.java
+++ b/src/magic/MagicMain.java
@@ -49,6 +49,12 @@ public class MagicMain {
             return;
         }
 
+        // transfer control to automatic card test
+        if (cmdline.isCardTest()) {
+            CardTest.main(cmdline);
+            return;
+        }
+
         parseCommandLine(cmdline);
 
         Thread.setDefaultUncaughtExceptionHandler(new UiExceptionHandler());

--- a/src/magic/test/TestGameBuilder.java
+++ b/src/magic/test/TestGameBuilder.java
@@ -55,8 +55,13 @@ public abstract class TestGameBuilder {
     }
 
     public static MagicPermanent createPermanent(final MagicPlayer player, final String name, final boolean tapped, final int count) {
+        final MagicCardDefinition cardDefinition = CardDefinitions.getCard(name);
+        return createPermanent(player, cardDefinition, tapped, count);
+    }
+
+
+    public static MagicPermanent createPermanent(final MagicPlayer player, final MagicCardDefinition cardDefinition, final boolean tapped, final int count) {
         final MagicGame game = player.getGame();
-        final MagicCardDefinition cardDefinition=CardDefinitions.getCard(name);
         MagicPermanent lastPermanent= MagicPermanent.NONE;
         for (int c=count;c>0;c--) {
 

--- a/test/magic/model/MagicManaCostTest.java
+++ b/test/magic/model/MagicManaCostTest.java
@@ -1,6 +1,5 @@
-package magic.model.mstatic;
+package magic.model;
 
-import magic.model.MagicManaCost;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +30,7 @@ public class MagicManaCostTest {
         assertEquals("{X}{X}{U}", uxx.reducedBy(MagicManaCost.create("{2}")).toString());
 
         assertEquals("{X}{R}", rx.increasedBy(MagicManaCost.create("{2}")).reducedBy(
-                MagicManaCost.create("{2}")).toString());
+            MagicManaCost.create("{2}")).toString());
     }
 
     @Test

--- a/test/magic/model/MagicMessageTest.java
+++ b/test/magic/model/MagicMessageTest.java
@@ -1,0 +1,40 @@
+package magic.model;
+
+import magic.ai.MagicAIImpl;
+import magic.model.player.AiProfile;
+import magic.model.player.HumanProfile;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MagicMessageTest {
+    private DuelPlayerConfig cfgAi = new DuelPlayerConfig(AiProfile.create(MagicAIImpl.MMAB, 12), new MagicDeckProfile("r"));
+    private DuelPlayerConfig cfg = new DuelPlayerConfig(HumanProfile.create("myself"), new MagicDeckProfile("r"));
+    private MagicPlayer player = new MagicPlayer(20, cfg, 0);
+    private MagicPlayer playerAi = new MagicPlayer(20, cfgAi, 0);
+
+    @Test
+    public void testNameReplacement() {
+        MagicCardDefinition def = new MagicCardDefinition();
+        def.setName("Card Name");
+        MagicCardDefinition defRef = new MagicCardDefinition();
+        defRef.setName("Recard Name");
+        MagicCard source = new MagicCard(def, player, 1);
+        MagicCard ref = new MagicCard(defRef, player, 2);
+        MagicInteger numRef = new MagicInteger(7);
+        assertEquals("Sacrifice <Card Name~1>",
+            MagicMessage.replaceName("Sacrifice SN", source, player, ref));
+        assertEquals("myself draws 7 cards",
+            MagicMessage.replaceName("PN draws RN cards", source, player, numRef));
+        assertEquals("myself deals 1 damage to <Recard Name~2>",
+            MagicMessage.replaceName("PN deals 1 damage to RN", source, player, ref));
+        assertEquals("Pay 7 life",
+            MagicMessage.replaceName("Pay RN life", source, player, numRef));
+        assertEquals("MMAB has no cards to discard",
+            MagicMessage.replaceName("PN has no cards to discard", source, playerAi, ref));
+        assertEquals("Target player$ draws X cards, where X is the number of lands.",
+            MagicMessage.replaceName("Target player$ draws X cards, where X is the number of lands.", source, player, ref));
+        assertEquals("Pay {X}{G}$",
+            MagicMessage.replaceName("Pay {X}{G}$", source, playerAi, ref));
+    }
+}

--- a/test/magic/model/mstatic/MagicManaCostTest.java
+++ b/test/magic/model/mstatic/MagicManaCostTest.java
@@ -52,7 +52,5 @@ public class MagicManaCostTest {
 
         MagicManaCost phy = MagicManaCost.create("{R/P}{G/P}{W/P}");
         assertEquals("{W/P}", phy.reducedBy(MagicManaCost.create("{R}{G}{U}")).toString());
-
-
     }
 }


### PR DESCRIPTION
This adds new "cardtest" mode to magarena. (you run it by supplying "--cardtest" arg on commandline)
Essentially, the game takes all implemented tokens and cards and uses them in a simple scenario (short game) to test them.

If some card is flawed, causes crashes or is ineffective, you can see it in the log.

When testing, I found for example a problem with too many lands (5 of each type) and costs having (X) in them - the game thinks too long how to pay for them.

And another problem that was found with this is stack overflow with Kiora's Follower and this scenario (magic.ai.MMAB$MMABWorker.runGame recursively calls itself).

This could be used as kind of quick (can run at most few hours) smoketest after adding a bunch of new cards or making larger changes to some mechanics (if it breaks something, there is some chance you'll encounter the problem in the card test).

Do you think this would be a usable tool during development? Any ideas to make it even better?
