### PR TITLE
WIP: Fixing build for OpenJDK 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ release/Magarena/decks/*.dec
 release/Magarena/reports
 doc/doxygen/
 doc/doxygen*.tmp
+/bin/

--- a/build.xml
+++ b/build.xml
@@ -90,6 +90,10 @@
       <get src="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_ant/${error-prone-version}/error_prone_ant-${error-prone-version}.jar"
          dest="lib/error_prone_ant-${error-prone-version}.jar"
          skipexisting="true" />
+  	  <echo message="downloading jakarta activation to ${lib}"/>
+  	  <get src="https://repo1.maven.org/maven2/jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar"
+  	     dest="${lib}/jakarta.activation-api-1.2.1.jar"
+  	     skipexisting="true" />
   </target>
 
   <!-- init - Create temporary directory to build the program -->


### PR DESCRIPTION
Just added Jakarta Activation as dependency, since it has superseded JAB since JDK 11.

See https://eclipse-ee4j.github.io/jaf/#Latest_News

Similar case: https://youtrack.jetbrains.com/issue/IDEA-205600.

Also fixes #1367

I still get an odd error, though:

```
% ant build
Buildfile: /home/allentiak/devel/projects/magarena/build.xml

init:

deps:

[...]

build:
    [javac] Compiling 1 source file to /home/allentiak/devel/projects/magarena/build
    [javac] An exception has occurred in the compiler (9-internal). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program and the following diagnostic in your report. Thank you.
    [javac] java.io.UncheckedIOException: java.nio.file.NotDirectoryException: /usr/lib/jvm/java-11-openjdk-amd64/lib/modules
[...]

```