### PR TITLE
Fix some outdated card image links

### DIFF
--- a/release/Magarena/scripts/0_0_black_Germ_creature_token.txt
+++ b/release/Magarena/scripts/0_0_black_Germ_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/0 black Germ creature token
 token=Germ
-image=https://magiccards.info/extras/token/modern-masters-2015/germ.jpg
+image=https://api.scryfall.com/cards/tmm2/7/en?format=image&version=border_crop
 image_updated=2015-11-12
 value=1
 type=Creature

--- a/release/Magarena/scripts/0_1_black_Cleric_creature_token.txt
+++ b/release/Magarena/scripts/0_1_black_Cleric_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 black Cleric creature token
 token=Cleric
-image=https://img.scryfall.com/cards/large/en/tdom/4.jpg
+image=https://api.scryfall.com/cards/tdom/4/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Cleric

--- a/release/Magarena/scripts/0_1_black_Serf_creature_token.txt
+++ b/release/Magarena/scripts/0_1_black_Serf_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 black Serf creature token
 token=Serf
-image=https://magiccards.info/extras/token/eternal-masters/serf.jpg
+image=https://api.scryfall.com/cards/tema/5/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Serf

--- a/release/Magarena/scripts/0_1_black_Thrull_creature_token.txt
+++ b/release/Magarena/scripts/0_1_black_Thrull_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 black Thrull creature token
 token=Thrull
-image=https://magiccards.info/extras/token/duel-decks-divine-vs-demonic/thrull.jpg
+image=https://api.scryfall.com/cards/tddc/3/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Thrull

--- a/release/Magarena/scripts/0_1_blue_Homunculus_artifact_creature_token.txt
+++ b/release/Magarena/scripts/0_1_blue_Homunculus_artifact_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 blue Homunculus artifact creature token
 token=Homunculus
-image=https://img.scryfall.com/cards/border_crop/en/tala/2.jpg?1517813031
+image=https://api.scryfall.com/cards/tala/2/en?format=image&version=border_crop
 value=1
 type=Artifact,Creature
 subtype=Homunculus

--- a/release/Magarena/scripts/0_1_colorless_Eldrazi_Spawn_creature_token.txt
+++ b/release/Magarena/scripts/0_1_colorless_Eldrazi_Spawn_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 colorless Eldrazi Spawn creature token
 token=Eldrazi Spawn
-image=https://magiccards.info/extras/token/rise-of-the-eldrazi/eldrazi-spawn-1.jpg
+image=https://api.scryfall.com/cards/troe/1a/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Eldrazi,Spawn

--- a/release/Magarena/scripts/0_1_green_Plant_creature_token.txt
+++ b/release/Magarena/scripts/0_1_green_Plant_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 green Plant creature token
 token=Plant
-image=https://magiccards.info/extras/token/duel-decks-zendikar-vs-eldrazi/plant.jpg
+image=https://api.scryfall.com/cards/ddp/80/en?format=image&version=border_crop
 image_updated=2015-11-12
 value=1
 type=Creature

--- a/release/Magarena/scripts/0_1_red_Elemental_creature_token.txt
+++ b/release/Magarena/scripts/0_1_red_Elemental_creature_token.txt
@@ -1,6 +1,6 @@
 name=0/1 red Elemental creature token
 token=Elemental
-image=https://magiccards.info/extras/token/rivals-of-ixalan/elemental-1.jpg
+image=https://api.scryfall.com/cards/trix/1/en?format=image&version=border_crop
 value=3
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/0_1_white_Goat_creature_token.txt
+++ b/release/Magarena/scripts/0_1_white_Goat_creature_token.txt
@@ -1,5 +1,5 @@
 name=0/1 white Goat creature token
-image=https://magiccards.info/extras/token/commander-2014/goat.jpg
+image=https://api.scryfall.com/cards/tc14/3/en?format=image&version=border_crop
 image_updated=2015-11-12
 token=Goat
 type=Creature

--- a/release/Magarena/scripts/10_10_colorless_Eldrazi_creature_token.txt
+++ b/release/Magarena/scripts/10_10_colorless_Eldrazi_creature_token.txt
@@ -1,6 +1,6 @@
 name=10/10 colorless Eldrazi creature token
 token=Eldrazi
-image=https://img.scryfall.com/cards/border_crop/en/tbfz/1.jpg?1517813031
+image=https://api.scryfall.com/cards/tbfz/1/en?format=image&version=border_crop
 value=5
 type=Creature
 subtype=Eldrazi

--- a/release/Magarena/scripts/1_1_black_Assassin_creature_token_with_deathtouch_and_haste.txt
+++ b/release/Magarena/scripts/1_1_black_Assassin_creature_token_with_deathtouch_and_haste.txt
@@ -1,6 +1,6 @@
 name=1/1 black Assassin creature token with deathtouch and haste
 token=Assassin
-image=https://img.scryfall.com/cards/border_crop/en/tcn2/5.jpg
+image=https://api.scryfall.com/cards/tcn2/5/en?format=image&version=border_crop
 value=2
 type=Creature
 subtype=Assassin

--- a/release/Magarena/scripts/1_1_black_Insect_creature_token.txt
+++ b/release/Magarena/scripts/1_1_black_Insect_creature_token.txt
@@ -1,6 +1,6 @@
 name=1/1 black Insect creature token
 token=Insect
-image=https://img.scryfall.com/cards/border_crop/en/takh/19.jpg
+image=https://api.scryfall.com/cards/takh/19/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Insect

--- a/release/Magarena/scripts/1_1_blue_Merfolk_creature_token_with_hexproof.txt
+++ b/release/Magarena/scripts/1_1_blue_Merfolk_creature_token_with_hexproof.txt
@@ -1,6 +1,6 @@
 name=1/1 blue Merfolk creature token with hexproof
 token=Merfolk
-image=https://img.scryfall.com/cards/border_crop/en/txln/3.jpg?1505310617
+image=https://api.scryfall.com/cards/txln/3/en?format=image&version=border_crop
 value=1
 pt=1/1
 color=u

--- a/release/Magarena/scripts/1_1_green_Elf_Druid_creature_token.txt
+++ b/release/Magarena/scripts/1_1_green_Elf_Druid_creature_token.txt
@@ -1,6 +1,6 @@
 name=1/1 green Elf Druid creature token
 token=Elf Warrior
-image=https://img.scryfall.com/cards/border_crop/en/tcma/11.jpg?1523997681
+image=https://api.scryfall.com/cards/tcma/11/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Elf,Druid

--- a/release/Magarena/scripts/1_1_green_Insect_creature_token_with_flying_and_deathtouch.txt
+++ b/release/Magarena/scripts/1_1_green_Insect_creature_token_with_flying_and_deathtouch.txt
@@ -1,6 +1,6 @@
 name=1/1 green Insect creature token with flying and deathtouch
 token=Insect
-image=http://mtg.onl/token-list/tokens/Insect_G_1_1_flying.jpg
+image=https://api.scryfall.com/cards/tm15/10/en?format=image&version=border_crop
 image_updated=2015-12-18
 value=3
 type=Creature

--- a/release/Magarena/scripts/1_1_green_and_white_Elf_Warrior_creature_token.txt
+++ b/release/Magarena/scripts/1_1_green_and_white_Elf_Warrior_creature_token.txt
@@ -1,6 +1,6 @@
 name=1/1 green and white Elf Warrior creature token
 token=Elf Warrior
-image=https://img.scryfall.com/cards/border_crop/en/tshm/12.jpg?1517813031
+image=https://api.scryfall.com/cards/tshm/12/en?format=image&version=border_crop
 value=2
 type=Creature
 subtype=Elf,Warrior

--- a/release/Magarena/scripts/1_1_red_Goblin_creature_token_with_Creatures_you_control_attack_each_combat_if_able.txt
+++ b/release/Magarena/scripts/1_1_red_Goblin_creature_token_with_Creatures_you_control_attack_each_combat_if_able.txt
@@ -1,6 +1,6 @@
 name=1/1 red Goblin creature token with Creatures you control attack each combat if able
 token=Goblin
-image=https://img.scryfall.com/cards/border_crop/en/tc16/12.jpg
+image=https://api.scryfall.com/cards/tc16/12/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Goblin

--- a/release/Magarena/scripts/1_1_white_Kor_Ally_creature_token.txt
+++ b/release/Magarena/scripts/1_1_white_Kor_Ally_creature_token.txt
@@ -1,6 +1,6 @@
 name=1/1 white Kor Ally creature token
 token=Kor Ally
-image=https://img.scryfall.com/cards/border_crop/en/tbfz/6.jpg?1517813031
+image=https://api.scryfall.com/cards/tbfz/6/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Kor,Ally

--- a/release/Magarena/scripts/1_1_white_Monk_creature_token_with_prowess.txt
+++ b/release/Magarena/scripts/1_1_white_Monk_creature_token_with_prowess.txt
@@ -1,6 +1,6 @@
 name=1/1 white Monk creature token with prowess
 token=Monk
-image=https://img.scryfall.com/cards/border_crop/en/tfrf/1.jpg?1517813031
+image=https://api.scryfall.com/cards/tfrf/1/en?format=image&version=border_crop
 value=1
 pt=1/1
 color=w

--- a/release/Magarena/scripts/1_1_white_Pegasus_creature_token_with_flying.txt
+++ b/release/Magarena/scripts/1_1_white_Pegasus_creature_token_with_flying.txt
@@ -1,6 +1,6 @@
 name=1/1 white Pegasus creature token with flying
 token=Pegasus
-image=https://img.scryfall.com/cards/border_crop/en/tc14/5.jpg?1530676677
+image=https://api.scryfall.com/cards/tc14/5/en?format=image&version=border_crop
 value=2
 type=Creature
 subtype=Pegasus

--- a/release/Magarena/scripts/1_1_white_Soldier_Ally_creature_token.txt
+++ b/release/Magarena/scripts/1_1_white_Soldier_Ally_creature_token.txt
@@ -1,6 +1,6 @@
 name=1/1 white Soldier Ally creature token
 token=Soldier Ally
-image=https://img.scryfall.com/cards/border_crop/en/twwk/1.jpg?1530592148
+image=https://api.scryfall.com/cards/twwk/1/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Soldier,Ally

--- a/release/Magarena/scripts/1_1_white_Soldier_enchantment_creature_token.txt
+++ b/release/Magarena/scripts/1_1_white_Soldier_enchantment_creature_token.txt
@@ -1,6 +1,6 @@
 name=1/1 white Soldier enchantment creature token
 token=Soldier
-image=https://img.scryfall.com/cards/border_crop/en/tbng/3.jpg?1517813031
+image=https://api.scryfall.com/cards/tbng/3/en?format=image&version=border_crop
 value=1
 type=Enchantment,Creature
 subtype=Soldier

--- a/release/Magarena/scripts/1_1_white_Vampire_creature_token_with_lifelink.txt
+++ b/release/Magarena/scripts/1_1_white_Vampire_creature_token_with_lifelink.txt
@@ -1,6 +1,6 @@
 name=1/1 white Vampire creature token with lifelink
 token=Vampire
-image=https://img.scryfall.com/cards/border_crop/en/txln/1.jpg?1505310802
+image=https://api.scryfall.com/cards/txln/1/en?format=image&version=border_crop
 value=1
 pt=1/1
 color=w

--- a/release/Magarena/scripts/1_3_green_Spider_enchantment_creature_token_with_reach.txt
+++ b/release/Magarena/scripts/1_3_green_Spider_enchantment_creature_token_with_reach.txt
@@ -1,6 +1,6 @@
 name=1/3 green Spider enchantment creature token with reach
 token=Spider
-image=https://img.scryfall.com/cards/border_crop/en/tjou/5.jpg?1517813031
+image=https://api.scryfall.com/cards/tjou/5/en?format=image&version=border_crop
 value=2
 type=Enchantment,Creature
 subtype=Spider

--- a/release/Magarena/scripts/2_2_black_Vampire_creature_token_with_flying.txt
+++ b/release/Magarena/scripts/2_2_black_Vampire_creature_token_with_flying.txt
@@ -1,6 +1,6 @@
 name=2/2 black Vampire creature token with flying
 token=Vampire
-image=https://img.scryfall.com/cards/border_crop/en/tktk/5.jpg?1517813031
+image=https://api.scryfall.com/cards/tktk/5/en?format=image&version=border_crop
 value=2
 type=Creature
 subtype=Vampire

--- a/release/Magarena/scripts/2_2_black_Zombie_creature_token.txt
+++ b/release/Magarena/scripts/2_2_black_Zombie_creature_token.txt
@@ -1,6 +1,6 @@
 name=2/2 black Zombie creature token
 token=Zombie
-image=https://img.scryfall.com/cards/border_crop/en/tc18/9.jpg?1535501361
+image=https://api.scryfall.com/cards/tc18/9/en?format=image&version=border_crop
 image_updated=2015-11-12
 value=2
 type=Creature

--- a/release/Magarena/scripts/2_2_black_Zombie_enchantment_creature_token.txt
+++ b/release/Magarena/scripts/2_2_black_Zombie_enchantment_creature_token.txt
@@ -1,6 +1,6 @@
 name=2/2 black Zombie enchantment creature token
 token=Zombie
-image=https://img.scryfall.com/cards/border_crop/en/tbng/6.jpg?1517813031
+image=https://api.scryfall.com/cards/tbng/6/en?format=image&version=border_crop
 value=2
 type=Enchantment,Creature
 subtype=Zombie

--- a/release/Magarena/scripts/2_2_blue_Bird_enchantment_creature_token_with_flying.txt
+++ b/release/Magarena/scripts/2_2_blue_Bird_enchantment_creature_token_with_flying.txt
@@ -1,6 +1,6 @@
 name=2/2 blue Bird enchantment creature token with flying
 token=Bird
-image=https://img.scryfall.com/cards/border_crop/en/tbng/4.jpg?1517813031
+image=https://api.scryfall.com/cards/tbng/4/en?format=image&version=border_crop
 value=2
 type=Enchantment,Creature
 subtype=Bird

--- a/release/Magarena/scripts/3_3_green_Dinosaur_creature_token_with_trample.txt
+++ b/release/Magarena/scripts/3_3_green_Dinosaur_creature_token_with_trample.txt
@@ -1,6 +1,6 @@
 name=3/3 green Dinosaur creature token with trample
 token=Dinosaur
-image=https://img.scryfall.com/cards/border_crop/en/txln/5.jpg?1505311019
+image=https://api.scryfall.com/cards/txln/5/en?format=image&version=border_crop
 value=3
 pt=3/3
 color=g

--- a/release/Magarena/scripts/4_4_red_Hellion_creature_token.txt
+++ b/release/Magarena/scripts/4_4_red_Hellion_creature_token.txt
@@ -1,6 +1,6 @@
 name=4/4 red Hellion creature token
 token=Hellion
-image=https://img.scryfall.com/cards/border_crop/en/tpca/12.jpg
+image=https://api.scryfall.com/cards/tpca/12/en?format=image&version=border_crop
 image_updated=2015-11-12
 value=4
 type=Creature

--- a/release/Magarena/scripts/5_5_black_and_red_Elemental_creature_token.txt
+++ b/release/Magarena/scripts/5_5_black_and_red_Elemental_creature_token.txt
@@ -1,6 +1,6 @@
 name=5/5 black and red Elemental creature token
 token=Elemental
-image=https://img.scryfall.com/cards/border_crop/en/tshm/9.jpg
+image=https://api.scryfall.com/cards/tshm/9/en?format=image&version=border_crop
 value=5
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/5_5_white_Giant_Warrior_creature_token.txt
+++ b/release/Magarena/scripts/5_5_white_Giant_Warrior_creature_token.txt
@@ -1,6 +1,6 @@
 name=5/5 white Giant Warrior creature token
 token=Giant Warrior
-image=https://img.scryfall.com/cards/border_crop/en/tmma/1.jpg?1517813031
+image=https://api.scryfall.com/cards/tmma/1/en?format=image&version=border_crop
 value=5
 type=Creature
 subtype=Giant,Warrior

--- a/release/Magarena/scripts/5_5_white_Horse_creature_token.txt
+++ b/release/Magarena/scripts/5_5_white_Horse_creature_token.txt
@@ -1,6 +1,6 @@
 name=5/5 white Horse creature token
 token=Horse
-image=https://img.scryfall.com/cards/border_crop/en/thou/10.jpg?1517813031
+image=https://api.scryfall.com/cards/thou/10/en?format=image&version=border_crop
 value=5
 pt=5/5
 color=w

--- a/release/Magarena/scripts/6_12_colorless_Construct_artifact_creature_token_with_trample.txt
+++ b/release/Magarena/scripts/6_12_colorless_Construct_artifact_creature_token_with_trample.txt
@@ -1,6 +1,6 @@
 name=6/12 colorless Construct artifact creature token with trample
 token=Construct
-image=https://img.scryfall.com/cards/border_crop/en/tc18/21.jpg?1535501572
+image=https://api.scryfall.com/cards/tc18/21/en?format=image&version=border_crop
 value=5
 pt=6/12
 color=

--- a/release/Magarena/scripts/6_6_black_Demon_creature_token.txt
+++ b/release/Magarena/scripts/6_6_black_Demon_creature_token.txt
@@ -1,6 +1,6 @@
 name=6/6 black Demon creature token
 token=Demon
-image=https://img.scryfall.com/cards/large/en/tdom/7.jpg
+image=https://api.scryfall.com/cards/tdom/7/en?format=image&version=border_crop
 value=4
 type=Creature
 subtype=Demon

--- a/release/Magarena/scripts/6_6_blue_Whale_creature_token.txt
+++ b/release/Magarena/scripts/6_6_blue_Whale_creature_token.txt
@@ -1,6 +1,6 @@
 name=6/6 blue Whale creature token
 token=Whale
-image=https://img.scryfall.com/cards/border_crop/en/ta25/7.jpg?1521723780
+image=https://api.scryfall.com/cards/ta25/7/en?format=image&version=border_crop
 value=6
 type=Creature
 subtype=Whale

--- a/release/Magarena/scripts/6_6_colorless_Beast_artifact_creature_token.txt
+++ b/release/Magarena/scripts/6_6_colorless_Beast_artifact_creature_token.txt
@@ -1,6 +1,6 @@
 name=6/6 colorless Beast artifact creature token
 token=Beast
-image=https://img.scryfall.com/cards/border_crop/en/tkld/1.jpg?1517813031
+image=https://api.scryfall.com/cards/tkld/1/en?format=image&version=border_crop
 image_updated=2017-09-04
 value=5
 type=Artifact,Creature

--- a/release/Magarena/scripts/6_6_green_Wurm_creature_token.txt
+++ b/release/Magarena/scripts/6_6_green_Wurm_creature_token.txt
@@ -1,6 +1,6 @@
 name=6/6 green Wurm creature token
 token=Wurm
-image=https://img.scryfall.com/cards/border_crop/en/tdds/7.jpg?1517813031
+image=https://api.scryfall.com/cards/tdds/7/en?format=image&version=border_crop
 value=4
 type=Creature
 subtype=Wurm

--- a/release/Magarena/scripts/6_6_red_Dragon_creature_token_with_flying.txt
+++ b/release/Magarena/scripts/6_6_red_Dragon_creature_token_with_flying.txt
@@ -1,6 +1,6 @@
 name=6/6 red Dragon creature token with flying
 token=Dragon
-image=https://img.scryfall.com/cards/border_crop/en/tc17/7.jpg?1517813031
+image=https://api.scryfall.com/cards/tc17/7/en?format=image&version=border_crop
 value=5
 type=Creature
 subtype=Dragon

--- a/release/Magarena/scripts/7_1_red_Elemental_creature_token_with_trample_and_haste.txt
+++ b/release/Magarena/scripts/7_1_red_Elemental_creature_token_with_trample_and_haste.txt
@@ -1,6 +1,6 @@
 name=7/1 red Elemental creature token with trample and haste
 token=Elemental
-image=https://img.scryfall.com/cards/border_crop/en/tzen/8.jpg?1517813031
+image=https://api.scryfall.com/cards/tzen/8/en?format=image&version=border_crop
 value=3
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/7_7_green_Elemental_creature_token_with_trample.txt
+++ b/release/Magarena/scripts/7_7_green_Elemental_creature_token_with_trample.txt
@@ -1,6 +1,6 @@
 name=7/7 green Elemental creature token with trample
 token=Elemental
-image=https://img.scryfall.com/cards/border_crop/en/tevg/1.jpg?1530590969
+image=https://api.scryfall.com/cards/tevg/1/en?format=image&version=border_crop
 value=5
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/8_8_blue_Octopus_creature_token.txt
+++ b/release/Magarena/scripts/8_8_blue_Octopus_creature_token.txt
@@ -1,6 +1,6 @@
 name=8/8 blue Octopus creature token
 token=Octopus
-image=https://img.scryfall.com/cards/border_crop/en/tbfz/7.jpg?1517813031
+image=https://api.scryfall.com/cards/tbfz/7/en?format=image&version=border_crop
 value=5
 type=Creature
 subtype=Octopus

--- a/release/Magarena/scripts/8_8_green_and_white_Elemental_creature_token_with_vigilance.txt
+++ b/release/Magarena/scripts/8_8_green_and_white_Elemental_creature_token_with_vigilance.txt
@@ -1,6 +1,6 @@
 name=8/8 green and white Elemental creature token with vigilance
 token=Elemental
-image=https://img.scryfall.com/cards/border_crop/en/trtr/12.jpg?1517813031
+image=https://api.scryfall.com/cards/trtr/12/en?format=image&version=border_crop
 value=3
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/8_8_red_Lizard_creature_token.txt
+++ b/release/Magarena/scripts/8_8_red_Lizard_creature_token.txt
@@ -1,6 +1,6 @@
 name=8/8 red Lizard creature token
 token=Lizard
-image=https://img.scryfall.com/cards/border_crop/en/tcn2/9.jpg
+image=https://api.scryfall.com/cards/tcn2/9/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Lizard

--- a/release/Magarena/scripts/8_8_red__green__and_white_Beast_creature_token.txt
+++ b/release/Magarena/scripts/8_8_red__green__and_white_Beast_creature_token.txt
@@ -1,6 +1,6 @@
 name=8/8 red, green, and white Beast creature token
 token=Beast
-image=https://img.scryfall.com/cards/border_crop/en/tala/10.jpg?1517813031
+image=https://api.scryfall.com/cards/tala/10/en?format=image&version=border_crop
 value=3
 type=Creature
 subtype=Beast

--- a/release/Magarena/scripts/9_9_blue_Kraken_creature_token.txt
+++ b/release/Magarena/scripts/9_9_blue_Kraken_creature_token.txt
@@ -1,6 +1,6 @@
 name=9/9 blue Kraken creature token
 token=Kraken
-image=https://img.scryfall.com/cards/border_crop/en/ta25/6.jpg?1529174788
+image=https://api.scryfall.com/cards/ta25/6/en?format=image&version=border_crop
 value=6
 type=Creature
 subtype=Kraken

--- a/release/Magarena/scripts/9_9_colorless_Golem_artifact_creature_token.txt
+++ b/release/Magarena/scripts/9_9_colorless_Golem_artifact_creature_token.txt
@@ -1,6 +1,6 @@
 name=9/9 colorless Golem artifact creature token
 token=Golem
-image=https://img.scryfall.com/cards/border_crop/en/tmbs/3.jpg?1517813031
+image=https://api.scryfall.com/cards/tmbs/3/en?format=image&version=border_crop
 value=4
 pt=9/9
 type=Artifact,Creature

--- a/release/Magarena/scripts/Ancient_Stone_Idol.txt
+++ b/release/Magarena/scripts/Ancient_Stone_Idol.txt
@@ -1,5 +1,5 @@
 name=Ancient Stone Idol
-image=https://img.scryfall.com/cards/border_crop/en/c18/53.jpg
+image=https://api.scryfall.com/cards/c18/53/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact,Creature

--- a/release/Magarena/scripts/Bloodtracker.txt
+++ b/release/Magarena/scripts/Bloodtracker.txt
@@ -1,5 +1,5 @@
 name=Bloodtracker
-image=https://img.scryfall.com/cards/border_crop/en/c18/14.jpg
+image=https://api.scryfall.com/cards/c18/14/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts/Crash_of_Rhino_Beetles.txt
+++ b/release/Magarena/scripts/Crash_of_Rhino_Beetles.txt
@@ -1,5 +1,5 @@
 name=Crash of Rhino Beetles
-image=https://img.scryfall.com/cards/border_crop/en/c18/29.jpg
+image=https://api.scryfall.com/cards/c18/29/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts/Kestia__the_Cultivator.txt
+++ b/release/Magarena/scripts/Kestia__the_Cultivator.txt
@@ -1,5 +1,5 @@
 name=Kestia, the Cultivator
-image=https://img.scryfall.com/cards/border_crop/en/c18/42.jpg
+image=https://api.scryfall.com/cards/c18/42/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Enchantment,Creature

--- a/release/Magarena/scripts/Manifest.txt
+++ b/release/Magarena/scripts/Manifest.txt
@@ -1,5 +1,5 @@
 name=;Manifest
-image=https://magiccards.info/extras/token/fate-reforged/manifest.jpg
+image=https://api.scryfall.com/cards/tfrf/4/en?format=image&version=border_crop
 value=1
 type=Creature
 rarity=C

--- a/release/Magarena/scripts/Morph.txt
+++ b/release/Magarena/scripts/Morph.txt
@@ -1,5 +1,5 @@
 name=;Morph
-image=https://magiccards.info/extras/token/khans-of-tarkir/morph.jpg
+image=https://api.scryfall.com/cards/tktk/11/en?format=image&version=border_crop
 value=1
 type=Creature
 rarity=C

--- a/release/Magarena/scripts/Night_Incarnate.txt
+++ b/release/Magarena/scripts/Night_Incarnate.txt
@@ -1,5 +1,5 @@
 name=Night Incarnate
-image=https://img.scryfall.com/cards/border_crop/en/c18/17.jpg
+image=https://api.scryfall.com/cards/c18/17/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts/Shivan_Raptor.txt
+++ b/release/Magarena/scripts/Shivan_Raptor.txt
@@ -1,5 +1,5 @@
 name=Shivan Raptor
-image=https://img.scryfall.com/cards/border_crop/en/usg/216.jpg?1517813031
+image=https://api.scryfall.com/cards/usg/216/en?format=image&version=border_crop
 value=3.671
 rarity=U
 type=Creature

--- a/release/Magarena/scripts/Thantis__the_Warweaver.txt
+++ b/release/Magarena/scripts/Thantis__the_Warweaver.txt
@@ -1,5 +1,5 @@
 name=Thantis, the Warweaver
-image=https://img.scryfall.com/cards/border_crop/en/c18/46.jpg
+image=https://api.scryfall.com/cards/c18/46/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Creature

--- a/release/Magarena/scripts/The_Monarch.txt
+++ b/release/Magarena/scripts/The_Monarch.txt
@@ -1,5 +1,5 @@
 name=The Monarch
-image=https://magiccards.info/extras/token/conspiracy-take-the-crown/the-monarch.jpg
+image=https://api.scryfall.com/cards/tcn2/1/en?format=image&version=border_crop
 image_updated=2017-09-04
 type=Enchantment
 rarity=C

--- a/release/Magarena/scripts/black_Demon_creature_token_with_flying.txt
+++ b/release/Magarena/scripts/black_Demon_creature_token_with_flying.txt
@@ -1,6 +1,6 @@
 name=black Demon creature token with flying
 token=Demon
-image=https://img.scryfall.com/cards/border_crop/en/tdvd/6.jpg?1520566391
+image=https://api.scryfall.com/cards/tdvd/6/en?format=image&version=border_crop
 image_updated=2015-11-12
 value=2
 type=Creature

--- a/release/Magarena/scripts/black_Horror_creature_token.txt
+++ b/release/Magarena/scripts/black_Horror_creature_token.txt
@@ -1,6 +1,6 @@
 name=black Horror creature token
 token=Horror
-image=https://img.scryfall.com/cards/border_crop/en/tc14/15.jpg?1530676739
+image=https://api.scryfall.com/cards/tc14/15/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Horror

--- a/release/Magarena/scripts/black_Vampire_creature_token.txt
+++ b/release/Magarena/scripts/black_Vampire_creature_token.txt
@@ -1,6 +1,6 @@
 name=black Vampire creature token
 token=Vampire
-image=https://img.scryfall.com/cards/border_crop/en/tzen/6.jpg?1517813031
+image=https://api.scryfall.com/cards/tzen/6/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Vampire

--- a/release/Magarena/scripts/black_Zombie_creature_token.txt
+++ b/release/Magarena/scripts/black_Zombie_creature_token.txt
@@ -1,6 +1,6 @@
 name=black Zombie creature token
 token=Zombie
-image=https://img.scryfall.com/cards/border_crop/en/temn/6.jpg?1517813031
+image=https://api.scryfall.com/cards/temn/6/en?format=image&version=border_crop
 value=0
 type=Creature
 subtype=Zombie

--- a/release/Magarena/scripts/black_and_green_Spirit_Warrior_creature_token.txt
+++ b/release/Magarena/scripts/black_and_green_Spirit_Warrior_creature_token.txt
@@ -1,6 +1,6 @@
 name=black and green Spirit Warrior creature token
 token=Spirit Warrior
-image=https://img.scryfall.com/cards/border_crop/en/tktk/10.jpg?1517813031
+image=https://api.scryfall.com/cards/tktk/10/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Spirit,Warrior

--- a/release/Magarena/scripts/colorless_Clue_artifact_token.txt
+++ b/release/Magarena/scripts/colorless_Clue_artifact_token.txt
@@ -1,5 +1,5 @@
 name=colorless Clue artifact token
-image=https://img.scryfall.com/cards/border_crop/en/tc18/19.jpg?1535501538
+image=https://api.scryfall.com/cards/tc18/19/en?format=image&version=border_crop
 token=Clue
 type=Artifact
 subtype=Clue

--- a/release/Magarena/scripts/colorless_Construct_artifact_creature_token.txt
+++ b/release/Magarena/scripts/colorless_Construct_artifact_creature_token.txt
@@ -1,6 +1,6 @@
 name=colorless Construct artifact creature token
 token=Construct
-image=https://img.scryfall.com/cards/border_crop/en/tkld/2.jpg?1517813031
+image=https://api.scryfall.com/cards/tkld/2/en?format=image&version=border_crop
 value=2
 type=Artifact,Creature
 subtype=Construct

--- a/release/Magarena/scripts/colorless_Equipment_artifact_token_named_Stoneforged_Blade.txt
+++ b/release/Magarena/scripts/colorless_Equipment_artifact_token_named_Stoneforged_Blade.txt
@@ -1,6 +1,6 @@
 name=colorless Equipment artifact token named Stoneforged Blade
 token=Stoneforged Blade
-image=https://img.scryfall.com/cards/border_crop/en/tc14/30.jpg?1530676841
+image=https://api.scryfall.com/cards/tc14/30/en?format=image&version=border_crop
 value=4
 type=Artifact
 subtype=Equipment

--- a/release/Magarena/scripts/colorless_Horror_artifact_creature_token.txt
+++ b/release/Magarena/scripts/colorless_Horror_artifact_creature_token.txt
@@ -1,6 +1,6 @@
 name=colorless Horror artifact creature token
 token=Horror
-image=https://img.scryfall.com/cards/border_crop/en/tc18/22.jpg?1535501587
+image=https://api.scryfall.com/cards/tc18/22/en?format=image&version=border_crop
 value=2
 type=Artifact,Creature
 subtype=Horror

--- a/release/Magarena/scripts/colorless_artifact_token_named_Etherium_Cell.txt
+++ b/release/Magarena/scripts/colorless_artifact_token_named_Etherium_Cell.txt
@@ -1,5 +1,5 @@
 name=colorless artifact token named Etherium Cell
-image=https://img.scryfall.com/cards/border_crop/en/taer/3.jpg?1523997567
+image=https://api.scryfall.com/cards/taer/3/en?format=image&version=border_crop
 token=Etherium Cell
 type=Artifact
 color=

--- a/release/Magarena/scripts/colorless_artifact_token_named_Gold.txt
+++ b/release/Magarena/scripts/colorless_artifact_token_named_Gold.txt
@@ -1,6 +1,6 @@
 name=colorless artifact token named Gold
 token=Gold
-image=https://img.scryfall.com/cards/border_crop/en/tc17/10.jpg?1523997640
+image=https://api.scryfall.com/cards/tc17/10/en?format=image&version=border_crop
 value=1
 color=
 type=Artifact

--- a/release/Magarena/scripts/colorless_artifact_token_named_Land_Mine.txt
+++ b/release/Magarena/scripts/colorless_artifact_token_named_Land_Mine.txt
@@ -1,5 +1,5 @@
 name=colorless artifact token named Land Mine
-image=https://img.scryfall.com/cards/border_crop/en/tm15/12.jpg
+image=https://api.scryfall.com/cards/tm15/12/en?format=image&version=border_crop
 token=Land Mine
 type=Artifact
 color=

--- a/release/Magarena/scripts/green_Elemental_creature_token.txt
+++ b/release/Magarena/scripts/green_Elemental_creature_token.txt
@@ -1,6 +1,6 @@
 name=green Elemental creature token
 token=Elemental
-image=https://img.scryfall.com/cards/border_crop/en/tc18/16.jpg?1535501482
+image=https://api.scryfall.com/cards/tc18/16/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/green_Hydra_creature_token.txt
+++ b/release/Magarena/scripts/green_Hydra_creature_token.txt
@@ -1,6 +1,6 @@
 name=green Hydra creature token
 token=Hydra
-image=https://img.scryfall.com/cards/border_crop/en/tjou/4.jpg?1517813031
+image=https://api.scryfall.com/cards/tjou/4/en?format=image&version=border_crop
 value=2
 type=Creature
 subtype=Hydra

--- a/release/Magarena/scripts/green_Ooze_creature_token.txt
+++ b/release/Magarena/scripts/green_Ooze_creature_token.txt
@@ -1,6 +1,6 @@
 name=green Ooze creature token
 token=Ooze
-image=https://img.scryfall.com/cards/border_crop/en/tmm3/13.jpg?1517813031
+image=https://api.scryfall.com/cards/tmm3/13/en?format=image&version=border_crop
 value=2
 type=Creature
 subtype=Ooze

--- a/release/Magarena/scripts/green_Treefolk_Warrior_creature_token.txt
+++ b/release/Magarena/scripts/green_Treefolk_Warrior_creature_token.txt
@@ -1,6 +1,6 @@
 name=green Treefolk Warrior creature token
 token=Treefolk Warrior
-image=https://img.scryfall.com/cards/border_crop/en/tm15/11.jpg?1517813031
+image=https://api.scryfall.com/cards/tm15/11/en?format=image&version=border_crop
 value=1
 type=Creature
 subtype=Treefolk,Warrior

--- a/release/Magarena/scripts/green_and_white_Elemental_creature_token.txt
+++ b/release/Magarena/scripts/green_and_white_Elemental_creature_token.txt
@@ -1,6 +1,6 @@
 name=green and white Elemental creature token
 token=Elemental
-image=https://img.scryfall.com/cards/border_crop/en/tmm3/16.jpg?1517813031
+image=https://api.scryfall.com/cards/tmm3/16/en?format=image&version=border_crop
 value=3
 type=Creature
 subtype=Elemental

--- a/release/Magarena/scripts/legendary_20_20_black_Avatar_creature_token_with_flying_and_indestructible_named_Marit_Lage.txt
+++ b/release/Magarena/scripts/legendary_20_20_black_Avatar_creature_token_with_flying_and_indestructible_named_Marit_Lage.txt
@@ -1,6 +1,6 @@
 name=legendary 20/20 black Avatar creature token with flying and indestructible named Marit Lage
 token=Marit Lage
-image=https://img.scryfall.com/cards/border_crop/en/tcsp/1.jpg?1535423404
+image=https://api.scryfall.com/cards/tmh1/6/en?format=image&version=border_crop
 value=1
 type=Legendary,Creature
 subtype=Avatar

--- a/release/Magarena/scripts/legendary_4_4_red_Dragon_creature_token_with_flying_named_Karox_Bladewing.txt
+++ b/release/Magarena/scripts/legendary_4_4_red_Dragon_creature_token_with_flying_named_Karox_Bladewing.txt
@@ -1,6 +1,6 @@
 name=legendary 4/4 red Dragon creature token with flying named Karox Bladewing
 token=Karox Bladewing
-image=https://img.scryfall.com/cards/border_crop/en/tdom/10.jpg
+image=https://api.scryfall.com/cards/tdom/10/en?format=image&version=border_crop
 value=1
 type=Legendary,Creature
 subtype=Dragon

--- a/release/Magarena/scripts/legendary_5_5_colorless_Goblin_Golem_artifact_creature_token_named_Tuktuk_the_Returned.txt
+++ b/release/Magarena/scripts/legendary_5_5_colorless_Goblin_Golem_artifact_creature_token_named_Tuktuk_the_Returned.txt
@@ -1,6 +1,6 @@
 name=legendary 5/5 colorless Goblin Golem artifact creature token named Tuktuk the Returned
 token=Tuktuk the Returned
-image=https://img.scryfall.com/cards/border_crop/en/tcm2/15.jpg?1534121899
+image=https://api.scryfall.com/cards/tcm2/15/en?format=image&version=border_crop
 image_updated=2015-11-12
 value=4
 type=Legendary,Artifact,Creature

--- a/release/Magarena/scripts/white_Avatar_creature_token.txt
+++ b/release/Magarena/scripts/white_Avatar_creature_token.txt
@@ -1,6 +1,6 @@
 name=white Avatar creature token
 token=Avatar
-image=https://img.scryfall.com/cards/border_crop/en/tm11/1.jpg?1517813031
+image=https://api.scryfall.com/cards/tm11/1/en?format=image&version=border_crop
 value=4
 type=Creature
 subtype=Avatar

--- a/release/Magarena/scripts_missing/Aminatou__the_Fateshifter.txt
+++ b/release/Magarena/scripts_missing/Aminatou__the_Fateshifter.txt
@@ -1,5 +1,5 @@
 name=Aminatou, the Fateshifter
-image=https://img.scryfall.com/cards/normal/en/c18/37.jpg
+image=https://api.scryfall.com/cards/c18/37/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Planeswalker

--- a/release/Magarena/scripts_missing/Aminatou_s_Augury.txt
+++ b/release/Magarena/scripts_missing/Aminatou_s_Augury.txt
@@ -1,5 +1,5 @@
 name=Aminatou's Augury
-image=https://img.scryfall.com/cards/normal/en/c18/6.jpg
+image=https://api.scryfall.com/cards/c18/6/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Amulet_of_Quoz.txt
+++ b/release/Magarena/scripts_missing/Amulet_of_Quoz.txt
@@ -1,5 +1,5 @@
 name=Amulet of Quoz
-image=https://img.scryfall.com/cards/normal/en/ice/308.jpg
+image=https://api.scryfall.com/cards/ice/308/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact

--- a/release/Magarena/scripts_missing/Arixmethes__Slumbering_Isle.txt
+++ b/release/Magarena/scripts_missing/Arixmethes__Slumbering_Isle.txt
@@ -1,5 +1,5 @@
 name=Arixmethes, Slumbering Isle
-image=https://img.scryfall.com/cards/normal/en/c18/38.jpg
+image=https://api.scryfall.com/cards/c18/38/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Boreas_Charger.txt
+++ b/release/Magarena/scripts_missing/Boreas_Charger.txt
@@ -1,5 +1,5 @@
 name=Boreas Charger
-image=https://img.scryfall.com/cards/normal/en/c18/1.jpg
+image=https://api.scryfall.com/cards/c18/1/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Bronze_Tablet.txt
+++ b/release/Magarena/scripts_missing/Bronze_Tablet.txt
@@ -1,5 +1,5 @@
 name=Bronze Tablet
-image=https://img.scryfall.com/cards/normal/en/atq/42.jpg
+image=https://api.scryfall.com/cards/atq/42/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact

--- a/release/Magarena/scripts_missing/Brudiclad__Telchor_Engineer.txt
+++ b/release/Magarena/scripts_missing/Brudiclad__Telchor_Engineer.txt
@@ -1,5 +1,5 @@
 name=Brudiclad, Telchor Engineer
-image=https://img.scryfall.com/cards/normal/en/c18/39.jpg
+image=https://api.scryfall.com/cards/c18/39/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Artifact,Creature

--- a/release/Magarena/scripts_missing/Chaos_Orb.txt
+++ b/release/Magarena/scripts_missing/Chaos_Orb.txt
@@ -1,5 +1,5 @@
 name=Chaos Orb
-image=https://img.scryfall.com/cards/normal/en/lea/235.jpg
+image=https://api.scryfall.com/cards/lea/235/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact

--- a/release/Magarena/scripts_missing/Contract_from_Below.txt
+++ b/release/Magarena/scripts_missing/Contract_from_Below.txt
@@ -1,5 +1,5 @@
 name=Contract from Below
-image=https://img.scryfall.com/cards/normal/en/lea/96.jpg
+image=https://api.scryfall.com/cards/lea/96/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Coveted_Jewel.txt
+++ b/release/Magarena/scripts_missing/Coveted_Jewel.txt
@@ -1,5 +1,5 @@
 name=Coveted Jewel
-image=https://img.scryfall.com/cards/normal/en/c18/54.jpg
+image=https://api.scryfall.com/cards/c18/54/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact

--- a/release/Magarena/scripts_missing/Darkpact.txt
+++ b/release/Magarena/scripts_missing/Darkpact.txt
@@ -1,5 +1,5 @@
 name=Darkpact
-image=https://img.scryfall.com/cards/normal/en/lea/99.jpg
+image=https://api.scryfall.com/cards/lea/99/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Demonic_Attorney.txt
+++ b/release/Magarena/scripts_missing/Demonic_Attorney.txt
@@ -1,5 +1,5 @@
 name=Demonic Attorney
-image=https://img.scryfall.com/cards/normal/en/lea/102.jpg
+image=https://api.scryfall.com/cards/lea/102/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Echo_Storm.txt
+++ b/release/Magarena/scripts_missing/Echo_Storm.txt
@@ -1,5 +1,5 @@
 name=Echo Storm
-image=https://img.scryfall.com/cards/normal/en/c18/7.jpg
+image=https://api.scryfall.com/cards/c18/7/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Emissary_of_Grudges.txt
+++ b/release/Magarena/scripts_missing/Emissary_of_Grudges.txt
@@ -1,5 +1,5 @@
 name=Emissary of Grudges
-image=https://img.scryfall.com/cards/normal/en/c18/20.jpg
+image=https://api.scryfall.com/cards/c18/20/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Empyrial_Storm.txt
+++ b/release/Magarena/scripts_missing/Empyrial_Storm.txt
@@ -1,5 +1,5 @@
 name=Empyrial Storm
-image=https://img.scryfall.com/cards/normal/en/c18/2.jpg
+image=https://api.scryfall.com/cards/c18/2/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Enchanter_s_Bane.txt
+++ b/release/Magarena/scripts_missing/Enchanter_s_Bane.txt
@@ -1,5 +1,5 @@
 name=Enchanter's Bane
-image=https://img.scryfall.com/cards/normal/en/c18/21.jpg
+image=https://api.scryfall.com/cards/c18/21/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment

--- a/release/Magarena/scripts_missing/Endless_Atlas.txt
+++ b/release/Magarena/scripts_missing/Endless_Atlas.txt
@@ -1,5 +1,5 @@
 name=Endless Atlas
-image=https://img.scryfall.com/cards/normal/en/c18/55.jpg
+image=https://api.scryfall.com/cards/c18/55/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact

--- a/release/Magarena/scripts_missing/Entreat_the_Dead.txt
+++ b/release/Magarena/scripts_missing/Entreat_the_Dead.txt
@@ -1,5 +1,5 @@
 name=Entreat the Dead
-image=https://img.scryfall.com/cards/normal/en/c18/15.jpg
+image=https://api.scryfall.com/cards/c18/15/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Estrid__the_Masked.txt
+++ b/release/Magarena/scripts_missing/Estrid__the_Masked.txt
@@ -1,5 +1,5 @@
 name=Estrid, the Masked
-image=https://img.scryfall.com/cards/normal/en/c18/40.jpg
+image=https://api.scryfall.com/cards/c18/40/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Planeswalker

--- a/release/Magarena/scripts_missing/Estrid_s_Invocation.txt
+++ b/release/Magarena/scripts_missing/Estrid_s_Invocation.txt
@@ -1,5 +1,5 @@
 name=Estrid's Invocation
-image=https://img.scryfall.com/cards/normal/en/c18/8.jpg
+image=https://api.scryfall.com/cards/c18/8/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment

--- a/release/Magarena/scripts_missing/Ever_Watching_Threshold.txt
+++ b/release/Magarena/scripts_missing/Ever_Watching_Threshold.txt
@@ -1,5 +1,5 @@
 name=Ever-Watching Threshold
-image=https://img.scryfall.com/cards/normal/en/c18/9.jpg
+image=https://api.scryfall.com/cards/c18/9/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment

--- a/release/Magarena/scripts_missing/Falling_Star.txt
+++ b/release/Magarena/scripts_missing/Falling_Star.txt
@@ -1,5 +1,5 @@
 name=Falling Star
-image=https://img.scryfall.com/cards/normal/en/leg/145.jpg
+image=https://api.scryfall.com/cards/leg/145/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Forge_of_Heroes.txt
+++ b/release/Magarena/scripts_missing/Forge_of_Heroes.txt
@@ -1,5 +1,5 @@
 name=Forge of Heroes
-image=https://img.scryfall.com/cards/normal/en/c18/58.jpg
+image=https://api.scryfall.com/cards/c18/58/en?format=image&version=border_crop
 value=2.500
 rarity=C
 type=Land

--- a/release/Magarena/scripts_missing/Fury_Storm.txt
+++ b/release/Magarena/scripts_missing/Fury_Storm.txt
@@ -1,5 +1,5 @@
 name=Fury Storm
-image=https://img.scryfall.com/cards/normal/en/c18/22.jpg
+image=https://api.scryfall.com/cards/c18/22/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Instant

--- a/release/Magarena/scripts_missing/Genesis_Storm.txt
+++ b/release/Magarena/scripts_missing/Genesis_Storm.txt
@@ -1,5 +1,5 @@
 name=Genesis Storm
-image=https://img.scryfall.com/cards/normal/en/c18/30.jpg
+image=https://api.scryfall.com/cards/c18/30/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Geode_Golem.txt
+++ b/release/Magarena/scripts_missing/Geode_Golem.txt
@@ -1,5 +1,5 @@
 name=Geode Golem
-image=https://img.scryfall.com/cards/normal/en/c18/56.jpg
+image=https://api.scryfall.com/cards/c18/56/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Artifact,Creature

--- a/release/Magarena/scripts_missing/Gyrus__Waker_of_Corpses.txt
+++ b/release/Magarena/scripts_missing/Gyrus__Waker_of_Corpses.txt
@@ -1,5 +1,5 @@
 name=Gyrus, Waker of Corpses
-image=https://img.scryfall.com/cards/normal/en/c18/41.jpg
+image=https://api.scryfall.com/cards/c18/41/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Heavenly_Blademaster.txt
+++ b/release/Magarena/scripts_missing/Heavenly_Blademaster.txt
@@ -1,5 +1,5 @@
 name=Heavenly Blademaster
-image=https://img.scryfall.com/cards/normal/en/c18/3.jpg
+image=https://api.scryfall.com/cards/c18/3/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Isolated_Watchtower.txt
+++ b/release/Magarena/scripts_missing/Isolated_Watchtower.txt
@@ -1,5 +1,5 @@
 name=Isolated Watchtower
-image=https://img.scryfall.com/cards/normal/en/c18/59.jpg
+image=https://api.scryfall.com/cards/c18/59/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Land

--- a/release/Magarena/scripts_missing/Jeweled_Bird.txt
+++ b/release/Magarena/scripts_missing/Jeweled_Bird.txt
@@ -1,5 +1,5 @@
 name=Jeweled Bird
-image=https://img.scryfall.com/cards/normal/en/arn/66.jpg
+image=https://api.scryfall.com/cards/arn/66/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Artifact

--- a/release/Magarena/scripts_missing/Lord_Windgrace.txt
+++ b/release/Magarena/scripts_missing/Lord_Windgrace.txt
@@ -1,5 +1,5 @@
 name=Lord Windgrace
-image=https://img.scryfall.com/cards/normal/en/c18/43.jpg
+image=https://api.scryfall.com/cards/c18/43/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Planeswalker

--- a/release/Magarena/scripts_missing/Loyal_Apprentice.txt
+++ b/release/Magarena/scripts_missing/Loyal_Apprentice.txt
@@ -1,5 +1,5 @@
 name=Loyal Apprentice
-image=https://img.scryfall.com/cards/normal/en/c18/23.jpg
+image=https://api.scryfall.com/cards/c18/23/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Creature

--- a/release/Magarena/scripts_missing/Loyal_Drake.txt
+++ b/release/Magarena/scripts_missing/Loyal_Drake.txt
@@ -1,5 +1,5 @@
 name=Loyal Drake
-image=https://img.scryfall.com/cards/normal/en/c18/10.jpg
+image=https://api.scryfall.com/cards/c18/10/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Creature

--- a/release/Magarena/scripts_missing/Loyal_Guardian.txt
+++ b/release/Magarena/scripts_missing/Loyal_Guardian.txt
@@ -1,5 +1,5 @@
 name=Loyal Guardian
-image=https://img.scryfall.com/cards/normal/en/c18/31.jpg
+image=https://api.scryfall.com/cards/c18/31/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Creature

--- a/release/Magarena/scripts_missing/Loyal_Subordinate.txt
+++ b/release/Magarena/scripts_missing/Loyal_Subordinate.txt
@@ -1,5 +1,5 @@
 name=Loyal Subordinate
-image=https://img.scryfall.com/cards/normal/en/c18/16.jpg
+image=https://api.scryfall.com/cards/c18/16/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Creature

--- a/release/Magarena/scripts_missing/Loyal_Unicorn.txt
+++ b/release/Magarena/scripts_missing/Loyal_Unicorn.txt
@@ -1,5 +1,5 @@
 name=Loyal Unicorn
-image=https://img.scryfall.com/cards/normal/en/c18/4.jpg
+image=https://api.scryfall.com/cards/c18/4/en?format=image&version=border_crop
 value=2.500
 rarity=U
 type=Creature

--- a/release/Magarena/scripts_missing/Magus_of_the_Balance.txt
+++ b/release/Magarena/scripts_missing/Magus_of_the_Balance.txt
@@ -1,5 +1,5 @@
 name=Magus of the Balance
-image=https://img.scryfall.com/cards/normal/en/c18/5.jpg
+image=https://api.scryfall.com/cards/c18/5/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Myth_Unbound.txt
+++ b/release/Magarena/scripts_missing/Myth_Unbound.txt
@@ -1,5 +1,5 @@
 name=Myth Unbound
-image=https://img.scryfall.com/cards/normal/en/c18/32.jpg
+image=https://api.scryfall.com/cards/c18/32/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment

--- a/release/Magarena/scripts_missing/Nesting_Dragon.txt
+++ b/release/Magarena/scripts_missing/Nesting_Dragon.txt
@@ -1,5 +1,5 @@
 name=Nesting Dragon
-image=https://img.scryfall.com/cards/normal/en/c18/24.jpg
+image=https://api.scryfall.com/cards/c18/24/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Nylea_s_Colossus.txt
+++ b/release/Magarena/scripts_missing/Nylea_s_Colossus.txt
@@ -1,5 +1,5 @@
 name=Nylea's Colossus
-image=https://img.scryfall.com/cards/normal/en/c18/33.jpg
+image=https://api.scryfall.com/cards/c18/33/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment,Creature

--- a/release/Magarena/scripts_missing/Octopus_Umbra.txt
+++ b/release/Magarena/scripts_missing/Octopus_Umbra.txt
@@ -1,5 +1,5 @@
 name=Octopus Umbra
-image=https://img.scryfall.com/cards/normal/en/c18/11.jpg
+image=https://api.scryfall.com/cards/c18/11/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment

--- a/release/Magarena/scripts_missing/Primordial_Mist.txt
+++ b/release/Magarena/scripts_missing/Primordial_Mist.txt
@@ -1,5 +1,5 @@
 name=Primordial Mist
-image=https://img.scryfall.com/cards/normal/en/c18/12.jpg
+image=https://api.scryfall.com/cards/c18/12/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Enchantment

--- a/release/Magarena/scripts_missing/Ral__Izzet_Viceroy.txt
+++ b/release/Magarena/scripts_missing/Ral__Izzet_Viceroy.txt
@@ -1,5 +1,5 @@
 name=Ral, Izzet Viceroy
-image=https://img.scryfall.com/cards/normal/en/med/GR5.jpg
+image=https://api.scryfall.com/cards/med/GR5/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Planeswalker

--- a/release/Magarena/scripts_missing/Ravenous_Slime.txt
+++ b/release/Magarena/scripts_missing/Ravenous_Slime.txt
@@ -1,5 +1,5 @@
 name=Ravenous Slime
-image=https://img.scryfall.com/cards/normal/en/c18/34.jpg
+image=https://api.scryfall.com/cards/c18/34/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Reality_Scramble.txt
+++ b/release/Magarena/scripts_missing/Reality_Scramble.txt
@@ -1,5 +1,5 @@
 name=Reality Scramble
-image=https://img.scryfall.com/cards/normal/en/c18/25.jpg
+image=https://api.scryfall.com/cards/c18/25/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Rebirth.txt
+++ b/release/Magarena/scripts_missing/Rebirth.txt
@@ -1,5 +1,5 @@
 name=Rebirth
-image=https://img.scryfall.com/cards/normal/en/leg/200.jpg
+image=https://api.scryfall.com/cards/leg/200/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Retrofitter_Foundry.txt
+++ b/release/Magarena/scripts_missing/Retrofitter_Foundry.txt
@@ -1,5 +1,5 @@
 name=Retrofitter Foundry
-image=https://img.scryfall.com/cards/normal/en/c18/57.jpg
+image=https://api.scryfall.com/cards/c18/57/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Artifact

--- a/release/Magarena/scripts_missing/Saheeli__the_Gifted.txt
+++ b/release/Magarena/scripts_missing/Saheeli__the_Gifted.txt
@@ -1,5 +1,5 @@
 name=Saheeli, the Gifted
-image=https://img.scryfall.com/cards/normal/en/c18/44.jpg
+image=https://api.scryfall.com/cards/c18/44/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Planeswalker

--- a/release/Magarena/scripts_missing/Saheeli_s_Directive.txt
+++ b/release/Magarena/scripts_missing/Saheeli_s_Directive.txt
@@ -1,5 +1,5 @@
 name=Saheeli's Directive
-image=https://img.scryfall.com/cards/normal/en/c18/26.jpg
+image=https://api.scryfall.com/cards/c18/26/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Shahrazad.txt
+++ b/release/Magarena/scripts_missing/Shahrazad.txt
@@ -1,5 +1,5 @@
 name=Shahrazad
-image=https://img.scryfall.com/cards/normal/en/arn/10.jpg
+image=https://api.scryfall.com/cards/arn/10/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Skull_Storm.txt
+++ b/release/Magarena/scripts_missing/Skull_Storm.txt
@@ -1,5 +1,5 @@
 name=Skull Storm
-image=https://img.scryfall.com/cards/normal/en/c18/18.jpg
+image=https://api.scryfall.com/cards/c18/18/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Sorcery

--- a/release/Magarena/scripts_missing/Sower_of_Discord.txt
+++ b/release/Magarena/scripts_missing/Sower_of_Discord.txt
@@ -1,5 +1,5 @@
 name=Sower of Discord
-image=https://img.scryfall.com/cards/normal/en/c18/19.jpg
+image=https://api.scryfall.com/cards/c18/19/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Tawnos__Urza_s_Apprentice.txt
+++ b/release/Magarena/scripts_missing/Tawnos__Urza_s_Apprentice.txt
@@ -1,5 +1,5 @@
 name=Tawnos, Urza's Apprentice
-image=https://img.scryfall.com/cards/normal/en/c18/45.jpg
+image=https://api.scryfall.com/cards/c18/45/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Tempest_Efreet.txt
+++ b/release/Magarena/scripts_missing/Tempest_Efreet.txt
@@ -1,5 +1,5 @@
 name=Tempest Efreet
-image=https://img.scryfall.com/cards/normal/en/leg/166.jpg
+image=https://api.scryfall.com/cards/leg/166/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Timmerian_Fiends.txt
+++ b/release/Magarena/scripts_missing/Timmerian_Fiends.txt
@@ -1,5 +1,5 @@
 name=Timmerian Fiends
-image=https://img.scryfall.com/cards/normal/en/hml/58.jpg
+image=https://api.scryfall.com/cards/hml/58/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Treasure_Nabber.txt
+++ b/release/Magarena/scripts_missing/Treasure_Nabber.txt
@@ -1,5 +1,5 @@
 name=Treasure Nabber
-image=https://img.scryfall.com/cards/normal/en/c18/27.jpg
+image=https://api.scryfall.com/cards/c18/27/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Turntimber_Sower.txt
+++ b/release/Magarena/scripts_missing/Turntimber_Sower.txt
@@ -1,5 +1,5 @@
 name=Turntimber Sower
-image=https://img.scryfall.com/cards/normal/en/c18/35.jpg
+image=https://api.scryfall.com/cards/c18/35/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Tuvasa_the_Sunlit.txt
+++ b/release/Magarena/scripts_missing/Tuvasa_the_Sunlit.txt
@@ -1,5 +1,5 @@
 name=Tuvasa the Sunlit
-image=https://img.scryfall.com/cards/normal/en/c18/47.jpg
+image=https://api.scryfall.com/cards/c18/47/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Varchild__Betrayer_of_Kjeldor.txt
+++ b/release/Magarena/scripts_missing/Varchild__Betrayer_of_Kjeldor.txt
@@ -1,5 +1,5 @@
 name=Varchild, Betrayer of Kjeldor
-image=https://img.scryfall.com/cards/normal/en/c18/28.jpg
+image=https://api.scryfall.com/cards/c18/28/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Varina__Lich_Queen.txt
+++ b/release/Magarena/scripts_missing/Varina__Lich_Queen.txt
@@ -1,5 +1,5 @@
 name=Varina, Lich Queen
-image=https://img.scryfall.com/cards/normal/en/c18/48.jpg
+image=https://api.scryfall.com/cards/c18/48/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Vedalken_Humiliator.txt
+++ b/release/Magarena/scripts_missing/Vedalken_Humiliator.txt
@@ -1,5 +1,5 @@
 name=Vedalken Humiliator
-image=https://img.scryfall.com/cards/normal/en/c18/13.jpg
+image=https://api.scryfall.com/cards/c18/13/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Whiptongue_Hydra.txt
+++ b/release/Magarena/scripts_missing/Whiptongue_Hydra.txt
@@ -1,5 +1,5 @@
 name=Whiptongue Hydra
-image=https://img.scryfall.com/cards/normal/en/c18/36.jpg
+image=https://api.scryfall.com/cards/c18/36/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Creature

--- a/release/Magarena/scripts_missing/Windgrace_s_Judgment.txt
+++ b/release/Magarena/scripts_missing/Windgrace_s_Judgment.txt
@@ -1,5 +1,5 @@
 name=Windgrace's Judgment
-image=https://img.scryfall.com/cards/normal/en/c18/49.jpg
+image=https://api.scryfall.com/cards/c18/49/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Instant

--- a/release/Magarena/scripts_missing/Xantcha__Sleeper_Agent.txt
+++ b/release/Magarena/scripts_missing/Xantcha__Sleeper_Agent.txt
@@ -1,5 +1,5 @@
 name=Xantcha, Sleeper Agent
-image=https://img.scryfall.com/cards/normal/en/c18/50.jpg
+image=https://api.scryfall.com/cards/c18/50/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Yennett__Cryptic_Sovereign.txt
+++ b/release/Magarena/scripts_missing/Yennett__Cryptic_Sovereign.txt
@@ -1,5 +1,5 @@
 name=Yennett, Cryptic Sovereign
-image=https://img.scryfall.com/cards/normal/en/c18/51.jpg
+image=https://api.scryfall.com/cards/c18/51/en?format=image&version=border_crop
 value=2.500
 rarity=M
 type=Legendary,Creature

--- a/release/Magarena/scripts_missing/Yuriko__the_Tiger_s_Shadow.txt
+++ b/release/Magarena/scripts_missing/Yuriko__the_Tiger_s_Shadow.txt
@@ -1,5 +1,5 @@
 name=Yuriko, the Tiger's Shadow
-image=https://img.scryfall.com/cards/normal/en/c18/52.jpg
+image=https://api.scryfall.com/cards/c18/52/en?format=image&version=border_crop
 value=2.500
 rarity=R
 type=Legendary,Creature


### PR DESCRIPTION
All card image links from `scripts_missing` should be valid again

There are still about 135 invalid image links in `scripts`, those probably need to be fixed manually (see https://github.com/magarena/magarena/issues/1655#issuecomment-812603718)