### PR TITLE
Correction of Temple Altisaur's script

### DIFF
--- a/release/Magarena/scripts/Temple_Altisaur.groovy
+++ b/release/Magarena/scripts/Temple_Altisaur.groovy
@@ -2,8 +2,10 @@
     new IfDamageWouldBeDealtTrigger(MagicTrigger.PREVENT_DAMAGE) {
         @Override
         public boolean accept(final MagicPermanent permanent, final MagicDamage damage) {
+            // If a source would deal damage to another Dinosaur you control, prevent all but 1 of that damage.
             return super.accept(permanent, damage) &&
                 damage.getTarget().hasSubType(MagicSubType.Dinosaur) &&
+                !permanent.equals(damage.getTarget()) &&
                 permanent.isFriend(damage.getTarget());
         }
         @Override


### PR DESCRIPTION
The effect shouldn't apply on the card itself, the text says:
If a source would deal damage to __another__ Dinosaur you control, prevent all but 1 of that damage.